### PR TITLE
Adjust secondary headings

### DIFF
--- a/public/sass/elements/_typography.scss
+++ b/public/sass/elements/_typography.scss
@@ -66,7 +66,7 @@
   }
 
   .heading-secondary {
-    @include core-27();
+    @include heading-27();
 
     display: block;
     color: $secondary-text-colour;
@@ -86,7 +86,7 @@
   }
 
   .heading-secondary {
-    @include core-24();
+    @include heading-24();
 
     display: block;
     color: $secondary-text-colour;


### PR DESCRIPTION
Two small adjustments to the secondary heading styles:
1. At the moment they only work for x-large headings. I've added one for large headings as well.
2. The spacing between the secondary and main headings was very tight:

![image](https://cloud.githubusercontent.com/assets/1590604/4107399/65e8529e-31c7-11e4-8ea7-96a36dba901e.png)

I've switched to the 'heading' mixins which seems to have done the trick:

![image](https://cloud.githubusercontent.com/assets/1590604/4107403/76ee98dc-31c7-11e4-948a-fd97ea4634d5.png)
