### PR TITLE
bug fix escaping element names

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -3,7 +3,8 @@ function ShowHideContent() {
 
 
   self.escapeElementName = function(str) {
-    str.replace('[', '\\[').replace(']', '\\]')
+    result = str.replace('[', '\\[').replace(']', '\\]')
+    return(result);
   };
 
   self.showHideRadioToggledContent = function () {


### PR DESCRIPTION
There was a bug in the escape element names PR I submitted last week; it was manifested by a div being un-hidden on clicking a radio button wasn't re-hidden when clicking another radio button.  This is the fix.