### PR TITLE
Improve discusssion links to hackpads

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -541,7 +541,7 @@
     </div>
 
     <p>
-      <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Colour" rel="external">Discuss colour on our Hackpad</a>
+      <a href="https://designpatterns.hackpad.com/Colour-PDuGV42pJqx" rel="external">Discuss colour on our Hackpad</a>
     </p>
 
   </div>

--- a/views/index.html
+++ b/views/index.html
@@ -732,9 +732,10 @@
       <p>
         Snap form fields to 100% width at smaller screen sizes.
       </p>
+      <p>
+        <a href="https://designpatterns.hackpad.com/Text-boxes-imgij2JcsHO" rel="external">Discuss text boxes on our Hackpad</a>
+      </p>
     </div>
-
-    <!-- TODO: Add postcode example -->
 
     <h3 class="heading-medium" id="form-fieldsets">Fieldsets and legends</h3>
     <p class="text">

--- a/views/index.html
+++ b/views/index.html
@@ -197,6 +197,10 @@
       </div>
     </div>
 
+    <p>
+      <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Typography" rel="external">Discuss typography on our Hackpad</a>
+    </p>
+
     <h3 class="heading-medium" id="typography-hidden-text">Hidden text (progressive disclosure)</h3>
     <p class="text">
       Use this to make your page easier to scan,
@@ -208,9 +212,8 @@
     <div class="example">
       {{> typography_progressive_disclosure }}
     </div>
-
     <p>
-      <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Typography" rel="external">Discuss typography on our Hackpad</a>
+      <a href="https://designpatterns.hackpad.com/Progressive-disclosure-mi03xhbZQpu" rel="external">Discuss progressive disclosure on our Hackpad</a>
     </p>
 
   </div>
@@ -585,7 +588,7 @@
     </div>
 
     <p>
-      <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Icons-and-images" rel="external">Discuss icons and images on our Hackpad</a>
+      <a href="https://designpatterns.hackpad.com/Iconography-UoIkbsbqgll" rel="external">Discuss icons on our Hackpad</a>
     </p>
 
   </div>
@@ -679,7 +682,7 @@
     </div>
 
     <p>
-      <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Data" rel="external">Discuss data on our Hackpad</a>
+      <a href="https://designpatterns.hackpad.com/Tables-AXM1FinduJR" rel="external">Discuss tables on our Hackpad</a>
     </p>
 
   </div>
@@ -936,7 +939,7 @@
     </div>
 
     <p>
-      <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Buttons" rel="external">Discuss buttons on our Hackpad</a>
+      <a href="https://designpatterns.hackpad.com/Navigation-buttons-continue-next-previous-zoP1sKiW3y4" rel="external">Discuss buttons on our Hackpad</a>
     </p>
 
   </div>
@@ -962,7 +965,7 @@
     </ul>
 
     <p>
-      <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2#:h=Errors-and-validation" rel="external">Discuss errors on our Hackpad</a>
+      <a href="https://designpatterns.hackpad.com/Error-messaging-and-validation-HiGXPZ7XiG0" rel="external">Discuss errors on our Hackpad</a>
     </p>
 
   </div>

--- a/views/index.html
+++ b/views/index.html
@@ -779,6 +779,9 @@
     <p class="text">
       Avoid using drop-down lists - use radio buttons or checkboxes instead.
     </p>
+    <p>
+      <a href="https://designpatterns.hackpad.com/Select-boxes-KzQ1IRd07HL" rel="external">Discuss select boxes on our Hackpad</a>
+    </p>
 
     <h3 class="heading-medium" id="form-radio-buttons">Radio buttons</h3>
     <ul class="list-bullet text">

--- a/views/index.html
+++ b/views/index.html
@@ -822,6 +822,10 @@
       </p>
     </div>
 
+    <p>
+      <a href="https://designpatterns.hackpad.com/Radio-buttons-and-checkboxes-8eBuLm9eRaz" rel="external">Discuss radio buttons and checkboxes on our Hackpad</a>
+    </p>
+
     <h3 class="heading-medium" id="form-inset-form-elements">Inset form elements</h3>
     <div class="text">
       <p>


### PR DESCRIPTION
Where a hackpad exists for a topic, link to this - rather than to the
elements feedback page.

- Add new link to Progressive disclosure hackpad
- Link icons and images to Iconography hackpad
- Link data feedback to Tables hackpad
- Link buttons to Navigation buttons hackpad
- Link errors and validation to Error messaging hackpad