### PR TITLE
Add a form wrapper to radio examples

### DIFF
--- a/views/snippets/form_checkboxes.html
+++ b/views/snippets/form_checkboxes.html
@@ -1,4 +1,4 @@
-<form class="form">
+<form>
   <fieldset>
     <legend class="form-label-bold">Which types of waste do you transport regularly?</legend>
     <p>Select all that apply</p>

--- a/views/snippets/form_focus.html
+++ b/views/snippets/form_focus.html
@@ -1,6 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <form class="form" action="/" method="post">
+    <form>
       <div class="form-group">
         <label class="form-label" for="full-name-f2">Full name</label>
         <input class="form-control" type="text" id="full-name-f2">

--- a/views/snippets/form_inset_checkboxes.html
+++ b/views/snippets/form_inset_checkboxes.html
@@ -1,4 +1,4 @@
-<form class="form">
+<form>
   <fieldset>
     <legend class="form-label-bold">What is your nationality?</legend>
     <p>

--- a/views/snippets/form_inset_radios.html
+++ b/views/snippets/form_inset_radios.html
@@ -1,4 +1,4 @@
-<form class="form">
+<form>
   <fieldset class="inline">
     <legend class="form-label">Do you know their National Insurance number?</legend>
     <div class="form-group form-group-compound">

--- a/views/snippets/form_radio_buttons.html
+++ b/views/snippets/form_radio_buttons.html
@@ -1,13 +1,15 @@
-<label class="block-label" for="radio-1">
-  <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">
-  Northern Ireland
-</label>
-<label class="block-label" for="radio-2">
-  <input id="radio-2" type="radio" name="radio-group" value="Isle of Man or the Channel Islands">
-  Isle of Man or the Channel Islands
-</label>
-<p class="form-block">or</p>
-<label class="block-label" for="radio-3">
-  <input id="radio-3" type="radio" name="radio-group" value="I am a British citizen living abroad">
-  I am a British citizen living abroad
-</label>
+<form>
+  <label class="block-label" for="radio-1">
+    <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">
+    Northern Ireland
+  </label>
+  <label class="block-label" for="radio-2">
+    <input id="radio-2" type="radio" name="radio-group" value="Isle of Man or the Channel Islands">
+    Isle of Man or the Channel Islands
+  </label>
+  <p class="form-block">or</p>
+  <label class="block-label" for="radio-3">
+    <input id="radio-3" type="radio" name="radio-group" value="I am a British citizen living abroad">
+    I am a British citizen living abroad
+  </label>
+</form>

--- a/views/snippets/form_radio_buttons_inline.html
+++ b/views/snippets/form_radio_buttons_inline.html
@@ -1,10 +1,12 @@
-<fieldset class="inline">
-  <label class="block-label" for="radio-inline-1">
-    <input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes">
-    Yes
-  </label>
-  <label class="block-label" for="radio-inline-2">
-    <input id="radio-inline-2" type="radio" name="radio-inline-group" value="No">
-    No
-  </label>
-</fieldset>
+<form>
+  <fieldset class="inline">
+    <label class="block-label" for="radio-inline-1">
+      <input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes">
+      Yes
+    </label>
+    <label class="block-label" for="radio-inline-2">
+      <input id="radio-inline-2" type="radio" name="radio-inline-group" value="No">
+      No
+    </label>
+  </fieldset>
+</form>


### PR DESCRIPTION
[selection-buttons.js](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/selection-buttons.js) requires a parent `<form>` wrapper, add this
to any examples which demonstrate chunky radio buttons.

Also remove the `.form` class, and any form attributes for form
examples.

[This fixes issue 155](https://github.com/alphagov/govuk_frontend_toolkit/issues/155), and [issue 54] (https://github.com/alphagov/govuk_elements/issues/54). 

The `<form>` element wasn't previously added to the elements code snippets to keep them short. 