### PR TITLE
Use proportional heading classnames

### DIFF
--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -42,10 +42,13 @@ code {
 }
 
 // Headings
+// Used with heading-large = 36px
 .heading-with-border {
   border-top: 1px solid $border-colour;
-  padding-top: ($gutter*1.5);
+  padding-top: em(45, 36);
 }
+
+
 
 // Text
 .tight {
@@ -62,7 +65,6 @@ code {
 // ==========================================================================
 
 .example {
-
   @include contain-floats;
   position: relative;
   overflow: hidden;
@@ -257,8 +259,8 @@ code {
     text-align: center;
   }
 
-  .heading-19 {
-    margin: $gutter-half 0;
+  .heading-small {
+    margin-bottom: em(10);
   }
 
   ul {
@@ -286,7 +288,7 @@ code {
   vertical-align: top;
 }
 
-.example-icons .heading-24 {
+.example-icons .heading-medium {
   margin-top: 0;
 }
 
@@ -356,10 +358,10 @@ code {
 // ==========================================================================
 
 .example-button .button {
-  margin-bottom: 15px; // increase spacing for this example
+  margin-bottom: 15px;  // increase spacing for this example
 }
 
-.example-button .heading-19 {
+.example-button .heading-small {
   margin-top: 0;
 }
 

--- a/public/sass/elements/_typography.scss
+++ b/public/sass/elements/_typography.scss
@@ -1,13 +1,18 @@
 // Typography
 // ==========================================================================
 
-// Increase default font size to 19px
+// Increase the base font size to 19px
+// Using the core-19 mixin from the govuk_toolkit _typography.scss file
+
 #content {
   @include core-19;
   -webkit-font-smoothing: antialiased;
 }
 
 // Core font sizes
+.font-xxlarge {
+  @include core-80;
+}
 .font-xlarge {
   @include core-48;
 }
@@ -19,6 +24,9 @@
 }
 .font-small {
   @include core-19;
+}
+.font-xsmall {
+  @include core-16;
 }
 
 // Bold font sizes
@@ -41,69 +49,84 @@
   @include bold-16();
 }
 
+// Common heading sizes
+// Using the bold-xx mixins from the govuk_toolkit _typography.scss file
+// Spacing is set in em, using the px to em function in the elements _helpers.scss file
+
 // Headings
-.heading-48,
 .heading-xlarge {
   @include bold-48();
-  margin-top: $gutter-half;
-  margin-bottom: $gutter;
+
+  margin-top: em(15, 32);
+  margin-bottom: em(30, 32);
+
   @include media(tablet) {
-    margin-top: $gutter;
-    margin-bottom: $gutter*2;
+    margin-top: em(30, 48);
+    margin-bottom: em(60, 48);
   }
-  .heading-27 {
-    display: block;
+
+  .heading-secondary {
     @include core-27();
+
+    display: block;
     color: $secondary-text-colour;
   }
+
 }
 
-.heading-36,
 .heading-large {
   @include bold-36();
-  margin-top: 25px;
-  margin-bottom: 10px;
+
+  margin-top: em(25, 24);
+  margin-bottom: em(10, 24);
+
   @include media(tablet) {
-    margin-top: 45px;
-    margin-bottom: 20px;
+    margin-top: em(45, 36 );
+    margin-bottom: em(20, 36);
   }
+
 }
 
-.heading-24,
 .heading-medium {
   @include bold-24();
-  margin-top: 25px;
-  margin-bottom: 10px;
+
+  margin-top: em(25, 20);
+  margin-bottom: em(10, 20);
+
   @include media(tablet) {
-    margin-top: 45px;
-    margin-bottom: 20px;
+    margin-top: em(45, 24);
+    margin-bottom: em(20, 24);
   }
+
 }
 
-.heading-19,
 .heading-small {
   @include bold-19();
-  margin-top: 10px;
-  margin-bottom: 5px;
+
+  margin-top: em(10, 16);
+  margin-bottom: em(5, 16);
+
   @include media(tablet) {
-    margin-top: 20px;
+    margin-top: em(20, 19);
   }
+
 }
 
 // Text
-p,
-pre {
-  margin-top: 5px;
-  margin-bottom: 20px;
+p {
+  margin-top: em(5, 16 );
+  margin-bottom: em(20, 16);
+
+  @include media(tablet) {
+    margin-top: em(5);
+    margin-bottom: em(20);
+  }
+
 }
 
-.lede,
-.lead {
+//
+.lede {
   @include core-24;
-}
-
-.copy-16 {
-  @include core-16;
 }
 
 // Set a max-width for text blocks

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -32,7 +32,7 @@
   }
 }
 
-.validation-summary .heading-19 {
+.validation-summary .heading-small {
   margin-top: $gutter-half;
 }
 

--- a/views/examples/forms.html
+++ b/views/examples/forms.html
@@ -19,7 +19,7 @@
 
       <form action="" method="post" class="form">
 
-        <h1 class="form-title heading-36">
+        <h1 class="form-title heading-large">
           Your details
         </h1>
 

--- a/views/examples/grid_layout.html
+++ b/views/examples/grid_layout.html
@@ -20,11 +20,11 @@
 
           <a href="/" class="example-back-link">Back to GOV.UK elements</a>
 
-          <h1 class="heading-48">
+          <h1 class="heading-xlarge">
             Grid layout
           </h1>
 
-          <h2 class="heading-36">Full width</h2>
+          <h2 class="heading-large">Full width</h2>
 
           <div class="text">
             <a href="#" class="js-highlight-grid">Toggle background colours</a> to see the how the padding on grid cells.
@@ -42,7 +42,7 @@
       <div class="grid grid-2-3">
         <div class="inner-block">
 
-          <h2 class="heading-36">Two thirds</h2>
+          <h2 class="heading-large">Two thirds</h2>
           <div class="text">
             <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
@@ -53,7 +53,7 @@
       </div>
       <div class="grid grid-1-3">
         <div class="inner-block">
-          <h2 class="heading-36">One third</h2>
+          <h2 class="heading-large">One third</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -64,7 +64,7 @@
     <div class="grid-wrapper">
       <div class="grid grid-1-2">
         <div class="inner-block">
-          <h2 class="heading-36">One half</h2>
+          <h2 class="heading-large">One half</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -72,7 +72,7 @@
       </div>
       <div class="grid grid-1-2">
         <div class="inner-block">
-          <h2 class="heading-36">One half</h2>
+          <h2 class="heading-large">One half</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -83,7 +83,7 @@
     <div class="grid-wrapper">
       <div class="grid grid-1-3">
         <div class="inner-block">
-          <h2 class="heading-36">One third</h2>
+          <h2 class="heading-large">One third</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -91,7 +91,7 @@
       </div>
       <div class="grid grid-1-3">
         <div class="inner-block">
-          <h2 class="heading-36">One third</h2>
+          <h2 class="heading-large">One third</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -99,7 +99,7 @@
       </div>
       <div class="grid grid-1-3">
         <div class="inner-block">
-          <h2 class="heading-36">One third</h2>
+          <h2 class="heading-large">One third</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -110,7 +110,7 @@
     <div class="grid-wrapper">
       <div class="grid grid-1-4">
         <div class="inner-block">
-          <h2 class="heading-36">One quarter</h2>
+          <h2 class="heading-large">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -118,7 +118,7 @@
       </div>
       <div class="grid grid-1-4">
         <div class="inner-block">
-          <h2 class="heading-36">One quarter</h2>
+          <h2 class="heading-large">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -126,7 +126,7 @@
       </div>
       <div class="grid grid-1-4">
         <div class="inner-block">
-          <h2 class="heading-36">One quarter</h2>
+          <h2 class="heading-large">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -134,7 +134,7 @@
       </div>
       <div class="grid grid-1-4">
         <div class="inner-block">
-          <h2 class="heading-36">One quarter</h2>
+          <h2 class="heading-large">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -144,7 +144,7 @@
 
     <div class="inner-block">
 
-      <h1 class="heading-36">
+      <h1 class="heading-large">
         If you don't need a grid&hellip;
       </h1>
       <div class="text">

--- a/views/examples/radio_buttons.html
+++ b/views/examples/radio_buttons.html
@@ -19,7 +19,7 @@
 
       <form action="" method="post" class="form">
 
-        <h1 class="form-title heading-36">
+        <h1 class="form-title heading-large">
           Where should we send your new<br> passport?
         </h1>
 
@@ -45,7 +45,7 @@
 
         <div class="panel-indent toggle-content" id="example-other-address">
 
-          <legend class="heading-24">
+          <legend class="heading-medium">
             Your other address
           </legend>
 

--- a/views/examples/template.html
+++ b/views/examples/template.html
@@ -35,7 +35,7 @@
 
           <a href="/" class="example-back-link">Back to GOV.UK elements</a>
 
-          <h1 class="heading-48">
+          <h1 class="heading-xlarge">
             Layout template
           </h1>
 
@@ -44,7 +44,7 @@
             It also shows how to implement the Alpha phase banner.
           </p>
 
-          <h2 class="heading-36">Full width</h2>
+          <h2 class="heading-large">Full width</h2>
 
           <a href="#" class="js-highlight-grid">Toggle background colours</a> to see the padding on grid cells.
 
@@ -60,7 +60,7 @@
       <div class="grid grid-2-3">
         <div class="inner-block">
 
-          <h2 class="heading-36">Two thirds</h2>
+          <h2 class="heading-large">Two thirds</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -69,7 +69,7 @@
       </div>
       <div class="grid grid-1-3">
         <div class="inner-block">
-          <h2 class="heading-36">One third</h2>
+          <h2 class="heading-">One third</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -80,7 +80,7 @@
     <div class="grid-wrapper">
       <div class="grid grid-1-2">
         <div class="inner-block">
-          <h2 class="heading-36">One half</h2>
+          <h2 class="heading-large">One half</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -88,7 +88,7 @@
       </div>
       <div class="grid grid-1-2">
         <div class="inner-block">
-          <h2 class="heading-36">One half</h2>
+          <h2 class="heading-large">One half</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -99,7 +99,7 @@
     <div class="grid-wrapper">
       <div class="grid grid-1-3">
         <div class="inner-block">
-          <h2 class="heading-36">One third</h2>
+          <h2 class="heading-large">One third</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -107,7 +107,7 @@
       </div>
       <div class="grid grid-1-3">
         <div class="inner-block">
-          <h2 class="heading-36">One third</h2>
+          <h2 class="heading-large">One third</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -115,7 +115,7 @@
       </div>
       <div class="grid grid-1-3">
         <div class="inner-block">
-          <h2 class="heading-36">One third</h2>
+          <h2 class="heading-large">One third</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -126,7 +126,7 @@
     <div class="grid-wrapper">
       <div class="grid grid-1-4">
         <div class="inner-block">
-          <h2 class="heading-36">One quarter</h2>
+          <h2 class="heading-large">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -134,7 +134,7 @@
       </div>
       <div class="grid grid-1-4">
         <div class="inner-block">
-          <h2 class="heading-36">One quarter</h2>
+          <h2 class="heading-large">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -142,7 +142,7 @@
       </div>
       <div class="grid grid-1-4">
         <div class="inner-block">
-          <h2 class="heading-36">One quarter</h2>
+          <h2 class="heading-large">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -150,7 +150,7 @@
       </div>
       <div class="grid grid-1-4">
         <div class="inner-block">
-          <h2 class="heading-36">One quarter</h2>
+          <h2 class="heading-large">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
@@ -160,7 +160,7 @@
 
     <div class="inner-block">
 
-      <h1 class="heading-36">
+      <h1 class="heading-large">
         If you don't need a grid&hellip;
       </h1>
 

--- a/views/examples/typography.html
+++ b/views/examples/typography.html
@@ -17,14 +17,14 @@
 
         <a href="/" class="example-back-link">Back to GOV.UK elements</a>
 
-        <h1 class="heading-48">
+        <h1 class="heading-xlarge">
           Typography
         </h1>
 
         <div class="text">
 
-          <h1 class="heading-48">
-            <span class="heading-27">A 27px section heading</span>
+          <h1 class="heading-xlarge">
+            <span class="heading-secondary">A 27px section heading</span>
             A 48px heading
           </h1>
 
@@ -32,19 +32,19 @@
             This is an intro paragraph at 24px. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.
           </p>
 
-          <h2 class="heading-36">A 36px heading</h2>
+          <h2 class="heading-large">A 36px heading</h2>
 
           <p>
             This is a body copy paragraph at 19px. Donec id elit non mi porta gravida at eget metus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec sed odio dui. Aenean lacinia bibendum nulla sed consectetur. Aenean lacinia bibendum nulla sed consectetur. Sed posuere consectetur est at lobortis.
           </p>
 
-          <h3 class="heading-24">A 24px heading</h3>
+          <h3 class="heading-medium">A 24px heading</h3>
 
           <p>
           Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum. Vestibulum id ligula porta felis euismod semper. Donec id elit non mi porta gravida at eget metus.
           </p>
 
-          <h4 class="heading-19">A 19px heading</h4>
+          <h4 class="heading-small">A 19px heading</h4>
 
           <p>Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.</p>
 

--- a/views/index.html
+++ b/views/index.html
@@ -43,7 +43,7 @@
           <li><a href="#guide-tables">Tables</a></li>
         </ol>
 
-        <h2 class="heading-24">Looking for the styles?</h2>
+        <h2 class="heading-medium">Looking for the styles?</h2>
         <p>
            The Sass files for <a href="https://github.com/alphagov/govuk_elements/tree/master/public/sass">all the examples in this page, can be found on GitHub</a>.
         </p>
@@ -52,7 +52,7 @@
 
       <div id="guide-layout">
 
-        <h2 class="heading-36 heading-with-border">1. Layout</h2>
+        <h2 class="heading-large heading-with-border">1. Layout</h2>
         <div class="text">
           <p>
             Use white space to create a visual hierarchy on the page. Design for small screens first using a single column layout.
@@ -69,7 +69,7 @@
           <li><a href="{{ site.baseurl}}/examples/grid-layout/">See an example of GOV.UK grid layout</a></li>
         </ul>
 
-        <h3 class="heading-24">Spacing</h3>
+        <h3 class="heading-medium">Spacing</h3>
         <ul class="list-bullet text">
           <li>spacing between elements is usually 5px, 10px, 15px or multiples of 15px</li>
           <li>gutters are 15px for smaller screens and 30px for larger screens</li>
@@ -90,13 +90,13 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Grid unit proportions</h3>
+        <h3 class="heading-medium">Grid unit proportions</h3>
         <ul class="list-bullet text">
           <li>introduce columns as the content requires it – base column ratios on halves, thirds or quarters of the page width</li>
           <li>for screen breakpoints use media queries &ndash; find these in the GOV.UK front end toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_conditionals.scss">_conditionals.scss</a> file</li>
         </ul>
 
-        <h4 class="heading-19">Halves</h4>
+        <h4 class="heading-small">Halves</h4>
         <div class="example example-grid">
           <div class="grid-wrapper">
             <div class="grid grid-1-2">
@@ -112,7 +112,7 @@
           </div>
         </div>
 
-        <h4 class="heading-19">Thirds</h4>
+        <h4 class="heading-small">Thirds</h4>
         <div class="example example-grid">
           <div class="grid-wrapper">
             <div class="grid grid-1-3">
@@ -148,7 +148,7 @@
           </div>
         </div>
 
-        <h4 class="heading-19">Quarters</h4>
+        <h4 class="heading-small">Quarters</h4>
         <div class="example example-grid">
           <div class="grid-wrapper">
             <div class="grid grid-1-4">
@@ -179,7 +179,7 @@
 
       <div id="guide-typography">
 
-        <h2 class="heading-36 heading-with-border">2. Typography</h2>
+        <h2 class="heading-large heading-with-border">2. Typography</h2>
         <p class="text">
            Use the GDS Transport Website font in Light and Bold. It's licensed for use on the GOV.UK domains only. For services publicly available on different domains, use an alternative typeface like Arial. You can find common font colours in the <a href="#guide-colour">colour palette</a>.
         </p>
@@ -189,7 +189,7 @@
           <li><a href="https://gds.blog.gov.uk/2012/07/05/a-few-notes-on-typography/">Read a blog post about developing the GOV.UK typeface</a></li>
         </ul>
 
-        <h3 class="heading-24">
+        <h3 class="heading-medium">
           Headings
         </h3>
 
@@ -201,14 +201,14 @@
 
         <div class="example">
           <div class="inner-block">
-            <h1 class="heading-48">A <em class="highlight">48px Bold</em> heading</h1>
-            <h2 class="heading-36">A <em class="highlight">36px Bold</em> heading</h2>
-            <h3 class="heading-24">A <em class="highlight">24px Bold</em> heading</h3>
-            <h4 class="heading-19">A <em class="highlight">19px Bold</em> heading</h4>
+            <h1 class="heading-xlarge">A <em class="highlight">48px Bold</em> heading</h1>
+            <h2 class="heading-large">A <em class="highlight">36px Bold</em> heading</h2>
+            <h3 class="heading-medium">A <em class="highlight">24px Bold</em> heading</h3>
+            <h4 class="heading-small">A <em class="highlight">19px Bold</em> heading</h4>
           </div>
         </div>
 
-        <h3 class="heading-24">
+        <h3 class="heading-medium">
           Lead paragraph
         </h3>
         <p>
@@ -226,7 +226,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24">
+        <h3 class="heading-medium">
           Body copy
         </h3>
 
@@ -251,7 +251,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Links</h3>
+        <h3 class="heading-medium">Links</h3>
         <ul class="text list-bullet">
           <li>links within body copy should be blue and underlined</li>
           <li>links without surrounding text should not have a full stop at the end</li>
@@ -276,7 +276,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Lists</h3>
+        <h3 class="heading-medium">Lists</h3>
         <p class="text">
           List items start with a lowercase letter and have no full stop at the end.
         </p>
@@ -300,7 +300,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Inset text</h3>
+        <h3 class="heading-medium">Inset text</h3>
         <p class="text">
           Use bordered inset text to draw attention to important content on the page.
         </p>
@@ -319,7 +319,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Hidden text (progressive disclosure)</h3>
+        <h3 class="heading-medium">Hidden text (progressive disclosure)</h3>
         <p class="text">
           Use this to make your page easier to scan,
           only showing contextual information when required.
@@ -343,17 +343,17 @@
 
       <div id="guide-colour">
 
-        <h2 class="heading-36 heading-with-border">3. Colour</h2>
+        <h2 class="heading-large heading-with-border">3. Colour</h2>
         <p class="text">
           Always use the GOV.UK colour palette.
         </p>
 
-        <h3 class="heading-24">Colour contrast</h3>
+        <h3 class="heading-medium">Colour contrast</h3>
         <p class="text">
           The colour contrast ratio for text and interative elements should be at least 4.5:1 <a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html" rel="external">as recommended by the W3C</a>. Test your service to meet this standard.
         </p>
 
-        <h3 class="heading-24">Sass variables</h3>
+        <h3 class="heading-medium">Sass variables</h3>
         <p class="text">
           Use Sass variables in case colour values need to be updated &ndash; find these in the GOV.UK front end toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_colours.scss">colours.scss</a> file.
         </p>
@@ -362,7 +362,7 @@
           <div class="inner-block">
 
             <div class="swatch-wrapper">
-              <h4 class="heading-19">Text</h4>
+              <h4 class="heading-small">Text</h4>
 
               <div class="swatch swatch-text-colour"></div>
               <ul>
@@ -385,7 +385,7 @@
             </div>
 
             <div class="swatch-wrapper">
-              <h4 class="heading-19">Links</h4>
+              <h4 class="heading-small">Links</h4>
 
               <div class="swatch swatch-link-colour"></div>
               <ul>
@@ -407,7 +407,7 @@
             </div>
 
             <div class="swatch-wrapper">
-              <h4 class="heading-19">Backgrounds</h4>
+              <h4 class="heading-small">Backgrounds</h4>
 
               <div class="swatch swatch-border-colour"></div>
               <ul>
@@ -429,7 +429,7 @@
             </div>
 
             <div class="swatch-wrapper">
-              <h4 class="heading-19">Buttons</h4>
+              <h4 class="heading-small">Buttons</h4>
 
               <div class="swatch swatch-button-colour"></div>
               <ul>
@@ -445,7 +445,7 @@
             </div>
 
             <div class="swatch-wrapper">
-              <h4 class="heading-19">Focus</h4>
+              <h4 class="heading-small">Focus</h4>
               <div class="swatch swatch-yellow"></div>
               <ul>
                 <li><b>#FFBF47</b></li>
@@ -456,13 +456,13 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Status colours</h3>
+        <h3 class="heading-medium">Status colours</h3>
         <div class="example">
           <div class="inner-block">
 
             <div class="swatch-wrapper">
 
-              <h4 class="heading-19">Phases</h4>
+              <h4 class="heading-small">Phases</h4>
 
               <div class="swatch swatch-alpha"></div>
               <ul>
@@ -480,7 +480,7 @@
 
             <div class="swatch-wrapper">
 
-              <h4 class="heading-19">Errors</h4>
+              <h4 class="heading-small">Errors</h4>
 
               <div class="swatch swatch-error"></div>
               <ul>
@@ -499,7 +499,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Greyscale palette</h3>
+        <h3 class="heading-medium">Greyscale palette</h3>
         <div class="example">
           <div class="inner-block">
 
@@ -541,7 +541,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Extended palette</h3>
+        <h3 class="heading-medium">Extended palette</h3>
         <ul class="list-bullet text">
           <li>used for graphs and supporting material</li>
           <li>for tints of the extended palette use 50% or 25%</li>
@@ -556,7 +556,7 @@
           <div class="inner-block">
 
             <div class="swatch-wrapper">
-              <h4 class="heading-19">Purple</h4>
+              <h4 class="heading-small">Purple</h4>
 
               <div class="swatch swatch-purple"></div>
               <ul>
@@ -564,7 +564,7 @@
                 <li>$purple</li>
               </ul>
 
-              <h4 class="heading-19">Mauve</h4>
+              <h4 class="heading-small">Mauve</h4>
 
               <div class="swatch swatch-mauve"></div>
               <ul>
@@ -572,7 +572,7 @@
                 <li>$mauve</li>
               </ul>
 
-              <h4 class="heading-19">Fuschia</h4>
+              <h4 class="heading-small">Fuschia</h4>
 
               <div class="swatch swatch-fuschia"></div>
               <ul>
@@ -582,7 +582,7 @@
             </div>
 
             <div class="swatch-wrapper">
-              <h4 class="heading-19">Pink</h4>
+              <h4 class="heading-small">Pink</h4>
 
               <div class="swatch swatch-pink"></div>
               <ul>
@@ -590,7 +590,7 @@
                 <li>$pink</li>
               </ul>
 
-              <h4 class="heading-19">Baby pink</h4>
+              <h4 class="heading-small">Baby pink</h4>
 
               <div class="swatch swatch-baby-pink"></div>
               <ul>
@@ -598,7 +598,7 @@
                 <li>$baby-pink</li>
               </ul>
 
-              <h4 class="heading-19">Red</h4>
+              <h4 class="heading-small">Red</h4>
 
               <div class="swatch swatch-red"></div>
               <ul>
@@ -608,7 +608,7 @@
             </div>
 
             <div class="swatch-wrapper">
-              <h4 class="heading-19">Mellow red</h4>
+              <h4 class="heading-small">Mellow red</h4>
 
               <div class="swatch swatch-mellow-red"></div>
               <ul>
@@ -616,7 +616,7 @@
                 <li>$mellow-red</li>
               </ul>
 
-              <h4 class="heading-19">Orange</h4>
+              <h4 class="heading-small">Orange</h4>
 
               <div class="swatch swatch-orange"></div>
               <ul>
@@ -624,7 +624,7 @@
                 <li>$orange</li>
               </ul>
 
-              <h4 class="heading-19">Brown</h4>
+              <h4 class="heading-small">Brown</h4>
 
               <div class="swatch swatch-brown"></div>
               <ul>
@@ -634,7 +634,7 @@
             </div>
 
             <div class="swatch-wrapper">
-              <h4 class="heading-19">Yellow</h4>
+              <h4 class="heading-small">Yellow</h4>
 
               <div class="swatch swatch-yellow"></div>
               <ul>
@@ -642,7 +642,7 @@
                 <li>$yellow</li>
               </ul>
 
-              <h4 class="heading-19">Green</h4>
+              <h4 class="heading-small">Green</h4>
 
               <div class="swatch swatch-green"></div>
               <ul>
@@ -650,7 +650,7 @@
                 <li>$green</li>
               </ul>
 
-              <h4 class="heading-19">Grass green</h4>
+              <h4 class="heading-small">Grass green</h4>
 
               <div class="swatch swatch-grass-green"></div>
               <ul>
@@ -660,7 +660,7 @@
             </div>
 
             <div class="swatch-wrapper">
-              <h4 class="heading-19">Turquoise</h4>
+              <h4 class="heading-small">Turquoise</h4>
 
               <div class="swatch swatch-turquoise"></div>
               <ul>
@@ -668,7 +668,7 @@
                 <li>$turquoise</li>
               </ul>
 
-              <h4 class="heading-19">Light blue</h4>
+              <h4 class="heading-small">Light blue</h4>
 
               <div class="swatch swatch-light-blue"></div>
               <ul>
@@ -685,7 +685,7 @@
 
       <div id="guide-icons-images">
 
-        <h2 class="heading-36 heading-with-border">4. Icons and images</h2>
+        <h2 class="heading-large heading-with-border">4. Icons and images</h2>
         <p class="text">
           Avoid unnecessary decoration - only use icons and images if there's a real user need.
         </p>
@@ -693,7 +693,7 @@
           <li><a href="https://www.gov.uk/government/history">See an example of image usage on GOV.UK</a></li>
         </ul>
 
-        <h3 class="heading-24">Icons</h3>
+        <h3 class="heading-medium">Icons</h3>
         <ul class="list-bullet text">
           <li>
             if icons are needed ensure they are clear, simple and accompanied by relevant text
@@ -707,7 +707,7 @@
           GOV.UK standard icons are provided, as well as organisation crests and media player icons &ndash; find these in the GOV.UK front end toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/tree/master/images">images folder</a>.
         </p>
 
-        <h3 class="heading-24">Images</h3>
+        <h3 class="heading-medium">Images</h3>
         <p>
           If images are needed they should be landscape, 3:2 aspect ratio.
         </p>
@@ -732,7 +732,7 @@
 
       <div id="guide-data">
 
-        <h2 class="heading-36 heading-with-border">5. Data</h2>
+        <h2 class="heading-large heading-with-border">5. Data</h2>
         <p class="text">
           Data is recommended as an alternative to using images.
         </p>
@@ -743,7 +743,7 @@
           <li><a href="https://www.gov.uk/performance/tax-disc">See an example of data on the GOV.UK performance platform</a></li>
         </ul>
 
-        <h3 class="heading-24">Data visualisation</h3>
+        <h3 class="heading-medium">Data visualisation</h3>
         <p class="text">
           For screen readers, ensure the data value appears first so it makes sense when read aloud.
         </p>
@@ -803,21 +803,21 @@
 
       <div id="guide-forms">
 
-        <h2 class="heading-36 heading-with-border">6. Forms</h2>
+        <h2 class="heading-large heading-with-border">6. Forms</h2>
         <p class="text">
           Keep forms as simple as possible &ndash; only ask what's needed to run your service.
         </p>
 
         <p><a href="{{ site.baseurl}}/examples/forms/">See an example of GOV.UK form layout</a></p>
 
-        <h3 class="heading-24">Optional and mandatory fields</h3>
+        <h3 class="heading-medium">Optional and mandatory fields</h3>
         <ul class="text list-bullet">
           <li>only ask for the information you absolutely need</li>
           <li>if you do ask for optional information, mark the labels of optional fields with '(optional)'</li>
           <li>don't mark mandatory fields with asterisks</li>
         </ul>
 
-        <h3 class="heading-24">Labels</h3>
+        <h3 class="heading-medium">Labels</h3>
         <ul class="text list-bullet">
           <li>all form fields should be given labels</li>
           <li>don't hide labels, unless the surrounding context makes them unnecessary</li>
@@ -843,7 +843,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Form fields</h3>
+        <h3 class="heading-medium">Form fields</h3>
         <div class="text">
           <p>
             Make field widths proportional to the input they take.
@@ -858,12 +858,12 @@
 
         <!-- TODO: Add postcode example -->
 
-        <h3 class="heading-24">Fieldsets and legends</h3>
+        <h3 class="heading-medium">Fieldsets and legends</h3>
         <p class="text">
           Use fieldsets to group related form controls. The first element inside a fieldset must be a <code>legend</code> element which describes the group.
         </p>
 
-        <h3 class="heading-24">Form focus states</h3>
+        <h3 class="heading-medium">Form focus states</h3>
         <p class="text">
           All elements use the yellow focus style as a highlight, as either a fill or 3px outline.
         </p>
@@ -889,7 +889,7 @@
               <div class="inner-block">
 
                 <div class="swatch-wrapper">
-                  <h4 class="heading-19">Focus</h4>
+                  <h4 class="heading-small">Focus</h4>
                   <div class="swatch swatch-yellow"></div>
                   <ul>
                     <li><b>#FFBF47</b></li>
@@ -903,7 +903,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Spacing between form elements</h3>
+        <h3 class="heading-medium">Spacing between form elements</h3>
         <p class="text">
           Ensure there is sufficient spacing between form elements.
         </p>
@@ -925,7 +925,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Hint and example text</h3>
+        <h3 class="heading-medium">Hint and example text</h3>
         <ul class="list-bullet text">
           <li>use hint text for supporting contextual help</li>
           <li>don’t use placeholder text in fields</li>
@@ -948,14 +948,14 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Drop-down lists</h3>
+        <h3 class="heading-medium">Drop-down lists</h3>
         <p class="text">
           Avoid using drop-down lists - use radio buttons or checkboxes instead.
         </p>
 
         <!-- TODO: link to blog post to support this statement -->
 
-        <h3 class="heading-24" id="guide-form-radio-buttons">Radio buttons</h3>
+        <h3 class="heading-medium" id="guide-form-radio-buttons">Radio buttons</h3>
         <ul class="list-bullet text">
           <li>use these to let users choose a single option from a list</li>
           <li>for more than two options, radio buttons should be stacked</li>
@@ -1016,7 +1016,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24" id="guide-form-checkboxes">Checkboxes</h3>
+        <h3 class="heading-medium" id="guide-form-checkboxes">Checkboxes</h3>
         <ul class="list-bullet text">
           <li>use these to select either on/off toggles or multiple selections</li>
           <li>make it clear with words when users can select one or multiple options</li>
@@ -1085,7 +1085,7 @@
         </div>
         -->
 
-        <h3 class="heading-24">Inset form elements</h3>
+        <h3 class="heading-medium">Inset form elements</h3>
         <div class="text">
           <p>
             Insets can be used within forms to emphasise supporting information.
@@ -1131,13 +1131,13 @@
 
       <div id="guide-buttons">
 
-        <h2 class="heading-36 heading-with-border">7. Buttons</h2>
+        <h2 class="heading-large heading-with-border">7. Buttons</h2>
 
         <p class="text">
           Use buttons to move though a transaction.
         </p>
 
-        <h3 class="heading-24">Button text</h3>
+        <h3 class="heading-medium">Button text</h3>
         <p class="text">
           Button text should be short and describe the action the button performs.
         </p>
@@ -1189,7 +1189,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Button colours</h3>
+        <h3 class="heading-medium">Button colours</h3>
         <ul class="list-bullet text">
           <li>buttons use the use the Sass variable <code>$button-colour</code>, Hex <code>#00823B</code></li>
           <li>buttons use the Sass variable <code>$yellow</code>, Hex <code>#FFBF47</code> as a focus colour, as an outline of 3px</li>
@@ -1208,7 +1208,7 @@
             <div class="grid grid-1-3">
               <div class="inner-block">
                 <div class="swatch-wrapper">
-                  <h4 class="heading-19">Button</h4>
+                  <h4 class="heading-small">Button</h4>
                   <div class="swatch swatch-button-colour"></div>
                   <ul>
                     <li><b>#00823B</b></li>
@@ -1221,7 +1221,7 @@
             <div class="grid grid-1-3">
               <div class="inner-block">
                 <div class="swatch-wrapper">
-                  <h4 class="heading-19">Focus</h4>
+                  <h4 class="heading-small">Focus</h4>
                   <div class="swatch swatch-yellow"></div>
                   <ul>
                     <li><b>#FFBF47</b></li>
@@ -1234,7 +1234,7 @@
           </div>
         </div>
 
-        <h3 class="heading-24">Disabled buttons</h3>
+        <h3 class="heading-medium">Disabled buttons</h3>
         <p>
           Disabled buttons should be set at 50% opacity.
         </p>
@@ -1249,7 +1249,7 @@
 
       <div id="guide-errors">
 
-        <h2 class="heading-36 heading-with-border">8. Errors and validation</h2>
+        <h2 class="heading-large heading-with-border">8. Errors and validation</h2>
         <p class="text">
            Summarise validation errors in a box at the top of your page.
            Use jump links in the summary box to reach the errors in the form.
@@ -1258,7 +1258,7 @@
            Ensure error messages make sense when read by screen readers.
         </p>
 
-        <h3 class="heading-24">Form validation</h3>
+        <h3 class="heading-medium">Form validation</h3>
         <ul class="list-bullet text">
           <li>use a red background and border on the box to visually connect the errors and messages in the form</li>
           <li>apply the same colour to the area of the form where an error has occurred</li>
@@ -1273,7 +1273,7 @@
             <form action="" method="post" class="form">
 
               <div class="validation-summary" aria-labelledby="error-heading" role="alert">
-                <h3 class="heading-19" id="error-heading">There was a problem submitting the form</h3>
+                <h3 class="heading-small" id="error-heading">There was a problem submitting the form</h3>
                 <p>Please try the following:</p>
                 <ul>
                   <li><a href="#error-your-name">Enter your first name</a></li>
@@ -1322,13 +1322,13 @@
 
       <div id="guide-tables">
 
-        <h2 class="heading-36 heading-with-border">9. Tables</h2>
+        <h2 class="heading-large heading-with-border">9. Tables</h2>
         <p class="text">
           Consider putting content into tables to make it easier to scan.
         </p>
         <p><a href="https://www.gov.uk/passport-fees">See an example of table usage on GOV.UK</a></p>
 
-        <h3 class="heading-24">Data in a table</h3>
+        <h3 class="heading-medium">Data in a table</h3>
         <div class="example">
           <div class="inner-block">
 


### PR DESCRIPTION
- Remove the value (e.g. -48, -36) from all headings
- Instead, set classnames for headings, ranging from xxlarge to small (this is more flexible, if they ever change).
- Use relative units for margins and padding on all headings and text
- Keep values for margins and padding easy to understand - here we're using a function called `em` which accepts a pixel value and returns a relative value in em `em($px, $base: 19)`, find this in [_helpers.scss](https://github.com/alphagov/govuk_elements/blob/master/public/sass/elements/_helpers.scss#L4)
