### PR TITLE
Simplify grid layout and grid example page

### DIFF
--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -7,16 +7,11 @@
 @import "service-design-manual/helpers/page-header";
 @import "service-design-manual/helpers/breadcrumbs";
 
-// Adjust Service Design Manual header to align with content
+// Override Service Design Manual header to align with content
 #global-breadcrumb,
 .page-header {
-  margin-left: $gutter-half;
-  margin-right: $gutter-half;
-
-  @include media(tablet) {
-    margin-left: $gutter;
-    margin-right: $gutter;
-  }
+  margin-left: 0;
+  margin-right: 0;
 }
 #global-breadcrumb li {
   margin-bottom: 0;

--- a/public/sass/elements/_layout.scss
+++ b/public/sass/elements/_layout.scss
@@ -7,27 +7,20 @@
 @import "helpers";
 @import "design-patterns/alpha-beta";
 
+// Use .outer-block to create a max width block of 1020px
 #wrapper {
   text-align: center;
-
+  @include outer-block;
+  @include contain-floats; // Repeated as %extend placeholder isn't supported
   padding-bottom: $gutter;
   @include media(desktop) {
     padding-bottom: $gutter*3;
   }
 }
 
-// Use .outer-block to create a max width block of 1020px,
 // Use .inner-block to create padding that matches the header and footer
-
-// .outer-block,
 #content {
   text-align: left;
-
-  @include outer-block;
-  @include contain-floats; // Repeated as %extend placeholder isn't supported
-}
-
-.inner-block {
   @include inner-block(margin);
 }
 
@@ -54,25 +47,25 @@
 // Usage:
 // For two equal columns
 
-// <div class="grid-wrapper">
+// <div class="grid-section">
 //   <div class="grid grid-1-2">
-//     <div class="inner-block">
+//     <div class="grid-inner">
 
 //     </div>
 //   </div>
 //   <div class="grid grid-1-2">
-//     <div class="inner-block">
+//     <div class="grid-inner">
 
 //     </div>
 //   </div>
 // </div>
 
-// Use .grid-wrapper to wrap and clear grid sections
-.grid-wrapper {
+// Use .grid-section to wrap and clear grid sections
+.grid-section {
   @include contain-floats;
   @include media(tablet){
-    margin-left: 15px;
-    margin-right: 15px;
+    margin-left: -$gutter-half;
+    margin-right: -$gutter-half;
   }
 }
 
@@ -80,14 +73,8 @@
 .grid-divider {
   @include contain-floats;
   border-bottom: 1px solid $border-colour;
-  margin-bottom: 20px;
-  margin-left: 15px;
-  margin-right: 15px;
-
-  @include media(tablet){
-    margin-left: 30px;
-    margin-right: 30px;
-  }
+  margin-bottom: $gutter-half;
+  margin-top: $gutter-half;
 }
 
 // 2. Grid units take 100% width, unless a .grid-width class is applied
@@ -127,31 +114,10 @@
   }
 }
 
-// Grid 'inner-block' sets spacing between grid cells
-.grid .inner-block {
-  padding: 0;
+// 3. Grid inner sets gutters within grid cells
+// This sets 15px left and right spacing
+.grid-inner {
   @include media(tablet) {
     margin: 0 $gutter-half;
   }
-}
-
-
-// Don't put .grid-wrapper inside .inner block
-// There's no need for the extra containing div
-// ** These styles are here in case you do, so we don't break the grid **
-
-.inner-block {
-
-  .grid-wrapper {
-    padding: 0;
-
-    margin-left: -15px;
-    margin-right: -15px;
-  }
-
-  .grid-divider {
-    margin-left: 0;
-    margin-right: 0;
-  }
-
 }

--- a/views/examples/grid_layout.html
+++ b/views/examples/grid_layout.html
@@ -6,6 +6,17 @@
 
 {{$head}}
   {{>head}}
+  <style>
+  .highlight-grid .grid-section {
+    background: #bfc1c3;
+  }
+  .highlight-grid .grid {
+    background: #dee0e2;
+  }
+  .highlight-grid .grid-inner {
+    background: #f8f8f8;
+  }
+</style>
 {{/head}}
 
 {{$propositionHeader}}
@@ -18,9 +29,9 @@
 <main id="wrapper" role="main">
   <div id="content">
 
-    <div class="grid-wrapper">
+    <div class="grid-section">
       <div class="grid">
-        <div class="inner-block">
+        <div class="grid-inner">
 
           <a href="/" class="example-back-link">Back to GOV.UK elements</a>
 
@@ -37,9 +48,9 @@
       </div>
     </div>
 
-    <div class="grid-wrapper">
+    <div class="grid-section">
       <div class="grid grid-2-3">
-        <div class="inner-block">
+        <div class="grid-inner">
 
           <h2 class="bold-small">Two thirds</h2>
           <div class="text">
@@ -49,70 +60,70 @@
         </div>
       </div>
       <div class="grid grid-1-3">
-        <div class="inner-block">
+        <div class="grid-inner">
           <h2 class="bold-small">One third</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus.</p>
         </div>
       </div>
     </div>
 
-    <div class="grid-wrapper">
+    <div class="grid-section">
       <div class="grid grid-1-2">
-        <div class="inner-block">
+        <div class="grid-inner">
           <h2 class="bold-small">One half</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
         </div>
       </div>
       <div class="grid grid-1-2">
-        <div class="inner-block">
+        <div class="grid-inner">
           <h2 class="bold-small">One half</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
         </div>
       </div>
     </div>
 
-    <div class="grid-wrapper">
+    <div class="grid-section">
       <div class="grid grid-1-3">
-        <div class="inner-block">
+        <div class="grid-inner">
           <h2 class="bold-small">One third</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
         </div>
       </div>
       <div class="grid grid-1-3">
-        <div class="inner-block">
+        <div class="grid-inner">
           <h2 class="bold-small">One third</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
         </div>
       </div>
       <div class="grid grid-1-3">
-        <div class="inner-block">
+        <div class="grid-inner">
           <h2 class="bold-small">One third</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
         </div>
       </div>
     </div>
 
-    <div class="grid-wrapper">
+    <div class="grid-section">
       <div class="grid grid-1-4">
-        <div class="inner-block">
+        <div class="grid-inner">
           <h2 class="bold-small">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
         </div>
       </div>
       <div class="grid grid-1-4">
-        <div class="inner-block">
+        <div class="grid-inner">
           <h2 class="bold-small">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
         </div>
       </div>
       <div class="grid grid-1-4">
-        <div class="inner-block">
+        <div class="grid-inner">
           <h2 class="bold-small">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
         </div>
       </div>
       <div class="grid grid-1-4">
-        <div class="inner-block">
+        <div class="grid-inner">
           <h2 class="bold-small">One quarter</h2>
           <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
         </div>
@@ -121,14 +132,14 @@
 
     <div class="grid-divider"></div>
 
-    <div class="grid-wrapper">
+    <div class="grid-section">
       <div class="grid grid-2-3">
-        <div class="inner-block">
+        <div class="grid-inner">
 
-          <h2 class="bold-small">Dividing the grid</h2>
+          <h2 class="heading-medium">Dividing the grid</h2>
           <div class="text">
             <p>
-              To set dividers between grid sections, use <code>.grid-divider</code>.
+              To set dividers between grid sections, use the class <code>.grid-divider</code>.
             </p>
           </div>
 
@@ -138,148 +149,60 @@
 
     <div class="grid-divider"></div>
 
-    <div class="inner-block">
-      <h2 class="heading-medium">
-        You won't always need a grid&hellip;
-      </h2>
-      <p>
-        For full-width layout, a grid isn't required.
-      </p>
-      <p>
-        Use <code>.outer-block</code> to set a max-width of 1020px and within it <code>.inner-block</code> to set left and right padding.<br> Find these mixins in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_grid_layout.scss">grid_layout.scss</a> file.
-      </p>
-      <p>
-        <a href="/" class="example-back-link">Back to GOV.UK elements</a>
-      </p>
-    </div><!-- /.inner-block -->
+    <h2 class="heading-medium">
+      You won't always need a grid&hellip;
+    </h2>
+    <p>
+      For a full-width layout, a grid isn't required.
+    </p>
+    <p>
+      Use <code>.outer-block</code> to set a max-width of 1020px and within it <code>.inner-block</code> to set left and right padding.
+    </p>
+    <p>
+      In this page, .outer-block is set on <code>main</code> and .inner-block set on <code>.content</code>.
+    </p>
+    <p>
+      Find these mixins in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_grid_layout.scss">grid_layout.scss</a> file.
+    </p>
+    <p>
+      <a href="/" class="example-back-link">Back to GOV.UK elements</a>
+    </p>
 
-    <!-- Hi there, the code below is not recommended -->
-    <!-- It's here for testing but feel free to ignore it -->
-
-    <!--
-    <div class="inner-block">
-      <div class="grid-wrapper">
-        <div class="grid">
-          <div class="inner-block">
-
-            <a href="/" class="example-back-link">Back to GOV.UK elements</a>
-
-            <h1 class="heading-xlarge">
-              Grid layout
-            </h1>
-
-            <h2 class="heading-small">Full width</h2>
-            <p>
-              <a href="#" class="js-highlight-grid">Toggle background colours</a> to see the size of each of the grid cells.
-            </p>
-
-          </div>
-        </div>
-      </div>
-      <div class="grid-wrapper">
-        <div class="grid grid-2-3">
-          <div class="inner-block">
-
-            <h2 class="bold-small">Two thirds</h2>
-            <div class="text">
-              <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-            </div>
-
-          </div>
-        </div>
-        <div class="grid grid-1-3">
-          <div class="inner-block">
-            <h2 class="bold-small">One third</h2>
-            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus.</p>
-          </div>
-        </div>
-      </div>
-      <div class="grid-wrapper">
-        <div class="grid grid-1-2">
-          <div class="inner-block">
-            <h2 class="bold-small">One half</h2>
-            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
-          </div>
-        </div>
-        <div class="grid grid-1-2">
-          <div class="inner-block">
-            <h2 class="bold-small">One half</h2>
-            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
-          </div>
-        </div>
-      </div>
-      <div class="grid-wrapper">
-        <div class="grid grid-1-3">
-          <div class="inner-block">
-            <h2 class="bold-small">One third</h2>
-            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
-          </div>
-        </div>
-        <div class="grid grid-1-3">
-          <div class="inner-block">
-            <h2 class="bold-small">One third</h2>
-            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
-          </div>
-        </div>
-        <div class="grid grid-1-3">
-          <div class="inner-block">
-            <h2 class="bold-small">One third</h2>
-            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
-          </div>
-        </div>
-      </div>
-      <div class="grid-wrapper">
-        <div class="grid grid-1-4">
-          <div class="inner-block">
-            <h2 class="bold-small">One quarter</h2>
-            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-          </div>
-        </div>
-        <div class="grid grid-1-4">
-          <div class="inner-block">
-            <h2 class="bold-small">One quarter</h2>
-            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-          </div>
-        </div>
-        <div class="grid grid-1-4">
-          <div class="inner-block">
-            <h2 class="bold-small">One quarter</h2>
-            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-          </div>
-        </div>
-        <div class="grid grid-1-4">
-          <div class="inner-block">
-            <h2 class="bold-small">One quarter</h2>
-            <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-          </div>
-        </div>
-      </div>
-      <div class="grid-divider">
-      </div>
-      <div class="grid-wrapper">
-        <div class="grid grid-2-3">
-          <div class="inner-block">
-
-            <h2 class="bold-small">Dividing the grid</h2>
-            <div class="text">
-              <p>
-                To set dividers between grid sections, use <code>.grid-divider</code>.
-              </p>
-            </div>
-
-          </div>
-        </div>
-      </div>
-    </div>
-    -->
-
-  </div><!-- /#content (.outer-block) -->
-</main>
+  </div><!-- /#content (.inner-block) -->
+</main><!-- /#main (.outer-block) -->
 
 {{/content}}
 
 {{$bodyEnd}}
   {{>scripts}}
+  <script>
+
+    // Add highlight for grid cells
+    $(document).ready(function() {
+      if ($('.js-highlight-grid').length>0) {
+
+        $('.js-highlight-grid').click(function(e) {
+
+          e.preventDefault();
+          var $html = $('html');
+
+          if ($('.grid-inner-highlight').length>0) {
+            // Don't add more than once
+          } else {
+            $('.grid .inner-block').wrapInner('<div class="grid-inner-highlight"></div>');
+          }
+
+          if ($html.hasClass('highlight-grid')) {
+            $html.removeClass('highlight-grid');
+          } else {
+            $html.addClass('highlight-grid');
+          }
+
+        });
+
+      }
+    });
+  </script>
 {{/bodyEnd}}
 
 {{/govuk_template}}


### PR DESCRIPTION
We've had many a conversation about grids in the front end meetings, 
please take a look and let me know what you think.

I've pushed this branch to: http://obscure-scrubland-6593.herokuapp.com/examples/grid-layout
so you can preview it. 
- Apply the outer-block mixin to `<main>`
- Apply the inner-block mixin to `<div id="content">`

Change grid classnames:
- Use `.grid-section` for grid sections
- Change `.inner-block` within `.grid` to `.grid-inner` to prevent confusion
  with the front end toolkit inner-block mixin.
  Grid gutters are only applied for tablet and up as for mobile, all
  grid cells are full width.
- Remove the margins on `.grid-divider`, this is now always
  full width
- Assume `.grid-section` will always exist within a wrapper using the
  `.inner-block` mixin, so set negative margins for tablet and up to allow
  for gutters on `.grid-inner`.
- Move styles and javascript which only exist for this example page
  into the example page.

The aim is to use this example to decide on how we’d like to implement
grids and to move these grid styles to _grid_layout.scss in the front
end toolkit, then I'll update the elements grid examples with the new classnames.
