### PR TITLE
Remove reference to .button-link in _buttons.scss

### DIFF
--- a/public/sass/elements/_buttons.scss
+++ b/public/sass/elements/_buttons.scss
@@ -46,7 +46,8 @@ summary {
 }
 
 details summary {
-  @extend .button-link;
+  color: $govuk-blue;
+  text-decoration: underline;
 }
 
 details summary:focus {


### PR DESCRIPTION
- This class no longer exists, as we don’t advise styling buttons as
  links
- Instead, add link styles to summary
