### PR TITLE
Add placeholder support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "express": "3.4.7",
     "consolidate": "0.x",
     "readdir": "0.0.6",
-    "node-sass": "0.9.6",
+    "node-sass": "1.0.1",
     "govuk_frontend_toolkit": "1.7.0",
     "govuk_template_mustache": "0.9.1",
     "grunt": "0.4.2",
@@ -18,7 +18,7 @@
     "grunt-contrib-copy": "0.5.0",
     "grunt-contrib-watch": "0.5.3",
     "grunt-nodemon": "0.x",
-    "grunt-sass": "~0.10.0",
+    "grunt-sass": "0.16.0",
     "grunt-text-replace": "~0.3.10",
     "grunt-concurrent": "~0.4.3",
     "express-writer": "0.0.4"

--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -6,7 +6,7 @@
 // Override here until updated in the GOV.UK template
 
 #global-header-bar {
-  @include site-width-container;
+  @extend %site-width-container;
 }
 #global-header-bar .inner-block {
   padding: 0;
@@ -55,7 +55,7 @@
 // ==========================================================================
 
 .example {
-  @include contain-floats;
+  @extend %contain-floats;
   position: relative;
   overflow: hidden;
   border: 1px solid $grey-2;

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -9,7 +9,7 @@
   float: left;
   width: 100%;
   clear: both;
-  @include contain-floats;
+  @extend %contain-floats;
   margin-bottom: $gutter-half;
   @include media(tablet) {
     margin-bottom: $gutter;
@@ -66,7 +66,7 @@ fieldset {
 .form-block {
   float: left;
   width: 100%;
-  @include contain-floats;
+  @extend %contain-floats;
 }
 
 

--- a/public/sass/elements/_helpers.scss
+++ b/public/sass/elements/_helpers.scss
@@ -13,43 +13,6 @@
   @return ($px / $base) + em;
 }
 
-// Create a contain floats mixin for this project,
-// as placeholders are not yet supported by libsass
-@mixin contain-floats {
-  &:after {
-    content: "";
-    display: block;
-    clear: both;
-  }
-  @include ie-lte(7) {
-    zoom: 1;
-  }
-}
-
-// Create a site-container mixin for this project,
-// as placeholders are not yet supported by libsass
-@mixin site-width-container {
-  max-width: $site-width;
-  @include ie-lte(8){
-    width: $site-width;
-  }
-  margin: 0 $gutter-half;
-  @include media(tablet){
-    margin: 0 $gutter;
-  }
-  @include media($min-width: ($site-width + $gutter * 2)){
-    margin: 0 auto;
-  }
-}
-
-// Create a grid-row mixin for this project,
-// as placeholders are not yet supported by libsass
-@mixin grid-row {
-  @include contain-floats;
-  margin: 0 (-$gutter-half);
-}
-
-
 // Want to see how the grid works?
 // add this class to the body to see how grid padding is set
 .example-highlight-grid {

--- a/public/sass/elements/_layout.scss
+++ b/public/sass/elements/_layout.scss
@@ -14,9 +14,10 @@
 
 // Page container wraps the entire site content block
 #page-container {
-  @include site-width-container;
-  @include contain-floats;
+  // Todo - remove this once govuk_template is updated to 2.0.1
   display: block;
+  @extend %site-width-container;
+  @extend %contain-floats;
   padding-bottom: $gutter;
   @include media(desktop) {
     padding-bottom: $gutter*3;
@@ -49,7 +50,7 @@
 
 // Use .grid-row to define a row for grid columns to sit in
 .grid-row {
-  @include grid-row;
+  @extend %grid-row;
 }
 
 // Use .grid-column to create a grid column with 15px gutter

--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -6,7 +6,7 @@
 
 // Indented panels with a grey left hand border
 .panel-indent {
-  @include contain-floats;
+  @extend %contain-floats;
   clear: both;
   border-left: 4px solid $border-colour;
 

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -44,7 +44,7 @@
 // Validation error message box
 // .validation-error {
 //   clear: both;
-//   @include contain-floats;
+//   @extend %contain-floats;
 //   border-left: 3px solid $error-colour;
 //   padding: $gutter- $gutter;
 //   margin-bottom: $gutter-half;


### PR DESCRIPTION
Now that [node-sass is fixed and deployment to Heroku succeeds](https://github.com/sass/node-sass/issues/467).
This reverts commit f8de27f.
- Update node-sass
- Use new grid layout placeholders
- Delete duplicate helper mixins
