### PR TITLE
Improve details summary polyfill

### DIFF
--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -103,7 +103,6 @@
 
         details.__summary.setAttribute('aria-expanded', 'true');
         details.__content.setAttribute('aria-hidden', 'false');
-
         details.__content.style.display = 'block';
       }
 
@@ -158,14 +157,13 @@
         if (details.getAttribute('open') === "") {
           twisty.className = 'arrow arrow-open';
           twisty.appendChild(document.createTextNode('\u25bc'));
-          details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild);
-
         } else {
           twisty.className = 'arrow arrow-closed';
           twisty.appendChild(document.createTextNode('\u25ba'));
-          details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild);
-
         }
+
+        details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild);
+        details.__summary.__twisty.setAttribute('aria-hidden', 'true');
 
       }
     }
@@ -177,6 +175,7 @@
       // Update aria-expanded attribute on click
       var expanded = summary.__details.__summary.getAttribute('aria-expanded') == 'true';
       // console.log("get aria expanded " +expanded);
+
       var hidden = summary.__details.__content.getAttribute('aria-hidden') == 'true';
       //console.log("get aria hidden " +hidden);
 

--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -92,7 +92,9 @@
       details.__summary.setAttribute('aria-controls', details.__content.id);
 
       // Set tabindex so the summary is keyboard accessible
-      details.__summary.setAttribute('tabindex', '0');
+      // details.__summary.setAttribute('tabindex', 0);
+      // http://www.saliences.com/browserBugs/tabIndex.html
+      details.__summary.tabIndex = 0;
 
       // Detect initial open/closed state
 

--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -24,6 +24,12 @@
 
   // Handle cross-modal click events
   function addClickEvent(node, callback) {
+    // Prevent space(32) from scrolling the page
+    addEvent(node, 'keypress', function (e, target) {
+      if (e.keyCode === 32) {
+        e.preventDefault();
+      }
+    });
     // When the key comes up - check if it is enter(13) or space(32)
     addEvent(node, 'keyup', function (e, target) {
       if (e.keyCode === 13 || e.keyCode === 32) { callback(e, target); }

--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -24,16 +24,12 @@
 
   // Handle cross-modal click events
   function addClickEvent(node, callback) {
-    var keydown = false;
-    addEvent(node, 'keydown', function () {
-      keydown = true;
-    });
+    // When the key comes up - check if it is enter(13) or space(32)
     addEvent(node, 'keyup', function (e, target) {
-      keydown = false;
-      if (e.keyCode === 13) { callback(e, target); }
+      if (e.keyCode === 13 || e.keyCode === 32) { callback(e, target); }
     });
-    addEvent(node, 'click', function (e, target) {
-      if (!keydown) { callback(e, target); }
+    addEvent(node, 'mouseup', function (e, target) {
+      callback(e, target);
     });
   }
 
@@ -86,6 +82,9 @@
         details.__content.id = 'details-content-' + i;
       }
 
+      // Add ARIA role="group" to details
+      details.setAttribute('role', 'group');
+
       // Add role=button to summary
       details.__summary.setAttribute('role', 'button');
 
@@ -100,16 +99,18 @@
       // Native support - has 'open' attribute
       if (details.open === true) {
 
-        console.log("Has open attribute - native open");
+        // console.log("Has open attribute - native open");
 
         details.__summary.setAttribute('aria-expanded', 'true');
         details.__content.setAttribute('aria-hidden', 'false');
+
+        details.__content.style.display = 'block';
       }
 
       // Native support - doesn't have 'open' attribute
       if (details.open === false) {
 
-        console.log("Doesn't have open attribute -  native closed ");
+        // console.log("Doesn't have open attribute -  native closed ");
 
         details.__summary.setAttribute('aria-expanded', 'false');
         details.__content.setAttribute('aria-hidden', 'true');
@@ -126,7 +127,7 @@
         // If open exists, but isn't supported it won't have a value
         if (details.getAttribute('open') === "") {
 
-          console.log("Has open attribute - NOT native open");
+          // console.log("Has open attribute - NOT native open");
 
           details.__summary.setAttribute('aria-expanded', 'true');
           details.__content.setAttribute('aria-hidden', 'false');
@@ -135,7 +136,7 @@
         // If doesn't exist - it will be null or undefined
         if (details.getAttribute('open') == null || details.getAttribute('open') == "undefined" ) {
 
-          console.log("Doesn't have open attribute - NOT native closed");
+          // console.log("Doesn't have open attribute - NOT native closed");
 
           details.__summary.setAttribute('aria-expanded', 'false');
           details.__content.setAttribute('aria-hidden', 'true');
@@ -175,7 +176,9 @@
 
       // Update aria-expanded attribute on click
       var expanded = summary.__details.__summary.getAttribute('aria-expanded') == 'true';
+      // console.log("get aria expanded " +expanded);
       var hidden = summary.__details.__content.getAttribute('aria-hidden') == 'true';
+      //console.log("get aria hidden " +hidden);
 
       summary.__details.__summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'));
       summary.__details.__content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'));

--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -96,14 +96,52 @@
       details.__summary.setAttribute('tabindex', '0');
 
       // Detect initial open/closed state
-      var detailsAttr = details.getAttribute("open");
-      if (detailsAttr == "null" ) {
+
+      // Native support - has 'open' attribute
+      if (details.open === true) {
+
+        console.log("Has open attribute - native open");
+
         details.__summary.setAttribute('aria-expanded', 'true');
         details.__content.setAttribute('aria-hidden', 'false');
-      } else {
+      }
+
+      // Native support - doesn't have 'open' attribute
+      if (details.open === false) {
+
+        console.log("Doesn't have open attribute -  native closed ");
+
         details.__summary.setAttribute('aria-expanded', 'false');
         details.__content.setAttribute('aria-hidden', 'true');
         details.__content.style.display = 'none';
+      }
+
+      // If this is not a native implementation
+      if (!details.__native) {
+
+        // Add an arrow
+        var twisty = document.createElement('i');
+
+        // Check for the 'open' attribute
+        // If open exists, but isn't supported it won't have a value
+        if (details.getAttribute('open') === "") {
+
+          console.log("Has open attribute - NOT native open");
+
+          details.__summary.setAttribute('aria-expanded', 'true');
+          details.__content.setAttribute('aria-hidden', 'false');
+        }
+
+        // If doesn't exist - it will be null or undefined
+        if (details.getAttribute('open') == null || details.getAttribute('open') == "undefined" ) {
+
+          console.log("Doesn't have open attribute - NOT native closed");
+
+          details.__summary.setAttribute('aria-expanded', 'false');
+          details.__content.setAttribute('aria-hidden', 'true');
+          details.__content.style.display = 'none';
+        }
+
       }
 
       // Create a circular reference from the summary back to its
@@ -113,10 +151,21 @@
       // If this is not a native implementation, create an arrow
       // inside the summary, saving its reference as a summary property
       if (!details.__native) {
+
         var twisty = document.createElement('i');
-        twisty.className = 'arrow arrow-closed';
-        twisty.appendChild(document.createTextNode('\u25ba'));
-        details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild);
+
+        if (details.getAttribute('open') === "") {
+          twisty.className = 'arrow arrow-open';
+          twisty.appendChild(document.createTextNode('\u25bc'));
+          details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild);
+
+        } else {
+          twisty.className = 'arrow arrow-closed';
+          twisty.appendChild(document.createTextNode('\u25ba'));
+          details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild);
+
+        }
+
       }
     }
 

--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -100,9 +100,6 @@
 
       // Native support - has 'open' attribute
       if (details.open === true) {
-
-        // console.log("Has open attribute - native open");
-
         details.__summary.setAttribute('aria-expanded', 'true');
         details.__content.setAttribute('aria-hidden', 'false');
         details.__content.style.display = 'block';
@@ -110,9 +107,6 @@
 
       // Native support - doesn't have 'open' attribute
       if (details.open === false) {
-
-        // console.log("Doesn't have open attribute -  native closed ");
-
         details.__summary.setAttribute('aria-expanded', 'false');
         details.__content.setAttribute('aria-hidden', 'true');
         details.__content.style.display = 'none';
@@ -127,18 +121,12 @@
         // Check for the 'open' attribute
         // If open exists, but isn't supported it won't have a value
         if (details.getAttribute('open') === "") {
-
-          // console.log("Has open attribute - NOT native open");
-
           details.__summary.setAttribute('aria-expanded', 'true');
           details.__content.setAttribute('aria-hidden', 'false');
         }
 
-        // If doesn't exist - it will be null or undefined
+        // If open doesn't exist - it will be null or undefined
         if (details.getAttribute('open') == null || details.getAttribute('open') == "undefined" ) {
-
-          // console.log("Doesn't have open attribute - NOT native closed");
-
           details.__summary.setAttribute('aria-expanded', 'false');
           details.__content.setAttribute('aria-hidden', 'true');
           details.__content.style.display = 'none';
@@ -151,7 +139,7 @@
       details.__summary.__details = details;
 
       // If this is not a native implementation, create an arrow
-      // inside the summary, saving its reference as a summary property
+      // inside the summary
       if (!details.__native) {
 
         var twisty = document.createElement('i');
@@ -174,12 +162,8 @@
     // Also update the arrow position
     function statechange(summary) {
 
-      // Update aria-expanded attribute on click
       var expanded = summary.__details.__summary.getAttribute('aria-expanded') == 'true';
-      // console.log("get aria expanded " +expanded);
-
       var hidden = summary.__details.__content.getAttribute('aria-hidden') == 'true';
-      //console.log("get aria hidden " +hidden);
 
       summary.__details.__summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'));
       summary.__details.__content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'));

--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -27,7 +27,10 @@
     // Prevent space(32) from scrolling the page
     addEvent(node, 'keypress', function (e, target) {
       if (e.keyCode === 32) {
-        e.preventDefault();
+        if (e.preventDefault) {
+          e.preventDefault();
+        }
+        else { e.returnValue = false; }
       }
     });
     // When the key comes up - check if it is enter(13) or space(32)

--- a/views/patterns/details_summary.html
+++ b/views/patterns/details_summary.html
@@ -22,6 +22,9 @@
   <h1 class="heading-xlarge">Details test page</h1>
   <p> Support for HTML5's &lt;details&gt; and &lt;summary&gt;</p>
 
+  <p>
+    Test case: Has open attribute - open at start
+  </p>
   <details open>
     <summary><span class="summary">Help with nationality</span></summary>
     <div class="panel-indent">
@@ -34,6 +37,9 @@
     </div>
   </details>
 
+  <p>
+    Test case: Doesn't have open attribute - closed at start
+  </p>
   <details>
     <summary><span class="summary">Why aren't all prisons available?</span></summary>
     <div class="panel-indent">

--- a/views/patterns/details_summary.html
+++ b/views/patterns/details_summary.html
@@ -23,7 +23,7 @@
   <p> Support for HTML5's &lt;details&gt; and &lt;summary&gt;</p>
 
   <p>
-    Test case: Has open attribute - open at start
+    Test case: Has <code>open</code> attribute - open at start
   </p>
   <details open>
     <summary><span class="summary">Help with nationality</span></summary>
@@ -38,7 +38,7 @@
   </details>
 
   <p>
-    Test case: Doesn't have open attribute - closed at start
+    Test case: Doesn't have <code>open</code> attribute - closed at start
   </p>
   <details>
     <summary><span class="summary">Why aren't all prisons available?</span></summary>

--- a/views/patterns/details_summary.html
+++ b/views/patterns/details_summary.html
@@ -22,24 +22,6 @@
   <h1 class="heading-xlarge">Details test page</h1>
   <p> Support for HTML5's &lt;details&gt; and &lt;summary&gt;</p>
 
-  <p>
-    Test case: Has <code>open</code> attribute - open at start
-  </p>
-  <details open>
-    <summary><span class="summary">Help with nationality</span></summary>
-    <div class="panel-indent">
-      <p>
-        If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
-      </p>
-      <p>
-        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
-      </p>
-    </div>
-  </details>
-
-  <p>
-    Test case: Doesn't have <code>open</code> attribute - closed at start
-  </p>
   <details>
     <summary><span class="summary">Why aren't all prisons available?</span></summary>
     <div class="panel-indent">


### PR DESCRIPTION
The current polyfill wasn't correctly detecting the "open" attribute and was firing twice in Chrome, 
when the summary was clicked.

For now, it has two checks - first for native support, which uses the boolean "open" attribute.  Then for non-native support, which checks for an "open" attribute with an empty value, otherwise "open" is
undefined (not present) and the details content should be closed.

For non-native support, an open or closed arrow (pointing right or down) is added, and styled to look like the native arrow in Chrome - depending on the initial "open" state. This arrow is hidden from assistive technology using `role="presentation"`. [Read the W3C Recommendation here](http://www.w3.org/TR/wai-aria/roles#presentation).

### A detailed explanation from Léonie:

`<details role="group">`
 
The implicit role for `<details>` should be "group". Since most browsers haven't implemented support for the element (let alone accessibility support), we need to apply this role manually – so that assistive technologies know that it's a container for a group of related content.

`<summary role="button" aria-controls="details-content-0" tabindex="0" aria-expanded="false">…</summary>`

#### [1] role="button * 

The implicit role for `<summary>` should be "button", but as with `<details>` we need to provide the accessibility support explicitly using the role attribute.

#### [2] aria-controls="details-content-0" 

* Note: `aria-controls` is not consistently supported by assistive technologies. 
Those that do support it usually provide a keyboard shortcut that lets the user move focus to the start of the element being controlled. It is not expected behaviour for a screen reader to automatically start to speak the content of the disclosure widget when it opens. 
* It's also worth noting that VoiceOver/Safari doesn't support `aria-controls` in any case.

#### [3] tabindex="0" *

Without basic browser support for `<summary>` it can't be focused on with the keyboard. Using tabindex="0" places the element into the natural tab order of the page, so as someone using a keyboard tabs through the page they'll be able to focus on it in order to activate it.

#### [4] aria-expanded="false" *

The aria-expanded attribute informs assistive technologies that the `<summary>` element triggers the expansion/collapse of something. When focus first moves to the `<summary>` element, its state is announced as "collapsed", and once the button is activated it changes to "expanded".







