### PR TITLE
Add guidance on phase banners

### DIFF
--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -362,3 +362,17 @@ $palette: (
 .example-button ul {
   padding-bottom: 0;
 }
+
+
+// 9. Alpha beta banners
+// ==========================================================================
+
+// Alpha
+.phase-banner-alpha {
+  @include phase-banner($state: alpha);
+}
+
+// Beta
+.phase-banner-beta {
+  @include phase-banner($state: beta);
+}

--- a/views/index.html
+++ b/views/index.html
@@ -31,6 +31,7 @@
       <li><a href="#guide-forms">Forms</a></li>
       <li><a href="#guide-buttons">Buttons</a></li>
       <li><a href="#guide-errors">Errors and validation</a></li>
+      <li><a href="#guide-alpha-beta">Alpha and beta banners</a></li>
     </ol>
 
     <h2 class="heading-medium">Looking for the styles?</h2>
@@ -995,6 +996,40 @@
 
   </div>
   <!-- / #guide-errors -->
+
+  <div id="guide-alpha-beta">
+
+    <h2 class="heading-large heading-with-border">9. Alpha and beta banners</h2>
+    <p class="text">
+      You have to use an alpha banner if your thing is in alpha, and a beta banner if it’s in beta.
+    </p>
+
+    <h3 class="heading-medium" id="error-form-validation">Things on the service.gov.uk subdomain</h3>
+    <p class="text">
+      If your service is in beta or alpha, you must show the relevant banner in the header.
+      It should sit directly underneath the black GOV.UK header and colour bar.
+    </p>
+
+    <div class="example">
+      {{> phase_banner_alpha }}
+    </div>
+
+    <div class="example">
+      {{> phase_banner_beta }}
+    </div>
+
+    <h3 class="heading-medium" id="error-form-validation">Things on GOV.UK</h3>
+    <p class="text">
+      If your GOV.UK content is in beta or alpha, show the relevant banner below the page title, but above the body content. You can see what they should look like in <a href="https://designnotes.blog.gov.uk/2014/03/26/betas-on-gov-uk/">this blog post</a>.
+    </p>
+
+    <h3 class="heading-medium" id="alpha-beta-creating-banners">Creating alpha and beta banners</h3>
+    <p class="text">
+      Use the GOV.UK Sass phase banner mixin &ndash; find this in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/design-patterns/_alpha-beta.scss">alpha-beta.scss</a> file
+    </p>
+
+  </div>
+  <!-- / #guide-alpha-beta -->
 
 </main><!-- / #content -->
 {{/content}}

--- a/views/snippets.html
+++ b/views/snippets.html
@@ -33,6 +33,8 @@
   <li><a href="#guide-data">Data</a></li>
   <li><a href="#guide-forms">Forms</a></li>
   <li><a href="#guide-buttons">Buttons</a></li>
+  <li>Errors and validation</li>
+  <li><a href="#guide-alpha-beta">Alpha and beta banners</a></li>
 </ol>
 
 <!-- 1. Layout -->
@@ -311,6 +313,29 @@
 <pre><code class="language-markup">
 </code></pre>
 -->
+
+<!-- 9. Alpha beta banners -->
+
+<h2 class="heading-medium" id="guide-alpha-beta">9. Alpha and beta banners</h2>
+
+<div class="example">
+  {{> phase_banner_alpha }}
+</div>
+<pre>
+<code class="language-markup">
+  {{> phase_banner_alpha }}
+</code>
+</pre>
+
+<div class="example">
+  {{> phase_banner_beta }}
+</div>
+<pre>
+<code class="language-markup">
+  {{> phase_banner_beta }}
+</code>
+</pre>
+
 
 </main><!-- / #content -->
 {{/content}}

--- a/views/snippets/phase_banner_alpha.html
+++ b/views/snippets/phase_banner_alpha.html
@@ -1,0 +1,6 @@
+<div class="phase-banner-alpha">
+  <p>
+    <strong class="phase-tag">ALPHA</strong>
+    <span>This is a new service – your <a href="#">feedback</a> will help us to improve it.</span>
+  </p>
+</div>

--- a/views/snippets/phase_banner_beta.html
+++ b/views/snippets/phase_banner_beta.html
@@ -1,0 +1,6 @@
+<div class="phase-banner-beta">
+  <p>
+    <strong class="phase-tag">BETA</strong>
+    <span>This is a new service – your <a href="#">feedback</a> will help us to improve it.</span>
+  </p>
+</div>


### PR DESCRIPTION
Move content from the [Service Design Manual - Patterns page](https://www.gov.uk/service-manual/user-centred-design/resources/patterns/alpha-beta).

GOV.UK elements explains how to make use of the Sass mixins provided by the [GOV.UK frontend toolkit](https://github.com/alphagov/govuk_frontend_toolkit) - this content should sit here. 

