### PR TITLE
Rename app to govuk-elements in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "express-prototype",
+  "name": "govuk-elements",
   "description": "GOVUK prototyping app in Express",
   "version": "0.0.1",
   "private": true,


### PR DESCRIPTION
So people who have this listed as a dependency in their projects based on the git url can have it install in a sensibly named location (previously would install at ./node_modules/express-prototype).
