### PR TITLE
Add IDs to subheadings for easier links

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -74,7 +74,7 @@
       {{> layout_spacing }}
     </div>
 
-    <h3 class="heading-medium" id="layout-grid">Grid unit proportions</h3>
+    <h3 class="heading-medium" id="layout-grid-unit-proportions">Grid unit proportions</h3>
     <ul class="list-bullet text">
       <li>introduce columns as the content requires it – base column ratios on halves, thirds or quarters of the page width</li>
       <li>for screen breakpoints use media queries &ndash; find these in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_conditionals.scss">_conditionals.scss</a> file</li>
@@ -328,7 +328,7 @@
       </div>
     </div>
 
-    <h3 class="heading-medium" id="colour-status">Status colours</h3>
+    <h3 class="heading-medium" id="colour-status-colours">Status colours</h3>
     <div class="example">
 
       <div class="swatch-wrapper">
@@ -361,7 +361,7 @@
 
     </div>
 
-    <h3 class="heading-medium" id="colour-palette-greyscale">Greyscale palette</h3>
+    <h3 class="heading-medium" id="colour-greyscale-palette">Greyscale palette</h3>
     <div class="example">
       <div class="swatch-wrapper">
         <div class="swatch swatch-black"></div>
@@ -651,7 +651,7 @@
       </div>
     </div>
 
-    <h3 class="heading-medium" id="data-table">Data in a table</h3>
+    <h3 class="heading-medium" id="data-in-a-table">Data in a table</h3>
     <p class="text">
       Consider putting content into tables to make it easier to scan.
     </p>
@@ -815,7 +815,7 @@
       </p>
     </div>
 
-    <h3 class="heading-medium" id="form-inset">Inset form elements</h3>
+    <h3 class="heading-medium" id="form-inset-form-elements">Inset form elements</h3>
     <div class="text">
       <p>
         Insets can be used within forms to emphasise supporting information.
@@ -851,7 +851,7 @@
       Use buttons to move though a transaction, aim to use only one button per page.
     </p>
 
-    <h3 class="heading-medium" id="button-text">Button text</h3>
+    <h3 class="heading-medium" id="buttons-button-text">Button text</h3>
     <p class="text">
       Button text should be short and describe the action the button performs.
     </p>
@@ -887,7 +887,7 @@
 
     </div>
 
-    <h3 class="heading-medium" id="button-sass-mixin">Creating buttons</h3>
+    <h3 class="heading-medium" id="buttons-creating-buttons">Creating buttons</h3>
     <p class="text">
       Use the GOV.UK Sass button mixin &ndash; find this in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/design-patterns/_buttons.scss">buttons.scss</a> file
     </p>
@@ -927,7 +927,7 @@
       </div>
     </div>
 
-    <h3 class="heading-medium" id="button-disabled">Disabled buttons</h3>
+    <h3 class="heading-medium" id="buttons-disabled-buttons">Disabled buttons</h3>
     <p>
       Disabled buttons should be set at 50% opacity.
     </p>


### PR DESCRIPTION
At present there is no way to link to subsections within GOV.UK
elements, adding IDs to each of the h3 headings enables this.

@edwardhorsford - let me know if that covers the content you wanted to link to.
