### PR TITLE
Add link to burn your select tags

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -773,7 +773,10 @@
 
     <h3 class="heading-medium" id="form-select-boxes">Drop-down lists</h3>
     <p class="text">
-      Avoid using drop-down lists - use radio buttons or checkboxes instead.
+      Avoid using drop-down lists (the HTML select element) - use radio buttons or checkboxes instead.
+    </p>
+    <p>
+      <a href="https://www.youtube.com/watch?v=CUkMCQR4TpY" rel="external">Watch Alice Bartlett present the failings of select boxes to meet the needs of less technically capable users</a>.
     </p>
 
     <h3 class="heading-medium" id="form-radio-buttons">Radio buttons</h3>


### PR DESCRIPTION
The best way to explain why we’d like people not to use native select
tags is to get them to watch this talk.

Also mention the HTML select element (next to drop-down lists), so it’s clear we’re talking
about the same thing.