### PR TITLE
Revisit error styles

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -27,7 +27,7 @@ $(document).ready(function() {
 
   // Example - Form focus styles
 
-  if ($('.form').length>0) {
+  if ($('.block-label').length>0) {
 
     $(".block-label").each(function() {
 
@@ -49,18 +49,26 @@ $(document).ready(function() {
       $('input:not(:checked)').parent().removeClass('selected');
       $('input:checked').parent().addClass('selected');
 
-      $('.toggle-content').hide();
+    });
 
-      var target = $('input:checked').parent().attr('data-target');
-      $('#'+target).show();
+    // For radio buttons
+    $('.block-label input[type=radio]').click(function(){
+
+      var data_target = $(this).parent().attr('data-target');
+      // console.log(data_target);
+
+      $(this).parent().siblings('.toggle-content').hide();
+
+      $('#'+data_target).show();
 
     });
 
-    // For pre-checked inputs, show toggled content
-    var target = $('input:checked').parent().attr('data-target');
-    $('#'+target).show();
-
   }
+
+  // For pre-checked inputs, show toggled content
+  var target = $('input:checked').parent().attr('data-target');
+  $('#'+target).show();
+
 
   // Example - Add aria support to details
 

--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -3,8 +3,11 @@
 
 // Indented panels with a grey left hand border
 .panel-indent {
+  float: left;
+  width: 100%;
+  @include box-sizing(border-box);
+
   @include contain-floats;
-  clear: both;
   border-left: 5px solid $panel-colour;
 
   padding-top: 10px;
@@ -23,20 +26,13 @@
 
 .panel-indent p:only-child {
   margin-bottom: 0;
+  padding-bottom: 10px;
 }
 
 // Remove bottom padding & margin on panels used within forms
 form .panel-indent {
-  width: 100%;
-  float: left;
-  padding-bottom: 0;
   margin-bottom: 0;
-  margin-right: 15px;
-  @include box-sizing(border-box);
-}
-
-form .panel-indent {
-  @include contain-floats;
+  padding-bottom: 0;
 }
 
 form .panel-indent .form-group:last-child {

--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -12,9 +12,9 @@
 
   padding-left: $gutter-half;
   @include media(tablet){
-    padding-left: 20px;
+    padding-left: 30px;
   }
-  margin: ($gutter $gutter-half $gutter*1.5 0);
+  margin: (20px $gutter-half $gutter*1.5 0);
 }
 
 .panel-indent legend {
@@ -25,6 +25,20 @@
   margin-bottom: 0;
 }
 
-.panel-indent .form-group:last-child {
+// Remove bottom padding & margin on panels used within forms
+form .panel-indent {
+  width: 100%;
+  float: left;
+  padding-bottom: 0;
+  margin-bottom: 0;
+  margin-right: 15px;
+  @include box-sizing(border-box);
+}
+
+form .panel-indent {
+  @include contain-floats;
+}
+
+form .panel-indent .form-group:last-child {
   margin-bottom: 0;
 }

--- a/public/sass/elements/forms/_form-chunky-labels.scss
+++ b/public/sass/elements/forms/_form-chunky-labels.scss
@@ -12,17 +12,19 @@
   background: $panel-colour;
   border: 1px solid $panel-colour;
   padding: (18px $gutter $gutter-half $gutter*1.5);
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-top: 15px;
 
   cursor: pointer; // Encourage clicking on block labels
 
   @include media(tablet) {
     float: left;
-    margin-top: 5px;
-    margin-bottom: 5px;
+    margin-top: 20px;
     // width: 25%; - Test : check that text within labels will wrap
   }
+}
+
+fieldset :first-child {
+  margin-top: 0;
 }
 
 .block-label:hover {

--- a/public/sass/elements/forms/_form-date-of-birth.scss
+++ b/public/sass/elements/forms/_form-date-of-birth.scss
@@ -9,6 +9,7 @@
   width: 50px;
   float: left;
   margin-right: 20px;
+  margin-bottom: 0;
   clear: none;
 }
 

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -1,9 +1,34 @@
 @import "../colours";
 
-// Validation summary box
+// Validation border and alignment
+
+.invalid,
+.validation-message,
 .validation-summary {
-  border: 3px solid $error-colour;
-  padding: $gutter-half $gutter;
+  border-left: 4px solid $error-colour;
+  margin-left: -($gutter-half);
+  padding-left: 10px;
+  @include media(tablet) {
+    margin-left: -19px;
+    padding-left: $gutter-half;
+  }
+}
+
+.form-group.invalid {
+  margin-bottom: 10px;
+  @include media(tablet) {
+    margin-bottom: 15px;
+  }
+  // padding-bottom: 10px;
+  // @include media(tablet) {
+  //   padding-bottom: 15px;
+  // }
+}
+
+// Validation summary box
+
+.validation-summary {
+  border: 4px solid $error-colour;
   margin-bottom: $gutter;
 
   @include ie-lte(6){
@@ -36,35 +61,21 @@
   margin-top: $gutter-half;
 }
 
-// Invalid
-
-.invalid,
-.validation-message {
-  border-left: 4px solid $error-colour;
-  margin-left: -($gutter-half);
-  padding-left: 10px;
-  @include media(tablet) {
-    margin-left: -19px;
-    padding-left: $gutter-half;
-  }
-}
-
 // Validation message
+
 .validation-message {
   clear: both;
   display: block;
-  @include core-19;
+  @include core-16;
   border-left: 4px solid $error-colour;
 
-  margin-top: $gutter-half;
-  margin-bottom: $gutter-half;
+  margin-bottom: 30px;
 
   padding-top: 10px;
   padding-bottom: 10px;
 
   @include media(tablet) {
-    margin-top: 20px;
-    margin-bottom: 20px;
+    margin-bottom: 45px;
   }
 }
 .validation-message a {
@@ -72,3 +83,5 @@
   text-decoration: none;
   font-weight: bold;
 }
+
+

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -36,29 +36,39 @@
   margin-top: $gutter-half;
 }
 
+// Invalid
 
-// Validation error message box
-// .validation-error {
-//   clear: both;
-//   @include contain-floats;
-//   border-left: 3px solid $error-colour;
-//   padding: $gutter- $gutter;
-//   margin-bottom: $gutter-half;
-//   margin-left: -($gutter);
-// }
-
-// .validation-error .form-group {
-//   margin-bottom: 20px;
-// }
-
-// .validation-error p {
-//   margin-bottom: 10px;
-// }
-
+.invalid,
+.validation-message {
+  border-left: 4px solid $error-colour;
+  margin-left: -($gutter-half);
+  padding-left: 10px;
+  @include media(tablet) {
+    margin-left: -19px;
+    padding-left: $gutter-half;
+  }
+}
 
 // Validation message
 .validation-message {
+  clear: both;
   display: block;
-  @include core-16;
+  @include core-19;
+  border-left: 4px solid $error-colour;
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  padding-top: 10px;
+  padding-bottom: 10px;
+
+  @include media(tablet) {
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+}
+.validation-message a {
   color: $error-colour;
+  text-decoration: none;
+  font-weight: bold;
 }

--- a/routes.js
+++ b/routes.js
@@ -21,6 +21,10 @@ module.exports = {
       res.render('examples/forms', {'assetPath' : assetPath });
     });
 
+    app.get('/examples/errors', function (req, res) {
+      res.render('examples/errors', {'assetPath' : assetPath });
+    });
+
     // GOV.UK template example pages
 
     app.get('/examples/template', function (req, res) {

--- a/views/examples/errors.html
+++ b/views/examples/errors.html
@@ -1,0 +1,124 @@
+{{<govuk_template}}
+
+{{$cookieMessage}}
+  {{>cookie_message}}
+{{/cookieMessage}}
+
+{{$head}}
+  {{>head}}
+{{/head}}
+
+{{$propositionHeader}}
+  {{>propositional_navigation}}
+{{/propositionHeader}}
+
+{{$headerClass}}with-proposition{{/headerClass}}
+
+{{$content}}
+<main id="wrapper" role="main">
+  <div id="content">
+    <div class="inner-block">
+
+      <form action="" method="post" class="form">
+
+        <div class="validation-group-error" id="error-send-new">
+
+          <h1 class="heading-medium error-title">
+            Where should we send your new<br> passport?
+          </h1>
+
+          <div class="form-group invalid">
+            <fieldset>
+
+              <label for="radio-home-address" class="block-label">
+                <input id="radio-home-address" type="radio" name="radio-indent-group" value="Yes">
+                Home address
+              </label>
+
+              <label for="radio-other-address" class="block-label" data-target="example-other-address">
+                <input id="radio-other-address" type="radio" name="radio-indent-group" value="No">
+                Other address
+              </label>
+
+              <div class="panel-indent toggle-content" id="example-other-address">
+
+                <legend class="heading-small">
+                  Your other address
+                </legend>
+
+                 <div class="form-group form-group-compound">
+                  <label class="form-label" for="address-line-1">Street</label>
+                  <input type="text" class="form-control" id="address-line-1">
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label visuallyhidden" for="address-line-2">Street</label>
+                  <input type="text" class="form-control" id="address-line-2">
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label" for="address-town">Town or City</label>
+                  <input type="text" class="form-control form-control-1-4" id="address-town">
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label" for="address-postcode">Postcode</label>
+                  <input type="text" class="form-control form-control-1-8" id="address-postcode">
+                </div>
+
+              </div>
+
+            </fieldset>
+          </div>
+
+          <div class="validation-message">
+            <a href="#">Please answer this question</a>
+          </div>
+
+        </div>
+
+        <!-- <div class="validation-group-error" id="error-send-old">
+          <div class="form-group">
+            <fieldset>
+
+              <legend class="form-title heading-small">How should we send your old passport?</legend>
+
+              <label for="radio-royal-mail" class="block-label">
+                <input id="radio-royal-mail" type="radio" name="radio-send" value="">
+                Royal Mail second class: free
+              </label>
+
+              <label for="radio-secure-delivery" class="block-label" data-target="example-secure-delivery">
+                <input id="radio-secure-delivery" type="radio" name="radio-send" value="">
+                Secure delivery: £3 extra
+              </label>
+
+              <div class="panel-indent toggle-content" id="example-secure-delivery">
+                <p>Your new passport will be sent by secure delivery.</p>
+               </div>
+
+            </fieldset>
+          </div>
+        </div> -->
+
+        <!-- Primary buttons, secondary links -->
+        <div class="form-group">
+          <input type="submit" class="button" value="Save and continue">
+          <ul>
+            <li><a href="#">Skip this section for now</a></li>
+            <li><a href="/">Back</a></li>
+          </ul>
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+</main>
+{{/content}}
+
+{{$bodyEnd}}
+  {{>scripts}}
+{{/bodyEnd}}
+
+{{/govuk_template}}

--- a/views/examples/errors.html
+++ b/views/examples/errors.html
@@ -15,17 +15,110 @@
 {{$headerClass}}with-proposition{{/headerClass}}
 
 {{$content}}
+
+<style>
+  /*.validation-message,*/
+  .validation-summary {
+    display: none;
+  }
+</style>
 <main id="wrapper" role="main">
   <div id="content">
     <div class="inner-block">
 
       <form action="" method="post" class="form">
 
-        <div class="validation-group-error" id="error-send-new">
+        <h1 class="form-title heading-large">
+          Your details
+        </h1>
 
-          <h1 class="heading-medium error-title">
-            Where should we send your new<br> passport?
-          </h1>
+        <div class="validation-summary" aria-labelledby="error-heading" role="alert">
+          <h3 class="heading-small" id="error-heading">There was a problem submitting the form</h3>
+          <p>Please try the following:</p>
+          <ul>
+            <li><a href="#error-full-name">Enter your full name</a></li>
+            <li><a href="#error-ni-number">Enter your National Insurance number</a></li>
+          </ul>
+        </div>
+
+        <!-- Full name -->
+        <div class="form-group invalid" id="error-full-name">
+          <label class="form-label-bold" for="full-name">Full name</label>
+          <p class="form-hint">As shown on your birth certificate or passport</p>
+          <input type="text" class="form-control" id="full-name">
+        </div>
+
+        <div class="validation-message">
+          <a href="#error-full-name">Please enter your full name</a>
+        </div>
+
+        <!-- National Insurance number -->
+        <div class="form-group invalid" id="error-ni-number">
+          <label class="form-label-bold" for="ni-number">
+            National Insurance number
+            <span class="form-hint">
+              It's on your National Insurance card, benefit letter, payslip or P60.
+              <br>
+              For example, 'VO 12 34 56 D'.
+            </span>
+          </label>
+          <input type="text" class="form-control" id="ni-number">
+        </div>
+
+        <div class="validation-message">
+          <a href="#error-ni-number">Please enter your National Insurance number</a>
+        </div>
+
+        <!-- Date of birth -->
+        <div class="form-group invalid">
+          <fieldset>
+            <legend class="form-label-bold">Date of birth</legend>
+
+            <div class="date-of-birth">
+              <p class="form-hint">For example, 08 04 2014</p>
+
+              <div class="form-group form-group-day">
+                <label for="dob-day">Day</label>
+                <input type="text" class="form-control" id="dob-day">
+              </div>
+              <div class="form-group form-group-month">
+                <label for="dob-month">Month</label>
+                <input type="text" class="form-control" id="dob-month">
+              </div>
+              <div class="form-group form-group-year">
+                <label for="dob-year">Year</label>
+                <input type="text" class="form-control" id="dob-year">
+              </div>
+            </div>
+
+            <div class="date-of-birth native-date-of-birth">
+              <p class="form-hint">For example, 08 April 2014</p>
+              <input type="date" class="form-control">
+            </div>
+
+          </fieldset>
+        </div>
+
+        <div class="validation-message">
+          <a href="#error-ni-number">Please enter your date of birth</a>
+        </div>
+
+        <!-- Primary buttons, secondary links -->
+        <div class="form-group">
+          <input type="submit" class="button" value="Continue">
+          <ul>
+            <li><a href="#">Skip this section for now</a></li>
+            <li><a href="/">Back</a></li>
+          </ul>
+        </div>
+
+      </form>
+
+      <form action="" method="post" class="form">
+
+        <h1 class="heading-medium">
+          Where should we send your new<br> passport?
+        </h1>
 
           <div class="form-group invalid">
             <fieldset>
@@ -75,33 +168,32 @@
             <a href="#">Please answer this question</a>
           </div>
 
+        <div class="form-group invalid">
+          <fieldset>
+
+            <legend class="heading-small">How should we send your old passport?</legend>
+
+            <label for="radio-royal-mail" class="block-label">
+              <input id="radio-royal-mail" type="radio" name="radio-send" value="">
+              Royal Mail second class: free
+            </label>
+
+            <label for="radio-secure-delivery" class="block-label" data-target="example-secure-delivery">
+              <input id="radio-secure-delivery" type="radio" name="radio-send" value="">
+              Secure delivery: £3 extra
+            </label>
+
+            <div class="panel-indent toggle-content" id="example-secure-delivery">
+              <p>Your new passport will be sent by secure delivery.</p>
+             </div>
+
+          </fieldset>
         </div>
 
-        <!-- <div class="validation-group-error" id="error-send-old">
-          <div class="form-group">
-            <fieldset>
+        <div class="validation-message">
+          <a href="#">Please answer this question</a>
+        </div>
 
-              <legend class="form-title heading-small">How should we send your old passport?</legend>
-
-              <label for="radio-royal-mail" class="block-label">
-                <input id="radio-royal-mail" type="radio" name="radio-send" value="">
-                Royal Mail second class: free
-              </label>
-
-              <label for="radio-secure-delivery" class="block-label" data-target="example-secure-delivery">
-                <input id="radio-secure-delivery" type="radio" name="radio-send" value="">
-                Secure delivery: £3 extra
-              </label>
-
-              <div class="panel-indent toggle-content" id="example-secure-delivery">
-                <p>Your new passport will be sent by secure delivery.</p>
-               </div>
-
-            </fieldset>
-          </div>
-        </div> -->
-
-        <!-- Primary buttons, secondary links -->
         <div class="form-group">
           <input type="submit" class="button" value="Save and continue">
           <ul>


### PR DESCRIPTION
Error styles, which are similar to those for Individual Electoral Registration.

Opinions, please. 

**Mobile:**

**1. Where the border on the left hand side connects both the field with the error and the error message.**

![errors-mobile](https://cloud.githubusercontent.com/assets/417754/3341446/782ef584-f888-11e3-9473-2c1594dd2675.png)

**2. Where there is a space underneath the border on the left hand side and the error message.**

![errors-with-spaces-mobile](https://cloud.githubusercontent.com/assets/417754/3341459/9cf7a5dc-f888-11e3-8a09-f36af5e5ee11.png)

**3. For longer forms, a summary box is provided at the top of the page with jump links.**

![errors-with-summary-mobike](https://cloud.githubusercontent.com/assets/417754/3341465/a8a53ad4-f888-11e3-8ca1-0025bbaa7b6b.png)

**Desktop:**

**1. Where the border on the left hand side connects both the field with the error and the error message.**

![errors-desktop](https://cloud.githubusercontent.com/assets/417754/3341439/6c20b6c4-f888-11e3-8ba6-0204d1d11988.png)

**2. Where there is a space underneath the border on the left hand side and the error message.**

![errors-with-spaces](https://cloud.githubusercontent.com/assets/417754/3341453/8a212870-f888-11e3-9ed0-414b9b60e0db.png)


**3. For longer forms, a summary box is provided at the top of the page with jump links.**

![errors-with-summary](https://cloud.githubusercontent.com/assets/417754/3341463/a5b7c198-f888-11e3-91c2-7e94098963ae.png)


