### PR TITLE
Make grid layout more robust

### DIFF
--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -51,20 +51,18 @@
 // ==========================================================================
 
 .example {
+  @include inner-block;
   @include contain-floats;
+
   position: relative;
   overflow: hidden;
   border: 1px solid $grey-2;
   outline: $gutter-half solid $highlight-colour;
+
   margin: $gutter*1.5 0 $gutter*2 0;
 
-  padding-top: $gutter-half;
-  padding-bottom: $gutter-half;
-
-  @include media(tablet) {
-    padding-top: $gutter;
-    padding-bottom: $gutter;
-  }
+  padding-top: $gutter;
+  padding-bottom: $gutter;
 
   // Blue text for heading sizes
   .highlight {
@@ -79,21 +77,11 @@
 // ==========================================================================
 
 // Grid layout boxes
-.example-grid {
-  background: white;
-  padding-top: 15px;
-  padding-bottom: 10px;
-  @include media(tablet) {
-    padding-top: 25px;
-    padding-bottom: 20px;
-  }
-}
-
 .example-grid p {
   width: 100%;
   background: url("../../public/images/examples/grid.png") 0 0 repeat;
   min-height: 30px;
-  margin-bottom: 10px;
+  margin-bottom: 0;
   @include media(tablet) {
     min-height: 60px;
   }

--- a/public/sass/elements/_layout.scss
+++ b/public/sass/elements/_layout.scss
@@ -1,29 +1,34 @@
 // Layout
 // ==========================================================================
 
+// Ensure .inner-block doesn't inherit a margin here
+// TODO: Change this in the govuk_template
+#global-header-bar .inner-block {
+  margin: 0;
+}
+
 #wrapper {
   text-align: center;
+
   padding-bottom: $gutter;
   @include media(desktop) {
     padding-bottom: $gutter*3;
   }
 }
 
-#content {
-  text-align: left;
-  @include outer-block;
-  @include contain-floats; // TODO: awaiting merge into front end toolkit
-}
-
 // Use .outer-block to create a max width block of 1020px,
 // Use .inner-block to create padding that matches the header and footer
 
-.outer-block {
+// .outer-block,
+#content {
+  text-align: left;
+
   @include outer-block;
-  @include contain-floats; // Repeated as %extend placeholder insn't understood
+  @include contain-floats; // Repeated as %extend placeholder isn't supported
 }
+
 .inner-block {
-  @include inner-block;
+  @include inner-block(margin);
 }
 
 
@@ -39,57 +44,107 @@
 // Grid layout
 // ==========================================================================
 
+// Usage:
+// For two equal columns
+
+// <div class="grid-wrapper">
+//   <div class="grid grid-1-2">
+//     <div class="inner-block">
+
+//     </div>
+//   </div>
+//   <div class="grid grid-1-2">
+//     <div class="inner-block">
+
+//     </div>
+//   </div>
+// </div>
+
+// Use .grid-wrapper to wrap and clear grid sections
 .grid-wrapper {
   @include contain-floats;
-  @include media(tablet) {
-    padding: 0 $gutter-half;
+  @include media(tablet){
+    margin-left: 15px;
+    margin-right: 15px;
   }
 }
 
-// Grid units take 100% width, unless a .grid-width class is applied
+// Use .grid-divider to create borders dividing grid sections
+.grid-divider {
+  @include contain-floats;
+  border-bottom: 1px solid $border-colour;
+  margin-bottom: 20px;
+  margin-left: 15px;
+  margin-right: 15px;
+
+  @include media(tablet){
+    margin-left: 30px;
+    margin-right: 30px;
+  }
+}
+
+// 2. Grid units take 100% width, unless a .grid-width class is applied
 .grid {
   float: left;
   width: 100%;
 }
 
-// Grid 'inner-block' aligns grid content with header and footer
-.grid .inner-block {
-  @include media(tablet) {
-    padding: 0 $gutter-half;
-  }
-}
-
+// Grid widths
 .grid-1-4 {
-  width: 100%;
   @include media(tablet) {
     width: 25%;
   }
 }
 
 .grid-1-3 {
-  width: 100%;
   @include media(tablet) {
     width: 33.333333333%;
   }
 }
 
 .grid-1-2 {
-  width: 100%;
   @include media(tablet) {
     width: 50%;
   }
 }
 
 .grid-2-3 {
-  width: 100%;
   @include media(tablet) {
     width: 66.666666667%;
   }
 }
 
 .grid-3-4 {
-  width: 100%;
   @include media(tablet) {
     width: 75%;
   }
+}
+
+// Grid 'inner-block' sets spacing between grid cells
+.grid .inner-block {
+  padding: 0;
+  @include media(tablet) {
+    margin: 0 $gutter-half;
+  }
+}
+
+
+// Don't put .grid-wrapper inside .inner block
+// There's no need for the extra containing div
+// ** These styles are here in case you do, so we don't break the grid **
+
+.inner-block {
+
+  .grid-wrapper {
+    padding: 0;
+
+    margin-left: -15px;
+    margin-right: -15px;
+  }
+
+  .grid-divider {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
 }

--- a/views/examples/grid_layout.html
+++ b/views/examples/grid_layout.html
@@ -28,15 +28,10 @@
             Grid layout
           </h1>
 
-          <h2 class="heading-large">Full width</h2>
-
-          <div class="text">
-            <a href="#" class="js-highlight-grid">Toggle background colours</a> to see the how the padding on grid cells.
-
-            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
-          </div>
+          <h2 class="heading-small">Full width</h2>
+          <p>
+            <a href="#" class="js-highlight-grid">Toggle background colours</a> to see the size of each of the grid cells.
+          </p>
 
         </div>
       </div>
@@ -46,21 +41,17 @@
       <div class="grid grid-2-3">
         <div class="inner-block">
 
-          <h2 class="heading-large">Two thirds</h2>
+          <h2 class="bold-small">Two thirds</h2>
           <div class="text">
             <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
           </div>
 
         </div>
       </div>
       <div class="grid grid-1-3">
         <div class="inner-block">
-          <h2 class="heading-large">One third</h2>
-          <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+          <h2 class="bold-small">One third</h2>
+          <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus.</p>
         </div>
       </div>
     </div>
@@ -68,18 +59,14 @@
     <div class="grid-wrapper">
       <div class="grid grid-1-2">
         <div class="inner-block">
-          <h2 class="heading-large">One half</h2>
-          <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+          <h2 class="bold-small">One half</h2>
+          <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
         </div>
       </div>
       <div class="grid grid-1-2">
         <div class="inner-block">
-          <h2 class="heading-large">One half</h2>
-          <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+          <h2 class="bold-small">One half</h2>
+          <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
         </div>
       </div>
     </div>
@@ -87,26 +74,20 @@
     <div class="grid-wrapper">
       <div class="grid grid-1-3">
         <div class="inner-block">
-          <h2 class="heading-large">One third</h2>
-          <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+          <h2 class="bold-small">One third</h2>
+          <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
         </div>
       </div>
       <div class="grid grid-1-3">
         <div class="inner-block">
-          <h2 class="heading-large">One third</h2>
-          <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+          <h2 class="bold-small">One third</h2>
+          <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
         </div>
       </div>
       <div class="grid grid-1-3">
         <div class="inner-block">
-          <h2 class="heading-large">One third</h2>
-          <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+          <h2 class="bold-small">One third</h2>
+          <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
         </div>
       </div>
     </div>
@@ -114,59 +95,187 @@
     <div class="grid-wrapper">
       <div class="grid grid-1-4">
         <div class="inner-block">
-          <h2 class="heading-large">One quarter</h2>
+          <h2 class="bold-small">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
         </div>
       </div>
       <div class="grid grid-1-4">
         <div class="inner-block">
-          <h2 class="heading-large">One quarter</h2>
+          <h2 class="bold-small">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
         </div>
       </div>
       <div class="grid grid-1-4">
         <div class="inner-block">
-          <h2 class="heading-large">One quarter</h2>
+          <h2 class="bold-small">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
         </div>
       </div>
       <div class="grid grid-1-4">
         <div class="inner-block">
-          <h2 class="heading-large">One quarter</h2>
+          <h2 class="bold-small">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
         </div>
       </div>
     </div>
+
+    <div class="grid-divider"></div>
+
+    <div class="grid-wrapper">
+      <div class="grid grid-2-3">
+        <div class="inner-block">
+
+          <h2 class="bold-small">Dividing the grid</h2>
+          <div class="text">
+            <p>
+              To set dividers between grid sections, use <code>.grid-divider</code>.
+            </p>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="grid-divider"></div>
 
     <div class="inner-block">
-
-      <h1 class="heading-large">
-        If you don't need a grid&hellip;
-      </h1>
-      <div class="text">
-
-        <p class="text">
-          Here we use two mixins from the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_grid_layout.scss">grid_layout.scss</a> file.
-
-          Use <code>.outer-block</code> to set a max-width of 1020px and <code>.inner-block</code> to set left and right padding.
-        </p>
-
+      <h2 class="heading-medium">
+        You won't always need a grid&hellip;
+      </h2>
+      <p>
+        For full-width layout, a grid isn't required.
+      </p>
+      <p>
+        Use <code>.outer-block</code> to set a max-width of 1020px and within it <code>.inner-block</code> to set left and right padding.<br> Find these mixins in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_grid_layout.scss">grid_layout.scss</a> file.
+      </p>
+      <p>
         <a href="/" class="example-back-link">Back to GOV.UK elements</a>
+      </p>
+    </div><!-- /.inner-block -->
 
+    <!-- Hi there, the code below is not recommended -->
+    <!-- It's here for testing but feel free to ignore it -->
+
+    <!--
+    <div class="inner-block">
+      <div class="grid-wrapper">
+        <div class="grid">
+          <div class="inner-block">
+
+            <a href="/" class="example-back-link">Back to GOV.UK elements</a>
+
+            <h1 class="heading-xlarge">
+              Grid layout
+            </h1>
+
+            <h2 class="heading-small">Full width</h2>
+            <p>
+              <a href="#" class="js-highlight-grid">Toggle background colours</a> to see the size of each of the grid cells.
+            </p>
+
+          </div>
+        </div>
       </div>
+      <div class="grid-wrapper">
+        <div class="grid grid-2-3">
+          <div class="inner-block">
 
+            <h2 class="bold-small">Two thirds</h2>
+            <div class="text">
+              <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+            </div>
+
+          </div>
+        </div>
+        <div class="grid grid-1-3">
+          <div class="inner-block">
+            <h2 class="bold-small">One third</h2>
+            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus.</p>
+          </div>
+        </div>
+      </div>
+      <div class="grid-wrapper">
+        <div class="grid grid-1-2">
+          <div class="inner-block">
+            <h2 class="bold-small">One half</h2>
+            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+          </div>
+        </div>
+        <div class="grid grid-1-2">
+          <div class="inner-block">
+            <h2 class="bold-small">One half</h2>
+            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+          </div>
+        </div>
+      </div>
+      <div class="grid-wrapper">
+        <div class="grid grid-1-3">
+          <div class="inner-block">
+            <h2 class="bold-small">One third</h2>
+            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+          </div>
+        </div>
+        <div class="grid grid-1-3">
+          <div class="inner-block">
+            <h2 class="bold-small">One third</h2>
+            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+          </div>
+        </div>
+        <div class="grid grid-1-3">
+          <div class="inner-block">
+            <h2 class="bold-small">One third</h2>
+            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+          </div>
+        </div>
+      </div>
+      <div class="grid-wrapper">
+        <div class="grid grid-1-4">
+          <div class="inner-block">
+            <h2 class="bold-small">One quarter</h2>
+            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+          </div>
+        </div>
+        <div class="grid grid-1-4">
+          <div class="inner-block">
+            <h2 class="bold-small">One quarter</h2>
+            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+          </div>
+        </div>
+        <div class="grid grid-1-4">
+          <div class="inner-block">
+            <h2 class="bold-small">One quarter</h2>
+            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+          </div>
+        </div>
+        <div class="grid grid-1-4">
+          <div class="inner-block">
+            <h2 class="bold-small">One quarter</h2>
+            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+          </div>
+        </div>
+      </div>
+      <div class="grid-divider">
+      </div>
+      <div class="grid-wrapper">
+        <div class="grid grid-2-3">
+          <div class="inner-block">
+
+            <h2 class="bold-small">Dividing the grid</h2>
+            <div class="text">
+              <p>
+                To set dividers between grid sections, use <code>.grid-divider</code>.
+              </p>
+            </div>
+
+          </div>
+        </div>
+      </div>
     </div>
+    -->
 
-  </div>
+  </div><!-- /#content (.outer-block) -->
 </main>
+
 {{/content}}
 
 {{$bodyEnd}}

--- a/views/index.html
+++ b/views/index.html
@@ -4,21 +4,17 @@
 
 {{$content}}
 
-<div class="outer-block">
-  <div class="inner-block">
-
-    <div class="phase-banner">
-      <p>
-        <strong class="phase-tag">ALPHA</strong>
-        <span>This is a new service – your <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2">feedback</a> will help us to improve it.</span>
-      </p>
-    </div>
-
-  </div>
-</div>
-
 <main id="wrapper" role="main">
   <div id="content">
+
+    <div class="inner-block">
+      <div class="phase-banner">
+        <p>
+          <strong class="phase-tag">ALPHA</strong>
+          <span>This is a new service – your <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2">feedback</a> will help us to improve it.</span>
+        </p>
+      </div>
+    </div>
 
     {{>service_manual_breadcrumb}}
     {{>service_manual_header}}
@@ -199,12 +195,10 @@
         </ul>
 
         <div class="example">
-          <div class="inner-block">
-            <h1 class="heading-xlarge">A <em class="highlight">48px Bold</em> heading</h1>
-            <h2 class="heading-large">A <em class="highlight">36px Bold</em> heading</h2>
-            <h3 class="heading-medium">A <em class="highlight">24px Bold</em> heading</h3>
-            <h4 class="heading-small">A <em class="highlight">19px Bold</em> heading</h4>
-          </div>
+          <h1 class="heading-xlarge">A <em class="highlight">48px Bold</em> heading</h1>
+          <h2 class="heading-large">A <em class="highlight">36px Bold</em> heading</h2>
+          <h3 class="heading-medium">A <em class="highlight">24px Bold</em> heading</h3>
+          <h4 class="heading-small">A <em class="highlight">19px Bold</em> heading</h4>
         </div>
 
         <h3 class="heading-medium">
@@ -215,13 +209,9 @@
         </p>
 
         <div class="example">
-          <div class="inner-block">
-
-            <div class="text">
-              <p class="lead">A <em class="highlight">24px</em> lead paragraph. Maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla.</p>
-              <p class="copy-19">A <em class="highlight">19px</em> body copy paragraph. Maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla. Maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla.</p>
-            </div>
-
+          <div class="text">
+            <p class="lead">A <em class="highlight">24px</em> lead paragraph. Maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla.</p>
+            <p class="copy-19">A <em class="highlight">19px</em> body copy paragraph. Maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla. Maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla.</p>
           </div>
         </div>
 
@@ -239,14 +229,11 @@
             for example, on this page &ndash; text blocks are two-thirds of the page width
           </li>
         </ul>
+
         <div class="example">
-          <div class="inner-block">
-
-            <div class="text">
-              <p class="copy-19">A <em class="highlight">19px</em> body copy paragraph. Maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla.</p>
-              <p class="copy-16">A <em class="highlight">16px</em> supporting text paragraph. Maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla. </p>
-            </div>
-
+          <div class="text">
+            <p class="copy-19">A <em class="highlight">19px</em> body copy paragraph. Maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla.</p>
+            <p class="copy-16">A <em class="highlight">16px</em> supporting text paragraph. Maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla. </p>
           </div>
         </div>
 
@@ -258,20 +245,16 @@
         </ul>
 
         <div class="example">
-          <div class="inner-block">
-
-            <div class="text">
-              <p class="copy-19">
-                <a href="">A 19px link without surrounding text</a>
-              </p>
-              <p class="copy-19">
-                <a href="">A 19px body copy link</a>. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
-              </p>
-              <p class="copy-19">
-                <a href="#" rel="external">A 19px body copy external link.</a> Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
-              </p>
-            </div>
-
+          <div class="text">
+            <p class="copy-19">
+              <a href="">A 19px link without surrounding text</a>
+            </p>
+            <p class="copy-19">
+              <a href="">A 19px body copy link</a>. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
+            </p>
+            <p class="copy-19">
+              <a href="#" rel="external">A 19px body copy external link.</a> Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
+            </p>
           </div>
         </div>
 
@@ -280,23 +263,19 @@
           List items start with a lowercase letter and have no full stop at the end.
         </p>
         <div class="example">
-          <div class="inner-block">
+          <ul class="list-bullet">
+            <li>here is a bulleted list</li>
+            <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
+            <li>vestibulum id ligula porta felis euismod semper</li>
+            <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
+          </ul>
 
-            <ul class="list-bullet text">
-              <li>here is a bulleted list</li>
-              <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
-              <li>vestibulum id ligula porta felis euismod semper</li>
-              <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
-            </ul>
-
-            <ol class="list-number text">
-              <li>here is a numbered list</li>
-              <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
-              <li>vestibulum id ligula porta felis euismod semper</li>
-              <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
-            </ol>
-
-          </div>
+          <ol class="list-number text">
+            <li>here is a numbered list</li>
+            <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
+            <li>vestibulum id ligula porta felis euismod semper</li>
+            <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
+          </ol>
         </div>
 
         <h3 class="heading-medium">Inset text</h3>
@@ -307,14 +286,10 @@
           <a href="https://www.gov.uk/holiday-entitlement-rights">See an example of inset text on GOV.UK</a>
         </p>
         <div class="example">
-          <div class="inner-block">
-
-            <div class="text panel-indent">
-              <p>
-                It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.
-              </p>
-            </div>
-
+          <div class="text panel-indent">
+            <p>
+              It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.
+            </p>
           </div>
         </div>
 
@@ -327,14 +302,10 @@
           Click on "How to get this" to see how this works.
         </p>
         <div class="example">
-          <div class="inner-block">
-
-            <details>
-              <summary>How to get this?</summary>
-              <p>The prisoner you’re visiting will be able to give you their prisoner number.</p>
-            </details>
-
-          </div>
+          <details>
+            <summary>How to get this?</summary>
+            <p>The prisoner you’re visiting will be able to give you their prisoner number.</p>
+          </details>
         </div>
 
       </div>
@@ -358,177 +329,171 @@
         </p>
 
         <div class="example">
-          <div class="inner-block">
 
-            <div class="swatch-wrapper">
-              <h4 class="heading-small">Text</h4>
 
-              <div class="swatch swatch-text-colour"></div>
-              <ul>
-                <li><b>#0B0C0C</b></li>
-                <li>$text-colour</li>
-              </ul>
+          <div class="swatch-wrapper">
+            <h4 class="heading-small">Text</h4>
 
-              <div class="swatch swatch-text-secondary"></div>
-              <ul>
-                <li><b>#6F777B</b></li>
-                <li>$secondary-text-colour</li>
-              </ul>
+            <div class="swatch swatch-text-colour"></div>
+            <ul>
+              <li><b>#0B0C0C</b></li>
+              <li>$text-colour</li>
+            </ul>
 
-              <div class="swatch swatch-page-colour"></div>
+            <div class="swatch swatch-text-secondary"></div>
+            <ul>
+              <li><b>#6F777B</b></li>
+              <li>$secondary-text-colour</li>
+            </ul>
 
-              <ul>
-                <li><b>#FFFFFF</b></li>
-                <li>$page-colour</li>
-              </ul>
-            </div>
+            <div class="swatch swatch-page-colour"></div>
 
-            <div class="swatch-wrapper">
-              <h4 class="heading-small">Links</h4>
+            <ul>
+              <li><b>#FFFFFF</b></li>
+              <li>$page-colour</li>
+            </ul>
+          </div>
 
-              <div class="swatch swatch-link-colour"></div>
-              <ul>
-                <li><b>#005ea5</b></li>
-                <li>$link-colour</li>
-              </ul>
+          <div class="swatch-wrapper">
+            <h4 class="heading-small">Links</h4>
 
-              <div class="swatch swatch-link-colour-hover"></div>
-              <ul>
-                <li><b>#2e8aca</b></li>
-                <li>$link-hover-colour</li>
-              </ul>
+            <div class="swatch swatch-link-colour"></div>
+            <ul>
+              <li><b>#005ea5</b></li>
+              <li>$link-colour</li>
+            </ul>
 
-              <div class="swatch swatch-link-colour-visited"></div>
-              <ul>
-                <li><b>#2e8aca</b></li>
-                <li>$link-visited</li>
-              </ul>
-            </div>
+            <div class="swatch swatch-link-colour-hover"></div>
+            <ul>
+              <li><b>#2e8aca</b></li>
+              <li>$link-hover-colour</li>
+            </ul>
 
-            <div class="swatch-wrapper">
-              <h4 class="heading-small">Backgrounds</h4>
+            <div class="swatch swatch-link-colour-visited"></div>
+            <ul>
+              <li><b>#2e8aca</b></li>
+              <li>$link-visited</li>
+            </ul>
+          </div>
 
-              <div class="swatch swatch-border-colour"></div>
-              <ul>
-                <li><b>#BFC1C3</b></li>
-                <li>$border-colour</li>
-              </ul>
+          <div class="swatch-wrapper">
+            <h4 class="heading-small">Backgrounds</h4>
 
-              <div class="swatch swatch-panel-colour"></div>
-              <ul>
-                <li><b>#DEE0E2</b></li>
-                <li>$panel-colour</li>
-              </ul>
+            <div class="swatch swatch-border-colour"></div>
+            <ul>
+              <li><b>#BFC1C3</b></li>
+              <li>$border-colour</li>
+            </ul>
 
-              <div class="swatch swatch-highlight-colour"></div>
-              <ul>
-                <li><b>#F8F8F8</b></li>
-                <li>$highlight-colour</li>
-              </ul>
-            </div>
+            <div class="swatch swatch-panel-colour"></div>
+            <ul>
+              <li><b>#DEE0E2</b></li>
+              <li>$panel-colour</li>
+            </ul>
 
-            <div class="swatch-wrapper">
-              <h4 class="heading-small">Buttons</h4>
+            <div class="swatch swatch-highlight-colour"></div>
+            <ul>
+              <li><b>#F8F8F8</b></li>
+              <li>$highlight-colour</li>
+            </ul>
+          </div>
 
-              <div class="swatch swatch-button-colour"></div>
-              <ul>
-                <li><b>#00823B</b></li>
-                <li>$button-colour</li>
-              </ul>
+          <div class="swatch-wrapper">
+            <h4 class="heading-small">Buttons</h4>
 
-              <div class="swatch swatch-green"></div>
-              <ul>
-                <li><b>#006435</b></li>
-                <li>$green (hover colour)</li>
-              </ul>
-            </div>
+            <div class="swatch swatch-button-colour"></div>
+            <ul>
+              <li><b>#00823B</b></li>
+              <li>$button-colour</li>
+            </ul>
 
-            <div class="swatch-wrapper">
-              <h4 class="heading-small">Focus</h4>
-              <div class="swatch swatch-yellow"></div>
-              <ul>
-                <li><b>#FFBF47</b></li>
-                <li>$yellow</li>
-              </ul>
-            </div>
+            <div class="swatch swatch-green"></div>
+            <ul>
+              <li><b>#006435</b></li>
+              <li>$green (hover colour)</li>
+            </ul>
+          </div>
 
+          <div class="swatch-wrapper">
+            <h4 class="heading-small">Focus</h4>
+            <div class="swatch swatch-yellow"></div>
+            <ul>
+              <li><b>#FFBF47</b></li>
+              <li>$yellow</li>
+            </ul>
           </div>
         </div>
 
         <h3 class="heading-medium">Status colours</h3>
         <div class="example">
-          <div class="inner-block">
 
-            <div class="swatch-wrapper">
+          <div class="swatch-wrapper">
 
-              <div class="swatch swatch-alpha"></div>
-              <ul>
-                <li><b>#d53880</b></li>
-                <li>$alpha-colour</li>
-              </ul>
-
-            </div>
-            <div class="swatch-wrapper">
-
-              <div class="swatch swatch-beta"></div>
-              <ul>
-                <li><b>#f47738</b></li>
-                <li>$beta-colour</li>
-              </ul>
-
-            </div>
-            <div class="swatch-wrapper">
-
-              <div class="swatch swatch-error"></div>
-              <ul>
-                <li><b>#df3034</b></li>
-                <li>$error-colour</li>
-              </ul>
-
-            </div>
+            <div class="swatch swatch-alpha"></div>
+            <ul>
+              <li><b>#d53880</b></li>
+              <li>$alpha-colour</li>
+            </ul>
 
           </div>
+          <div class="swatch-wrapper">
+
+            <div class="swatch swatch-beta"></div>
+            <ul>
+              <li><b>#f47738</b></li>
+              <li>$beta-colour</li>
+            </ul>
+
+          </div>
+          <div class="swatch-wrapper">
+
+            <div class="swatch swatch-error"></div>
+            <ul>
+              <li><b>#df3034</b></li>
+              <li>$error-colour</li>
+            </ul>
+
+          </div>
+
         </div>
 
         <h3 class="heading-medium">Greyscale palette</h3>
         <div class="example">
-          <div class="inner-block">
 
-            <div class="swatch-wrapper">
-              <div class="swatch swatch-black"></div>
-              <ul>
-                <li><b>#0B0C0C</b></li>
-                <li>$black</li>
-              </ul>
-            </div>
-            <div class="swatch-wrapper">
-              <div class="swatch swatch-grey-1"></div>
-              <ul>
-                <li><b>#6F777B</b></li>
-                <li>$grey-1</li>
-              </ul>
-            </div>
-            <div class="swatch-wrapper">
-              <div class="swatch swatch-grey-2"></div>
-              <ul>
-                <li><b>#BFC1C3</b></li>
-                <li>$grey-2</li>
-              </ul>
-            </div>
-            <div class="swatch-wrapper">
-              <div class="swatch swatch-grey-3"></div>
-              <ul>
-                <li><b>#DEE0E2</b></li>
-                <li>$grey-3</li>
-              </ul>
-            </div>
-            <div class="swatch-wrapper">
-              <div class="swatch swatch-grey-4"></div>
-              <ul>
-                <li><b>#F8F8F8</b></li>
-                <li>$grey-4</li>
-              </ul>
-            </div>
+          <div class="swatch-wrapper">
+            <div class="swatch swatch-black"></div>
+            <ul>
+              <li><b>#0B0C0C</b></li>
+              <li>$black</li>
+            </ul>
+          </div>
+          <div class="swatch-wrapper">
+            <div class="swatch swatch-grey-1"></div>
+            <ul>
+              <li><b>#6F777B</b></li>
+              <li>$grey-1</li>
+            </ul>
+          </div>
+          <div class="swatch-wrapper">
+            <div class="swatch swatch-grey-2"></div>
+            <ul>
+              <li><b>#BFC1C3</b></li>
+              <li>$grey-2</li>
+            </ul>
+          </div>
+          <div class="swatch-wrapper">
+            <div class="swatch swatch-grey-3"></div>
+            <ul>
+              <li><b>#DEE0E2</b></li>
+              <li>$grey-3</li>
+            </ul>
+          </div>
+          <div class="swatch-wrapper">
+            <div class="swatch swatch-grey-4"></div>
+            <ul>
+              <li><b>#F8F8F8</b></li>
+              <li>$grey-4</li>
+            </ul>
           </div>
         </div>
 
@@ -544,131 +509,130 @@
         </p>
 
         <div class="example">
-          <div class="inner-block">
 
-            <div class="swatch-wrapper">
-              <h4 class="heading-small">Purple</h4>
 
-              <div class="swatch swatch-purple"></div>
-              <ul>
-                <li><b>#2e358b</b></li>
-                <li>$purple</li>
-              </ul>
+          <div class="swatch-wrapper">
+            <h4 class="heading-small">Purple</h4>
 
-              <h4 class="heading-small">Mauve</h4>
+            <div class="swatch swatch-purple"></div>
+            <ul>
+              <li><b>#2e358b</b></li>
+              <li>$purple</li>
+            </ul>
 
-              <div class="swatch swatch-mauve"></div>
-              <ul>
-                <li><b>#6f72af</b></li>
-                <li>$mauve</li>
-              </ul>
+            <h4 class="heading-small">Mauve</h4>
 
-              <h4 class="heading-small">Fuschia</h4>
+            <div class="swatch swatch-mauve"></div>
+            <ul>
+              <li><b>#6f72af</b></li>
+              <li>$mauve</li>
+            </ul>
 
-              <div class="swatch swatch-fuschia"></div>
-              <ul>
-                <li><b>#912b88</b></li>
-                <li>$fuschia</li>
-              </ul>
-            </div>
+            <h4 class="heading-small">Fuschia</h4>
 
-            <div class="swatch-wrapper">
-              <h4 class="heading-small">Pink</h4>
-
-              <div class="swatch swatch-pink"></div>
-              <ul>
-                <li><b>#d53880</b></li>
-                <li>$pink</li>
-              </ul>
-
-              <h4 class="heading-small">Baby pink</h4>
-
-              <div class="swatch swatch-baby-pink"></div>
-              <ul>
-                <li><b>#f499be</b></li>
-                <li>$baby-pink</li>
-              </ul>
-
-              <h4 class="heading-small">Red</h4>
-
-              <div class="swatch swatch-red"></div>
-              <ul>
-                <li><b>#b10e1e</b></li>
-                <li>$red</li>
-              </ul>
-            </div>
-
-            <div class="swatch-wrapper">
-              <h4 class="heading-small">Mellow red</h4>
-
-              <div class="swatch swatch-mellow-red"></div>
-              <ul>
-                <li><b>#df3034</b></li>
-                <li>$mellow-red</li>
-              </ul>
-
-              <h4 class="heading-small">Orange</h4>
-
-              <div class="swatch swatch-orange"></div>
-              <ul>
-                <li><b>#f47738</b></li>
-                <li>$orange</li>
-              </ul>
-
-              <h4 class="heading-small">Brown</h4>
-
-              <div class="swatch swatch-brown"></div>
-              <ul>
-                <li><b>#b58840</b></li>
-                <li>$brown</li>
-              </ul>
-            </div>
-
-            <div class="swatch-wrapper">
-              <h4 class="heading-small">Yellow</h4>
-
-              <div class="swatch swatch-yellow"></div>
-              <ul>
-                <li><b>#ffbf47</b></li>
-                <li>$yellow</li>
-              </ul>
-
-              <h4 class="heading-small">Green</h4>
-
-              <div class="swatch swatch-green"></div>
-              <ul>
-                <li><b>#006435</b></li>
-                <li>$green</li>
-              </ul>
-
-              <h4 class="heading-small">Grass green</h4>
-
-              <div class="swatch swatch-grass-green"></div>
-              <ul>
-                <li><b>#85994b</b></li>
-                <li>$grass-green</li>
-              </ul>
-            </div>
-
-            <div class="swatch-wrapper">
-              <h4 class="heading-small">Turquoise</h4>
-
-              <div class="swatch swatch-turquoise"></div>
-              <ul>
-                <li><b>#28a197</b></li>
-                <li>$turquoise</li>
-              </ul>
-
-              <h4 class="heading-small">Light blue</h4>
-
-              <div class="swatch swatch-light-blue"></div>
-              <ul>
-                <li><b>#2b8cc4</b></li>
-                <li>$light-blue</li>
-              </ul>
-            </div>
-
+            <div class="swatch swatch-fuschia"></div>
+            <ul>
+              <li><b>#912b88</b></li>
+              <li>$fuschia</li>
+            </ul>
           </div>
+
+          <div class="swatch-wrapper">
+            <h4 class="heading-small">Pink</h4>
+
+            <div class="swatch swatch-pink"></div>
+            <ul>
+              <li><b>#d53880</b></li>
+              <li>$pink</li>
+            </ul>
+
+            <h4 class="heading-small">Baby pink</h4>
+
+            <div class="swatch swatch-baby-pink"></div>
+            <ul>
+              <li><b>#f499be</b></li>
+              <li>$baby-pink</li>
+            </ul>
+
+            <h4 class="heading-small">Red</h4>
+
+            <div class="swatch swatch-red"></div>
+            <ul>
+              <li><b>#b10e1e</b></li>
+              <li>$red</li>
+            </ul>
+          </div>
+
+          <div class="swatch-wrapper">
+            <h4 class="heading-small">Mellow red</h4>
+
+            <div class="swatch swatch-mellow-red"></div>
+            <ul>
+              <li><b>#df3034</b></li>
+              <li>$mellow-red</li>
+            </ul>
+
+            <h4 class="heading-small">Orange</h4>
+
+            <div class="swatch swatch-orange"></div>
+            <ul>
+              <li><b>#f47738</b></li>
+              <li>$orange</li>
+            </ul>
+
+            <h4 class="heading-small">Brown</h4>
+
+            <div class="swatch swatch-brown"></div>
+            <ul>
+              <li><b>#b58840</b></li>
+              <li>$brown</li>
+            </ul>
+          </div>
+
+          <div class="swatch-wrapper">
+            <h4 class="heading-small">Yellow</h4>
+
+            <div class="swatch swatch-yellow"></div>
+            <ul>
+              <li><b>#ffbf47</b></li>
+              <li>$yellow</li>
+            </ul>
+
+            <h4 class="heading-small">Green</h4>
+
+            <div class="swatch swatch-green"></div>
+            <ul>
+              <li><b>#006435</b></li>
+              <li>$green</li>
+            </ul>
+
+            <h4 class="heading-small">Grass green</h4>
+
+            <div class="swatch swatch-grass-green"></div>
+            <ul>
+              <li><b>#85994b</b></li>
+              <li>$grass-green</li>
+            </ul>
+          </div>
+
+          <div class="swatch-wrapper">
+            <h4 class="heading-small">Turquoise</h4>
+
+            <div class="swatch swatch-turquoise"></div>
+            <ul>
+              <li><b>#28a197</b></li>
+              <li>$turquoise</li>
+            </ul>
+
+            <h4 class="heading-small">Light blue</h4>
+
+            <div class="swatch swatch-light-blue"></div>
+            <ul>
+              <li><b>#2b8cc4</b></li>
+              <li>$light-blue</li>
+            </ul>
+          </div>
+
         </div>
 
       </div>
@@ -798,41 +762,37 @@
         </p>
 
         <div class="example">
-          <div class="inner-block">
-
-            <table>
-              <thead>
-                <tr>
-                  <th></th>
-                  <th>Business Plan</th>
-                  <th>Actual</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>Vehicle volumes</td>
-                  <td>103,672,000</td>
-                  <td>97,424,000</td>
-                </tr>
-                <tr>
-                  <td>Driver volumes</td>
-                  <td>16,891,000</td>
-                  <td>15,197,000</td>
-                </tr>
-                <tr>
-                 <td>Electronic take-up target</td>
-                  <td>54%</td>
-                  <td>-</td>
-                </tr>
-                <tr>
-                  <td>Electronic take-up (actual)</td>
-                  <td>-</td>
-                  <td>50.3%</td>
-                </tr>
-              </tbody>
-            </table>
-
-          </div>
+          <table>
+            <thead>
+              <tr>
+                <th></th>
+                <th>Business Plan</th>
+                <th>Actual</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Vehicle volumes</td>
+                <td>103,672,000</td>
+                <td>97,424,000</td>
+              </tr>
+              <tr>
+                <td>Driver volumes</td>
+                <td>16,891,000</td>
+                <td>15,197,000</td>
+              </tr>
+              <tr>
+               <td>Electronic take-up target</td>
+                <td>54%</td>
+                <td>-</td>
+              </tr>
+              <tr>
+                <td>Electronic take-up (actual)</td>
+                <td>-</td>
+                <td>50.3%</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
 
       </div>
@@ -868,16 +828,12 @@
           Click on the label "Full name" to bring focus to the form field.
         </p>
         <div class="example">
-          <div class="inner-block">
-
-            <form action="" method="post" class="form">
-              <div class="form-group">
-                <label for="full-name-f1" class="form-label">Full name</label>
-                <input type="text" class="form-control" id="full-name-f1">
-              </div>
-            </form>
-
-          </div>
+          <form action="" method="post" class="form">
+            <div class="form-group">
+              <label for="full-name-f1" class="form-label">Full name</label>
+              <input type="text" class="form-control" id="full-name-f1">
+            </div>
+          </form>
         </div>
 
         <h3 class="heading-medium">Form fields</h3>
@@ -946,20 +902,18 @@
         </p>
 
         <div class="example">
-          <div class="inner-block">
 
-            <form action="" method="post" class="form form-group-example">
-              <div class="form-group">
-                <label class="form-label" for="first-name-2">First name</label>
-                <input type="text" class="form-control" id="first-name-2">
-              </div>
-              <div class="form-group">
-                <label class="form-label" for="last-name-2">Last name</label>
-                <input type="text" class="form-control" id="last-name-2">
-              </div>
-            </form>
+          <form action="" method="post" class="form form-group-example">
+            <div class="form-group">
+              <label class="form-label" for="first-name-2">First name</label>
+              <input type="text" class="form-control" id="first-name-2">
+            </div>
+            <div class="form-group">
+              <label class="form-label" for="last-name-2">Last name</label>
+              <input type="text" class="form-control" id="last-name-2">
+            </div>
+          </form>
 
-          </div>
         </div>
 
         <h3 class="heading-medium">Hint and example text</h3>
@@ -969,20 +923,19 @@
           <li>hint text should sit above a form field</li>
           <li>ensure hint text can be read correctly by screen readers</li>
         </ul>
+
         <div class="example">
-          <div class="inner-block">
 
-            <form action="" method="post" class="form">
-              <div class="form-group">
-                <label class="form-label" for="ni-number-1">
-                  National Insurance number
-                  <span class="form-hint">It'll be on your last payslip. For example, JH 21 90 0A.</span>
-                </label>
-                <input type="text" class="form-control" id="ni-number-1">
-              </div>
-            </form>
+          <form action="" method="post" class="form">
+            <div class="form-group">
+              <label class="form-label" for="ni-number-1">
+                National Insurance number
+                <span class="form-hint">It'll be on your last payslip. For example, JH 21 90 0A.</span>
+              </label>
+              <input type="text" class="form-control" id="ni-number-1">
+            </div>
+          </form>
 
-          </div>
         </div>
 
         <h3 class="heading-medium">Drop-down lists</h3>
@@ -1000,57 +953,53 @@
         </ul>
 
         <div class="example">
-          <div class="inner-block">
 
-            <form action="" method="post" class="form">
-              <fieldset class="inline">
-                <legend></legend>
+          <form action="" method="post" class="form">
+            <fieldset class="inline">
+              <legend></legend>
 
-                <label for="radio-inline-1" class="block-label">
-                  <input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes">
-                  Yes
-                </label>
-                <label for="radio-inline-2" class="block-label">
-                  <input id="radio-inline-2" type="radio" name="radio-inline-group" value="No">
-                  No
-                </label>
-              </fieldset>
-            </form>
+              <label for="radio-inline-1" class="block-label">
+                <input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes">
+                Yes
+              </label>
+              <label for="radio-inline-2" class="block-label">
+                <input id="radio-inline-2" type="radio" name="radio-inline-group" value="No">
+                No
+              </label>
+            </fieldset>
+          </form>
 
-          </div>
         </div>
 
         <div class="example">
-          <div class="inner-block">
 
-            <form action="" method="post" class="form">
-              <fieldset>
-                <legend></legend>
+          <form action="" method="post" class="form">
+            <fieldset>
+              <legend></legend>
 
-                <div class="form-group">
+              <div class="form-group">
 
-                  <label for="radio-1" class="block-label">
-                    <input id="radio-1" type="radio" name="radio-group" value="1">
-                    Northern Ireland
-                  </label>
+                <label for="radio-1" class="block-label">
+                  <input id="radio-1" type="radio" name="radio-group" value="1">
+                  Northern Ireland
+                </label>
 
-                  <label for="radio-2" class="block-label">
-                    <input id="radio-2" type="radio" name="radio-group" value="2">
-                    Isle of Man or the Channel Islands
-                  </label>
+                <label for="radio-2" class="block-label">
+                  <input id="radio-2" type="radio" name="radio-group" value="2">
+                  Isle of Man or the Channel Islands
+                </label>
 
-                  <p class="form-block">or</p>
+                <p class="form-block">or</p>
 
-                  <label for="radio-3" class="block-label">
-                    <input id="radio-3" type="radio" name="radio-group" value="2">
-                    I am a British citizen living abroad
-                  </label>
+                <label for="radio-3" class="block-label">
+                  <input id="radio-3" type="radio" name="radio-group" value="2">
+                  I am a British citizen living abroad
+                </label>
 
-                </div>
-              </fieldset>
-            </form>
+              </div>
+            </fieldset>
+          </form>
 
-          </div>
         </div>
 
         <h3 class="heading-medium" id="guide-form-checkboxes">Checkboxes</h3>
@@ -1060,29 +1009,27 @@
         </ul>
 
         <div class="example">
-          <div class="inner-block">
 
-            <form action="" method="post" class="form">
-              <fieldset>
-                <legend class="form-label-bold">Which types of waste do you transport regularly?</legend>
+          <form action="" method="post" class="form">
+            <fieldset>
+              <legend class="form-label-bold">Which types of waste do you transport regularly?</legend>
 
-                <p>Select all that apply</p>
-                <label for="checkbox-1" class="block-label">
-                  <input id="checkbox-1" type="checkbox" value="1">
-                  Waste from animal carcasses
-                </label>
-                <label for="checkbox-2" class="block-label">
-                  <input id="checkbox-2" type="checkbox" value="2">
-                  Waste from mines or quarries
-                </label>
-                <label for="checkbox-3" class="block-label">
-                  <input id="checkbox-3" type="checkbox" value="2">
-                  Farm or agricultural waste
-                </label>
-              </fieldset>
-            </form>
+              <p>Select all that apply</p>
+              <label for="checkbox-1" class="block-label">
+                <input id="checkbox-1" type="checkbox" value="1">
+                Waste from animal carcasses
+              </label>
+              <label for="checkbox-2" class="block-label">
+                <input id="checkbox-2" type="checkbox" value="2">
+                Waste from mines or quarries
+              </label>
+              <label for="checkbox-3" class="block-label">
+                <input id="checkbox-3" type="checkbox" value="2">
+                Farm or agricultural waste
+              </label>
+            </fieldset>
+          </form>
 
-          </div>
         </div>
 
         <div class="text">
@@ -1090,20 +1037,20 @@
         </div>
 
         <div class="example">
-          <div class="inner-block">
-            <form action="" method="post" class="form">
-              <div class="form-group">
-                <label for="telephone-number" class="form-label">Enter your telephone number</label>
-                <input type="text" class="form-control" id="telephone-number">
 
-                <label for="checkbox-telephone-number" class="form-checkbox">
-                  <input id="checkbox-telephone-number" type="checkbox" value="checkbox-telephone-number">
-                  I need to be contacted using a text phone
-                </label>
-              </div>
+          <form action="" method="post" class="form">
+            <div class="form-group">
+              <label for="telephone-number" class="form-label">Enter your telephone number</label>
+              <input type="text" class="form-control" id="telephone-number">
 
-            </form>
-          </div>
+              <label for="checkbox-telephone-number" class="form-checkbox">
+                <input id="checkbox-telephone-number" type="checkbox" value="checkbox-telephone-number">
+                I need to be contacted using a text phone
+              </label>
+            </div>
+
+          </form>
+
         </div>
 
         <div class="text">
@@ -1116,9 +1063,7 @@
 
         <!--
         <div class="example">
-          <div class="inner-block">
 
-          </div>
         </div>
         -->
 
@@ -1133,34 +1078,33 @@
         </div>
 
         <div class="example">
-          <div class="inner-block">
 
-            <!--
-            .form-group-example is used here to re-add the bottom margin on .form group,
-            the bottom margin is removed in this example page to keep examples compact
-            -->
+          <!--
+          .form-group-example is used here to re-add the bottom margin on .form group,
+          the bottom margin is removed in this example page to keep examples compact
+          -->
 
-            <form action="" method="post" class="form form-group-example">
+          <form action="" method="post" class="form form-group-example">
 
-              <fieldset class="inline">
-                <legend class="form-label">Do you know their National Insurance number?</legend>
-                <div class="form-group form-group-related">
-                  <label for="radio-indent-1" class="block-label" data-target="example-ni-number">
-                    <input id="radio-indent-1" type="radio" name="radio-indent-group" value="Yes">
-                    Yes
-                  </label>
-                  <label for="radio-indent-2" class="block-label">
-                    <input id="radio-indent-2" type="radio" name="radio-indent-group" value="No">
-                    No
-                  </label>
-                </div>
-                <div class="panel-indent toggle-content" id="example-ni-number">
-                  <label for="national-insurance" class="form-label">National Insurance number</label>
-                  <input type="text" class="form-control" id="national-insurance">
-                </div>
-              </fieldset>
-            </form>
-          </div>
+            <fieldset class="inline">
+              <legend class="form-label">Do you know their National Insurance number?</legend>
+              <div class="form-group form-group-related">
+                <label for="radio-indent-1" class="block-label" data-target="example-ni-number">
+                  <input id="radio-indent-1" type="radio" name="radio-indent-group" value="Yes">
+                  Yes
+                </label>
+                <label for="radio-indent-2" class="block-label">
+                  <input id="radio-indent-2" type="radio" name="radio-indent-group" value="No">
+                  No
+                </label>
+              </div>
+              <div class="panel-indent toggle-content" id="example-ni-number">
+                <label for="national-insurance" class="form-label">National Insurance number</label>
+                <input type="text" class="form-control" id="national-insurance">
+              </div>
+            </fieldset>
+          </form>
+
         </div>
 
       </div>
@@ -1180,9 +1124,7 @@
         </p>
 
         <div class="example">
-          <div class="inner-block">
-            <button class="button">Save and continue</button>
-          </div>
+          <button class="button">Save and continue</button>
         </div>
 
         <p class="text">
@@ -1190,9 +1132,7 @@
         </p>
 
         <div class="example">
-          <div class="inner-block">
-            <a href="#" class="button button-get-started">Start now</a>
-          </div>
+          <a href="#" class="button button-get-started">Start now</a>
         </div>
 
         <p class="text">
@@ -1200,20 +1140,18 @@
         </p>
 
         <div class="example example-button form-group-example">
-          <div class="inner-block">
 
-            <form action="" method="post" class="form">
-              <div class="form-group">
-                <label for="form-email-address-1" class="form-label">Email address</label>
-                <input type="text" class="form-control" id="form-email-address-1">
-              </div>
-              <div class="form-group">
-                <button class="button">Save and continue</button>
-                <p><a href="#">Back</a></p>
-              </div>
-            </form>
+          <form action="" method="post" class="form">
+            <div class="form-group">
+              <label for="form-email-address-1" class="form-label">Email address</label>
+              <input type="text" class="form-control" id="form-email-address-1">
+            </div>
+            <div class="form-group">
+              <button class="button">Save and continue</button>
+              <p><a href="#">Back</a></p>
+            </div>
+          </form>
 
-          </div>
         </div>
 
         <h3 class="heading-medium">Creating buttons</h3>
@@ -1264,9 +1202,7 @@
           Disabled buttons should be set at 50% opacity.
         </p>
         <div class="example">
-          <div class="inner-block">
-            <button class="button" disabled="disabled">Primary button</button>
-          </div>
+          <button class="button" disabled="disabled">Primary button</button>
         </div>
 
       </div>
@@ -1290,57 +1226,6 @@
           <li>error copy should be specific to the question and validation should identify all errors</li>
           <li>errors should not cause pre-filled fields to clear</li>
         </ul>
-
-        <!--
-        <div class="example form-group-example">
-          <div class="inner-block">
-
-            <form action="" method="post" class="form">
-
-              <div class="validation-summary" aria-labelledby="error-heading" role="alert">
-                <h3 class="heading-small" id="error-heading">There was a problem submitting the form</h3>
-                <p>Please try the following:</p>
-                <ul>
-                  <li><a href="#error-your-name">Enter your first name</a></li>
-                  <li><a href="#error-your-email">Enter your email address</a></li>
-                </ul>
-              </div>
-
-              <fieldset>
-
-                <div class="validation-error">
-                  <div class="form-group" id="error-your-name">
-                    <label for="your-name-1" class="form-label">
-                      First name
-                      <span class="validation-message">must be completed</span>
-                    </label>
-                    <input type="text" class="form-control" id="your-name-1">
-                  </div>
-                </div>
-
-                <div class="form-group">
-                  <label for="your-email-1" class="form-label">
-                    Middle name (optional)
-                  </label>
-                  <input type="text" class="form-control" id="your-email-1">
-                </div>
-
-                <div class="validation-error">
-                  <div class="form-group" id="error-your-email">
-                    <label for="your-email-1" class="form-label">
-                      Your email address
-                      <span class="validation-message">must be completed</span>
-                    </label>
-                    <input type="text" class="form-control" id="your-email-1">
-                  </div>
-                </div>
-
-              </fieldset>
-            </form>
-
-          </div>
-        </div>
-        -->
 
       </div>
       <!-- / #guide-errors -->


### PR DESCRIPTION
- Allow for .grid-wrapper within .inner-block (but don’t recommend)
- Add explanation and examples to layout.scss
- Reduce lorem in grid layout example page
- Remove .inner-block from elements example boxes, as it is no longer
  required
