### PR TITLE
Use semantic colour variables

### DIFF
--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -5,7 +5,7 @@
 .panel-indent {
   @include contain-floats;
   clear: both;
-  border-left: 5px solid $grey-3;
+  border-left: 5px solid $panel-colour;
 
   padding-top: 10px;
   padding-left: $gutter-half;

--- a/public/sass/elements/forms/_form-chunky-labels.scss
+++ b/public/sass/elements/forms/_form-chunky-labels.scss
@@ -9,8 +9,8 @@
   clear: left;
   position: relative;
 
-  background: $grey-3;
-  border: 1px solid $grey-3;
+  background: $panel-colour;
+  border: 1px solid $panel-colour;
   padding: (18px $gutter $gutter-half $gutter*1.5);
   margin-bottom: $gutter-half;
 

--- a/public/sass/elements/forms/_form-date-of-birth.scss
+++ b/public/sass/elements/forms/_form-date-of-birth.scss
@@ -5,11 +5,11 @@
 
 .date-of-birth label {
   display: block;
-  color: $grey-1;
+  color: $secondary-text-colour;
   margin-bottom: 5px;
 }
 
-.date-of-birth .form-group {  
+.date-of-birth .form-group {
   @include media(tablet){
     width: 50px;
     float: left;


### PR DESCRIPTION
The `$grey-x` may clash with the deprecated colours from static. Also using the semantic variables is in keeping with govuk_frontend_toolkit.
