### PR TITLE
New error message styles

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -71,6 +71,7 @@ fieldset {
 
 // Form hints & examples are light grey and sit above a form control
 .form-hint {
+  @include core-16;
   display: block;
   color: $secondary-text-colour;
   margin-bottom: 5px;

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -2,63 +2,65 @@
 
 // Validation summary box
 .validation-summary {
-  border: 3px solid $error-colour;
-  padding: $gutter-half $gutter;
-  margin-bottom: $gutter;
+  @include bold-16;
+
+  margin-bottom: em(30);
+  padding: em(15) em(30);
+
+  background: $error-colour;
+  color: white;
 
   @include ie-lte(6){
     zoom: 1;
   }
-}
 
-.validation-summary ul {
-  margin-top: 10px;
-}
-
-.validation-summary li,
-.validation-summary p {
-  @include core-16;
-}
-
-.validation-summary p {
-  margin-top: $gutter-half;
-  margin-bottom: 5px;
-}
-
-.validation-summary a {
-  color: $error-colour;
-  @include ie-lte(6) {
-    color: $error-colour !important;
+  .heading-small {
+    margin-top: em(15);
+    margin-bottom: em(10);
   }
+
+  p {
+    margin-top: $gutter-half;
+    margin-bottom: 5px;
+  }
+
+  a {
+    color: white;
+    @include ie-lte(6) {
+      color: white !important;
+    }
+  }
+
 }
 
-.validation-summary .heading-small {
-  margin-top: $gutter-half;
-}
-
-
-// Validation error message box
-// .validation-error {
-//   clear: both;
-//   @include contain-floats;
-//   border-left: 3px solid $error-colour;
-//   padding: $gutter- $gutter;
-//   margin-bottom: $gutter-half;
-//   margin-left: -($gutter);
-// }
-
-// .validation-error .form-group {
-//   margin-bottom: 20px;
-// }
-
-// .validation-error p {
-//   margin-bottom: 10px;
-// }
-
-
-// Validation message
-.validation-message {
-  display: block;
-  @include core-16;
+// Show error styles for label and input pairs
+.validation-error {
+  clear: both;
+  @include contain-floats;
   color: $error-colour;
+
+  // Make any labels red and bold
+  label {
+    font-weight: bold;
+    color: $error-colour;
+  }
+
+  // Sit error message on a new line
+  .validation-message {
+    @include core-16;
+    display: block;
+  }
+
+  // Add a 3px red border to inputs
+  input {
+   border: 3px solid $error-colour;
+  }
+
+  // Set border colour to match focus
+  input:focus {
+    border-color: $yellow;
+    outline-color: $yellow;
+    outline-width: 2px;
+  }
+
 }

--- a/views/index.html
+++ b/views/index.html
@@ -1293,7 +1293,6 @@
           <li>errors should not cause pre-filled fields to clear</li>
         </ul>
 
-        <!--
         <div class="example form-group-example">
           <div class="inner-block">
 
@@ -1342,7 +1341,6 @@
 
           </div>
         </div>
-        -->
 
       </div>
       <!-- / #guide-errors -->


### PR DESCRIPTION
- Add large red panel to summarise errors
- this looks like the green panels we use at the end of transactions,
  with jump links
- Add a red outline to form fields, matching the width of the focus
  style

![errors-mobile](https://cloud.githubusercontent.com/assets/417754/2997556/c28d6816-dd00-11e3-95e7-b0dee668ca85.png)
![errors-desktop](https://cloud.githubusercontent.com/assets/417754/2997558/caba83de-dd00-11e3-9738-fbddcac580d5.png)
