### PR TITLE
Reduce spacing to the right of block labels

### DIFF
--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -45,7 +45,7 @@
 // To stack horizontally, use .inline on parent, to sit block labels next to each other
 .inline .block-label {
   clear: none;
-  margin-right: $gutter-half;
+  margin-right: 10px;
 }
 
 // Selected and focused states


### PR DESCRIPTION
This should be 10px, the same as the space between block labels.