### PR TITLE
Add feedback links to each section

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -169,6 +169,10 @@
           </div>
         </div>
 
+        <p>
+          <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Layout" rel="external">Discuss layout on our Hackpad</a>
+        </p>
+
       </div>
       <!-- / #guide-layout -->
 
@@ -314,6 +318,10 @@
             </div>
           </details>
         </div>
+
+        <p>
+          <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Typography" rel="external">Discuss typography on our Hackpad</a>
+        </p>
 
       </div>
       <!-- / #guide-typography -->
@@ -642,6 +650,10 @@
 
         </div>
 
+        <p>
+          <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Colour" rel="external">Discuss colour on our Hackpad</a>
+        </p>
+
       </div>
       <!-- / #guide-colour -->
 
@@ -688,6 +700,10 @@
             </div>
           </div>
         </div>
+
+        <p>
+          <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Icons-and-images" rel="external">Discuss icons and images on our Hackpad</a>
+        </p>
 
       </div>
       <!-- / #guide-icons-images -->
@@ -801,6 +817,10 @@
             </tbody>
           </table>
         </div>
+
+        <p>
+          <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Data" rel="external">Discuss data on our Hackpad</a>
+        </p>
 
       </div>
       <!-- / #guide-data -->
@@ -1114,6 +1134,10 @@
 
         </div>
 
+        <p>
+          <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Forms" rel="external">Discuss forms on our Hackpad</a>
+        </p>
+
       </div>
       <!-- / #guide-forms -->
 
@@ -1212,6 +1236,10 @@
           <button class="button" disabled="disabled">Primary button</button>
         </div>
 
+        <p>
+          <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Buttons" rel="external">Discuss buttons on our Hackpad</a>
+        </p>
+
       </div>
       <!-- / #guide-buttons -->
 
@@ -1233,6 +1261,10 @@
           <li>error copy should be specific to the question and validation should identify all errors</li>
           <li>errors should not cause pre-filled fields to clear</li>
         </ul>
+
+        <p>
+          <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Errors-and-validation" rel="external">Discuss errors on our Hackpad</a>
+        </p>
 
       </div>
       <!-- / #guide-errors -->


### PR DESCRIPTION
- In user testing, the feedback link in the Alpha banner at the top of
  the page either wasn’t noticed, or wasn’t associated with leaving
  feedback on the page content
- Make it clear how to get to the Hackpad and leave feedback
