### PR TITLE
Add validation guidance and examples

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,8 @@ app.set('views', __dirname + '/views');
 // Middleware to serve static assets
 app.use('/public', express.static(__dirname + '/public'));
 app.use('/public', express.static(__dirname + '/govuk/public'));
+app.use(express.json());       // to support JSON-encoded bodies
+app.use(express.urlencoded()); // to support URL-encoded bodies
 
 // routes (found in routes.js)
 

--- a/govuk/public/javascripts/govuk/analytics/error-tracking.js
+++ b/govuk/public/javascripts/govuk/analytics/error-tracking.js
@@ -1,0 +1,27 @@
+// Extension to track errors using google analytics as a data store.
+(function() {
+
+  "use strict";
+
+  GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {};
+
+  GOVUK.analyticsPlugins.error = function () {
+    var trackJavaScriptError = function (e) {
+      var errorSource = e.filename + ': ' + e.lineno;
+      GOVUK.analytics.trackEvent('JavaScript Error', e.message, {
+        label: errorSource,
+        value: 1,
+        nonInteraction: true
+      });
+    };
+
+    if (window.addEventListener) {
+      window.addEventListener('error', trackJavaScriptError, false);
+    } else if (window.attachEvent) {
+      window.attachEvent('onerror', trackJavaScriptError);
+    } else {
+      window.onerror = trackJavaScriptError;
+    }
+  }
+
+}());

--- a/govuk/public/javascripts/govuk/analytics/google-analytics-classic-tracker.js
+++ b/govuk/public/javascripts/govuk/analytics/google-analytics-classic-tracker.js
@@ -1,0 +1,111 @@
+(function() {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+
+  var GoogleAnalyticsClassicTracker = function(id, cookieDomain) {
+    window._gaq = window._gaq || [];
+    configureProfile(id, cookieDomain);
+    allowCrossDomainTracking();
+    anonymizeIp();
+
+    function configureProfile(id, cookieDomain) {
+      _gaq.push(['_setAccount', id]);
+      _gaq.push(['_setDomainName', cookieDomain]);
+    }
+
+    function allowCrossDomainTracking() {
+      _gaq.push(['_setAllowLinker', true]);
+    }
+
+    // https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApi_gat#_gat._anonymizeIp
+    function anonymizeIp() {
+      _gaq.push(['_gat._anonymizeIp']);
+    }
+  };
+
+  GoogleAnalyticsClassicTracker.load = function() {
+    var ga = document.createElement('script'),
+        s = document.getElementsByTagName('script')[0];
+
+    ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    s.parentNode.insertBefore(ga, s);
+  };
+
+  // https://developers.google.com/analytics/devguides/collection/gajs/asyncMigrationExamples#VirtualPageviews
+  GoogleAnalyticsClassicTracker.prototype.trackPageview = function(path) {
+    var pageview = ['_trackPageview'];
+
+    if (typeof path === "string") {
+      pageview.push(path);
+    }
+
+    _gaq.push(pageview);
+  };
+
+  // https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide
+  GoogleAnalyticsClassicTracker.prototype.trackEvent = function(category, action, options) {
+    var value,
+        options = options || {},
+        hasLabel = false,
+        hasValue = false,
+        evt = ["_trackEvent", category, action];
+
+    // Label is optional
+    if (typeof options.label === "string") {
+      hasLabel = true;
+      evt.push(options.label);
+    }
+
+    // Value is optional, but when used must be an
+    // integer, otherwise the event will be invalid
+    // and not logged
+    if (options.value || options.value === 0) {
+      value = parseInt(options.value, 10);
+      if (typeof value === "number" && !isNaN(value)) {
+        hasValue = true;
+
+        // Push an empty label if not set for correct final argument order
+        if (!hasLabel) {
+          evt.push('');
+        }
+
+        evt.push(value);
+      }
+    }
+
+    // Prevents an event from affecting bounce rate
+    // https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#non-interaction
+    if (options.nonInteraction) {
+
+      // Push empty label/value if not already set, for correct final argument order
+      if (!hasValue) {
+        if (!hasLabel) {
+          evt.push('');
+        }
+        evt.push(0);
+      }
+
+      evt.push(true);
+    }
+
+    _gaq.push(evt);
+  };
+
+  /*
+    https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiSocialTracking
+    network – The network on which the action occurs (e.g. Facebook, Twitter)
+    action – The type of action that happens (e.g. Like, Send, Tweet)
+    target – The text value that indicates the subject of the action
+  */
+  GoogleAnalyticsClassicTracker.prototype.trackSocial = function(network, action, target) {
+    _gaq.push(['_trackSocial', network, action, target]);
+  };
+
+  // https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingCustomVariables
+  GoogleAnalyticsClassicTracker.prototype.setCustomVariable = function(index, value, name, scope) {
+    _gaq.push(['_setCustomVar', index, name, String(value), scope]);
+  };
+
+  GOVUK.GoogleAnalyticsClassicTracker = GoogleAnalyticsClassicTracker;
+})();

--- a/govuk/public/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/govuk/public/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -1,0 +1,104 @@
+(function() {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+
+  var GoogleAnalyticsUniversalTracker = function(id, cookieDomain) {
+    configureProfile(id, cookieDomain);
+    anonymizeIp();
+
+    function configureProfile(id, cookieDomain) {
+      sendToGa('create', id, {'cookieDomain': cookieDomain});
+    }
+
+    function anonymizeIp() {
+      // https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#anonymizeip
+      sendToGa('set', 'anonymizeIp', true);
+    }
+  };
+
+  GoogleAnalyticsUniversalTracker.load = function() {
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  };
+
+  // https://developers.google.com/analytics/devguides/collection/analyticsjs/pages
+  GoogleAnalyticsUniversalTracker.prototype.trackPageview = function(path, title) {
+    if (typeof path === "string") {
+      var pageviewObject = {
+            page: path
+          };
+
+      if (typeof title === "string") {
+        pageviewObject.title = title;
+      }
+      sendToGa('send', 'pageview', pageviewObject);
+    } else {
+      sendToGa('send', 'pageview');
+    }
+  };
+
+  // https://developers.google.com/analytics/devguides/collection/analyticsjs/events
+  GoogleAnalyticsUniversalTracker.prototype.trackEvent = function(category, action, options) {
+    var value,
+        options = options || {},
+        evt = {
+          hitType: 'event',
+          eventCategory: category,
+          eventAction: action
+        };
+
+    // Label is optional
+    if (typeof options.label === "string") {
+      evt.eventLabel = options.label;
+    }
+
+    // Value is optional, but when used must be an
+    // integer, otherwise the event will be invalid
+    // and not logged
+    if (options.value || options.value === 0) {
+      value = parseInt(options.value, 10);
+      if (typeof value === "number" && !isNaN(value)) {
+        evt.eventValue = value;
+      }
+    }
+
+    // Prevents an event from affecting bounce rate
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/events#implementation
+    if (options.nonInteraction) {
+      evt.nonInteraction = 1;
+    }
+
+    sendToGa('send', evt);
+  };
+
+  /*
+    https://developers.google.com/analytics/devguides/collection/analyticsjs/social-interactions
+    network – The network on which the action occurs (e.g. Facebook, Twitter)
+    action – The type of action that happens (e.g. Like, Send, Tweet)
+    target – Specifies the target of a social interaction.
+             This value is typically a URL but can be any text.
+  */
+  GoogleAnalyticsUniversalTracker.prototype.trackSocial = function(network, action, target) {
+    sendToGa('send', {
+      'hitType': 'social',
+      'socialNetwork': network,
+      'socialAction': action,
+      'socialTarget': target
+    });
+  };
+
+  // https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets
+  GoogleAnalyticsUniversalTracker.prototype.setDimension = function(index, value) {
+    sendToGa('set', 'dimension' + index, String(value));
+  };
+
+  function sendToGa() {
+    if (typeof window.ga === "function") {
+      ga.apply(window, arguments);
+    }
+  }
+
+  GOVUK.GoogleAnalyticsUniversalTracker = GoogleAnalyticsUniversalTracker;
+})();

--- a/govuk/public/javascripts/govuk/analytics/print-intent.js
+++ b/govuk/public/javascripts/govuk/analytics/print-intent.js
@@ -1,0 +1,37 @@
+// Extension to monitor attempts to print pages.
+(function () {
+  "use strict";
+
+  GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {};
+
+  GOVUK.analyticsPlugins.printIntent = function () {
+    var printAttempt = (function () {
+      GOVUK.analytics.trackEvent('Print Intent', document.location.pathname);
+      GOVUK.analytics.trackPageview('/print' + document.location.pathname);
+    });
+
+    // Most browsers
+    if (window.matchMedia) {
+      var mediaQueryList = window.matchMedia('print'),
+        mqlListenerCount = 0;
+      mediaQueryList.addListener(function (mql) {
+        if (!mql.matches && mqlListenerCount === 0) {
+          printAttempt();
+          mqlListenerCount++;
+          // If we try and print again within 3 seconds, don't log it
+          window.setTimeout(function () {
+            mqlListenerCount = 0;
+            // printing will be tracked again now
+          }, 3000);
+        }
+      });
+    }
+
+    // IE < 10
+    if (window.onafterprint) {
+      window.onafterprint = printAttempt;
+    }
+
+  };
+
+}());

--- a/govuk/public/javascripts/govuk/analytics/tracker.js
+++ b/govuk/public/javascripts/govuk/analytics/tracker.js
@@ -1,0 +1,61 @@
+(function() {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+
+  // For usage and initialisation see:
+  // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md#create-an-analytics-tracker
+
+  var Tracker = function(config) {
+    this.universal = new GOVUK.GoogleAnalyticsUniversalTracker(config.universalId, config.cookieDomain);
+    this.classic = new GOVUK.GoogleAnalyticsClassicTracker(config.classicId, config.cookieDomain);
+  };
+
+  Tracker.load = function() {
+    GOVUK.GoogleAnalyticsClassicTracker.load();
+    GOVUK.GoogleAnalyticsUniversalTracker.load();
+  };
+
+  Tracker.prototype.trackPageview = function(path, title) {
+    this.classic.trackPageview(path);
+    this.universal.trackPageview(path, title);
+  };
+
+  /*
+    https://developers.google.com/analytics/devguides/collection/analyticsjs/events
+    options.label – Useful for categorizing events (eg nav buttons)
+    options.value – Values must be non-negative. Useful to pass counts
+    options.nonInteraction – Prevent event from impacting bounce rate
+  */
+  Tracker.prototype.trackEvent = function(category, action, options) {
+    this.classic.trackEvent(category, action, options);
+    this.universal.trackEvent(category, action, options);
+  };
+
+  Tracker.prototype.trackShare = function(network) {
+    var target = location.pathname;
+    this.classic.trackSocial(network, 'share', target);
+    this.universal.trackSocial(network, 'share', target);
+  };
+
+  /*
+    Assumes that the index of the dimension is the same for both classic and universal.
+    Check this for your app before using this
+   */
+  Tracker.prototype.setDimension = function(index, value, name, scope) {
+    var PAGE_LEVEL_SCOPE = 3;
+    scope = scope || PAGE_LEVEL_SCOPE;
+
+    if (typeof index !== "number") {
+      index = parseInt(index, 10);
+    }
+
+    if (typeof scope !== "number") {
+      scope = parseInt(scope, 10);
+    }
+
+    this.universal.setDimension(index, value);
+    this.classic.setCustomVariable(index, value, name, scope);
+  };
+
+  GOVUK.Tracker = Tracker;
+})();

--- a/govuk/public/sass/_css3.scss
+++ b/govuk/public/sass/_css3.scss
@@ -20,13 +20,17 @@
           box-shadow: $shadow;
 }
 
-@mixin scale($x, $y) {
+@mixin scale($x, $y, $transform-origin: 50% 50% 0) {
   // $x and $y should be numeric values without units
   -webkit-transform: scale($x, $y); // Still in use now, started at: Chrome 4.0, Safari 3.1, Mobile Safari 3.2, Android 2.1
      -moz-transform: scale($x, $y); // Firefox 3.5 to 15.0
       -ms-transform: scale($x, $y); // IE9 only
-       -o-transform: scale($x, $y); // Opera 10.5 to 12.0
           transform: scale($x, $y);
+
+  -webkit-transform-origin: $transform-origin; // Chrome, Safari 3.1
+     -moz-transform-origin: $transform-origin; // Firefox 10 to 15.0
+      -ms-transform-origin: $transform-origin; // IE9
+          transform-origin: $transform-origin;
 }
 
 @mixin translate($x, $y) {

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -113,29 +113,6 @@ function ShowHideContent() {
   }
 }
 
-function setFocus() {
-  var self = this;
-  self.exampleSetFocus = function () {
-
-    // Only set focus for the error example pages
-    if ($(".js-error-example").length) {
-      // If there is an error summary, set focus to the summary
-      if ($(".error-summary").length) {
-        $(".error-summary").focus();
-        $(".error-summary a").click(function(e) {
-          e.preventDefault();
-          var href = $(this).attr("href");
-          $(href).focus();
-        });
-      }
-      // Otherwise, set focus to the field with the error
-      else {
-        $(".error input:first").focus();
-      }
-    }
-  }
-}
-
 $(document).ready(function() {
 
   // Turn off jQuery animation
@@ -154,10 +131,27 @@ $(document).ready(function() {
   var toggleContent = new ShowHideContent();
   toggleContent.showHideRadioToggledContent();
   toggleContent.showHideCheckboxToggledContent();
-
-  // $(window).load(function() { 
-  //   var focusContent = new setFocus();
-  //   focusContent.exampleSetFocus();
-  // });
   
+});
+
+$(window).load(function() { 
+
+  // Only set focus for the error example pages
+  if ($(".js-error-example").length) {
+    
+    // If there is an error summary, set focus to the summary
+    if ($(".error-summary").length) {
+      $(".error-summary").focus();
+      $(".error-summary a").click(function(e) {
+        e.preventDefault();
+        var href = $(this).attr("href");
+        $(href).focus();
+      });
+    }
+    // Otherwise, set focus to the field with the error
+    else {
+      $(".error input:first").focus();
+    }
+  }
+
 });

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -112,6 +112,24 @@ function ShowHideContent() {
   }
 }
 
+function setFocus() {
+  var self = this;
+  self.exampleSetFocus = function () {
+
+    // Only set focus for the error example pages
+    if ($(".error-example").length) {
+      // If there is an error summary, set focus to the summary
+      if ($(".error-summary").length) {
+        $(".error-summary").focus();
+      }
+      // Otherwise, set focus to the field with the error
+      else {
+        $(".error input:first").focus();
+      }
+    }
+  }
+}
+
 $(document).ready(function() {
 
   // Turn off jQuery animation
@@ -130,5 +148,8 @@ $(document).ready(function() {
   var toggleContent = new ShowHideContent();
   toggleContent.showHideRadioToggledContent();
   toggleContent.showHideCheckboxToggledContent();
+
+  var focusContent = new setFocus();
+  focusContent.exampleSetFocus();
 
 });

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -117,10 +117,15 @@ function setFocus() {
   self.exampleSetFocus = function () {
 
     // Only set focus for the error example pages
-    if ($(".error-example").length) {
+    if ($(".js-error-example").length) {
       // If there is an error summary, set focus to the summary
       if ($(".error-summary").length) {
         $(".error-summary").focus();
+        $(".error-summary a").click(function(e) {
+          e.preventDefault();
+          var href = $(this).attr("href");
+          $(href).focus();
+        });
       }
       // Otherwise, set focus to the field with the error
       else {

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -72,6 +72,7 @@ function ShowHideContent() {
 
     });
   }
+
   self.showHideCheckboxToggledContent = function () {
 
     $(".block-label input[type='checkbox']").each(function() {
@@ -154,7 +155,9 @@ $(document).ready(function() {
   toggleContent.showHideRadioToggledContent();
   toggleContent.showHideCheckboxToggledContent();
 
-  var focusContent = new setFocus();
-  focusContent.exampleSetFocus();
-
+  // $(window).load(function() { 
+  //   var focusContent = new setFocus();
+  //   focusContent.exampleSetFocus();
+  // });
+  
 });

--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -40,8 +40,8 @@
   padding-top: em(45, 36);
 }
 
-// Text
-.tight {
+// Use for paragraphs before lists
+.lead-in {
   margin-bottom: 0;
 }
 

--- a/public/sass/elements/_buttons.scss
+++ b/public/sass/elements/_buttons.scss
@@ -7,9 +7,13 @@
 
 .button {
   @include button ($button-colour);
+  @include box-sizing(border-box);
   margin: 0 $gutter-half $gutter-half 0;
   padding: em(10) em(15) em(5) em(15);
   vertical-align: top;
+  @include media (mobile) {
+    width: 100%;
+  }
 }
 
 // Fix unwanted button padding in Firefox

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -70,6 +70,7 @@ fieldset {
   float: left;
   width: 100%;
   @extend %contain-floats;
+  margin: 10px 0 0 0;
 }
 
 

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -12,6 +12,7 @@ fieldset {
 
 // Form group is used to wrap label and input pairs
 .form-group {
+  @include box-sizing(border-box);
   float: left;
   width: 100%;
   @extend %contain-floats;

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -155,13 +155,6 @@ fieldset {
   margin: -2px 5px 0 0;
 }
 
-// Buttons
-.form .button {
-  @include media(mobile) {
-    width: 100%;
-  }
-}
-
 
 // Form validation
 @import "forms/form-validation";

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -54,7 +54,7 @@ fieldset {
 
 .form-label {
   @include core-19;
-  margin-bottom: 5px;
+  // margin-bottom: 5px;
 }
 
 .form-label-bold {
@@ -70,7 +70,10 @@ fieldset {
   float: left;
   width: 100%;
   @extend %contain-floats;
-  margin: 10px 0 0 0;
+  margin-bottom: 5px;
+  @include media(tablet) {
+    margin-top: 10px;
+  }
 }
 
 
@@ -80,6 +83,7 @@ fieldset {
 .form-hint {
   display: block;
   color: $secondary-text-colour;
+  font-weight: normal;
   margin-bottom: 5px;
   @include media (tablet) {
     margin-top: 8px;

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -54,15 +54,14 @@ fieldset {
 
 .form-label {
   @include core-19;
-  // margin-bottom: 5px;
 }
 
 .form-label-bold {
-  @include bold-24;
-  margin-bottom: 0;
-  .form-hint {
-    @include core-19;
-  }
+  @include bold-19;
+}
+
+.form-hint {
+  @include core-19;
 }
 
 // Used for paragraphs in-between form elements
@@ -85,9 +84,6 @@ fieldset {
   color: $secondary-text-colour;
   font-weight: normal;
   margin-bottom: 5px;
-  @include media (tablet) {
-    margin-top: 8px;
-  }
 }
 
 

--- a/public/sass/elements/_helpers.scss
+++ b/public/sass/elements/_helpers.scss
@@ -29,6 +29,7 @@
 .example-back-link {
   @include inline-block;
   margin-top: $gutter;
+  margin-bottom: $gutter*2;
 }
 
 // Hide, but not for screenreaders

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -17,14 +17,10 @@
   border: 1px solid $panel-colour;
   padding: (18px $gutter $gutter-half $gutter*1.5);
   margin-top: 10px;
-  margin-bottom: 10px;
-
   cursor: pointer; // Encourage clicking on block labels
 
   @include media(tablet) {
     float: left;
-    margin-top: 5px;
-    margin-bottom: 5px;
     // width: 25%; - Test : check that text within labels will wrap
   }
 

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -12,8 +12,7 @@ $error-colour: #b10e1e;
   margin-right: 15px;
 
   // Form labels should be red and bold
-  .form-label,
-  .form-label-bold,
+  .error-label,
   .error-message {
     color: $error-colour;
     font-weight: bold;
@@ -53,6 +52,23 @@ legend .error-message {
   padding-bottom: 10px;
   @include media(tablet) {
     padding-bottom: 15px;
+  }
+}
+
+// Duplicate error messages for longer forms
+.error-message-repeat {
+  color: $error-colour !important;
+  font-weight: bold;
+  display: block;
+  clear: both;
+  text-decoration: none;
+  padding-top: 10px;
+  @include media(tablet) {
+    padding-top: 15px;
+  }
+  margin-bottom: 0;
+  &:hover {
+    text-decoration: underline;
   }
 }
 
@@ -98,5 +114,13 @@ legend .error-message {
       text-decoration: underline;
     }
   }
+}
 
+// Show additional messages when JS is enabled
+.js-error {
+  display: none;
+}
+
+.js-enabled .js-error {
+  display: block;
 }

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -27,7 +27,6 @@ $error-colour: #b10e1e;
 
 .error,
 .error-summary {
-
   // Add a red border to the left of the field
   border-left: 5px solid $error-colour;
   padding-left: 10px;
@@ -42,6 +41,7 @@ $error-colour: #b10e1e;
   // Add spacing below error message
   display: block;
   clear: both;
+  margin-top: 0;
   margin-bottom: 0;
   padding-bottom: 5px;
 }
@@ -49,10 +49,10 @@ $error-colour: #b10e1e;
 label .error-message,
 legend .error-message {
 
-  // Add spacing above error message
-  padding-top: 5px;
+  // Add spacing below error message
+  padding-bottom: 10px;
   @include media(tablet) {
-    padding-top: 10px;
+    padding-bottom: 15px;
   }
 }
 
@@ -86,6 +86,7 @@ legend .error-message {
   }
 
   .error-summary-list {
+    padding-left: 0;
     li {
       @include media(tablet) {
         margin-bottom: 5px;

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -77,7 +77,7 @@ legend .error-message {
   }
 
   .error-summary-heading {
-    margin-top: 0;
+    margin-top: 10px;
   }
 
   p {

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -1,68 +1,101 @@
-// Validation summary box
+// Form validation
+// ==========================================================================
 
-@import "colours";
-@import "measurements";
-@import "conditionals";
-@import "typography";
+// Update the error colour in the govuk frontend toolkit
+$error-colour: #b10e1e;
 
-.validation-summary {
-  border: 3px solid $error-colour;
-  padding: $gutter-half $gutter;
-  margin-bottom: $gutter;
+// Using the classname .error as it's shorter than .validation and easier to type!
+.error {
 
-  @include ie-lte(6){
-    zoom: 1;
+  // Ensure the .error class is applied to .form-group, otherwide box-sizing(border-box) will need to be used
+  // @include box-sizing(border-box);
+  margin-right: 15px;
+
+  // Form labels should be red and bold
+  .form-label,
+  .form-label-bold,
+  .error-message {
+    color: $error-colour;
+    font-weight: bold;
+  }
+
+  // Form inputs should have a red border
+  .form-control {
+    border: 4px solid $error-colour;
   }
 }
 
-.validation-summary ul {
-  margin-top: 10px;
-}
+.error,
+.error-summary {
 
-.validation-summary li,
-.validation-summary p {
-  @include core-16;
-}
-
-.validation-summary p {
-  margin-top: $gutter-half;
-  margin-bottom: 5px;
-}
-
-.validation-summary a {
-  color: $error-colour;
-  @include ie-lte(6) {
-    color: $error-colour !important;
+  // Add a red border to the left of the field
+  border-left: 5px solid $error-colour;
+  padding-left: 10px;
+  @include media(tablet) {
+    padding-left: $gutter-half;
   }
 }
 
-.validation-summary .heading-small {
-  margin-top: $gutter-half;
-}
+.error-message {
+  @include core-19;
 
-
-// Validation error message box
-// .validation-error {
-//   clear: both;
-//   @extend %contain-floats;
-//   border-left: 3px solid $error-colour;
-//   padding: $gutter- $gutter;
-//   margin-bottom: $gutter-half;
-//   margin-left: -($gutter);
-// }
-
-// .validation-error .form-group {
-//   margin-bottom: 20px;
-// }
-
-// .validation-error p {
-//   margin-bottom: 10px;
-// }
-
-
-// Validation message
-.validation-message {
+  // Add spacing below error message
   display: block;
-  @include core-16;
-  color: $error-colour;
+  clear: both;
+  margin-bottom: 0;
+  padding-bottom: 5px;
+}
+
+label .error-message,
+legend .error-message {
+
+  // Add spacing above error message
+  padding-top: 5px;
+  @include media(tablet) {
+    padding-top: 10px;
+  }
+}
+
+// Summary of multiple error messages
+.error-summary {
+
+  // Use the GOV.UK outline focus style
+  &:focus {
+    outline: 3px solid $yellow;
+  }
+
+  // Error summary has a border on all sides
+  border: 5px solid $error-colour;
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+  padding: 10px;
+  @include media (tablet) {
+    margin-top: $gutter;
+    margin-bottom: $gutter;
+    padding: $gutter-half;
+  }
+
+  .error-summary-heading {
+    margin-top: 0;
+  }
+
+  p {
+    margin-top: 15px;
+    margin-bottom: 5px;
+  }
+
+  .error-summary-list {
+    li {
+      @include media(tablet) {
+        margin-bottom: 5px;
+      }
+    }
+    a {
+      color: $error-colour;
+      font-weight: bold;
+      text-decoration: underline;
+    }
+  }
+
 }

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -11,8 +11,7 @@ $error-colour: #b10e1e;
   // @include box-sizing(border-box);
   margin-right: 15px;
 
-  // Form labels should be red and bold
-  .error-label,
+  // Error messages should be red and bold
   .error-message {
     color: $error-colour;
     font-weight: bold;

--- a/routes.js
+++ b/routes.js
@@ -26,6 +26,18 @@ module.exports = {
       res.render('examples/forms', {'assetPath' : assetPath });
     });
 
+    app.get('/examples/form-validation-single-question', function (req, res) {
+      res.render('examples/form-validation-single-question', {'assetPath' : assetPath });
+    });
+
+    app.get('/examples/form-validation-single-question-radio', function (req, res) {
+      res.render('examples/form-validation-single-question-radio', {'assetPath' : assetPath });
+    });
+
+    app.get('/examples/form-validation-multiple-questions', function (req, res) {
+      res.render('examples/form-validation-multiple-questions', {'assetPath' : assetPath });
+    });
+
     // GOV.UK elements test pages
 
     // Progressive disclosure pattern

--- a/routes.js
+++ b/routes.js
@@ -30,12 +30,47 @@ module.exports = {
       res.render('examples/form-validation-single-question', {'assetPath' : assetPath });
     });
 
+    app.post('/examples/form-validation-single-question', function(req, res) {
+      var niNumber = req.body.niNumber;
+      var error = false;
+      if (!niNumber) {
+        error = true;
+      } else {
+        error = false;
+      }
+      res.render('examples/form-validation-single-question', {'assetPath' : assetPath, 'niNumber': niNumber, 'error': error});
+    });
+
     app.get('/examples/form-validation-single-question-radio', function (req, res) {
-      res.render('examples/form-validation-single-question-radio', {'assetPath' : assetPath });
+      res.render('examples/form-validation-single-question-radio', {'assetPath' : assetPath});
+    });
+
+    app.post('/examples/form-validation-single-question-radio', function (req, res) {
+      var age = req.body.age19YearsOrOver;
+      var error = false;
+      if (!age) {
+        error = true;
+      } else {
+        error = false;
+      }
+      res.render('examples/form-validation-single-question-radio', {'assetPath' : assetPath, 'age': age, 'error': error});
     });
 
     app.get('/examples/form-validation-multiple-questions', function (req, res) {
       res.render('examples/form-validation-multiple-questions', {'assetPath' : assetPath });
+    });
+
+    app.post('/examples/form-validation-multiple-questions', function(req, res) {
+      var fullName = req.body.fullName;
+      var niNo = req.body.niNo;
+      var error = false;
+      if (!fullName || !niNo) {
+        error = true;
+      }
+      else {
+        error = false;
+      }
+      res.render('examples/form-validation-multiple-questions', {'assetPath' : assetPath, 'fullName': fullName, 'niNo': niNo, 'error': error});
     });
 
     // GOV.UK elements test pages

--- a/routes.js
+++ b/routes.js
@@ -46,14 +46,14 @@ module.exports = {
     });
 
     app.post('/examples/form-validation-single-question-radio', function (req, res) {
-      var age = req.body.age19YearsOrOver;
+      var country = req.body.country;
       var error = false;
-      if (!age) {
+      if (!country) {
         error = true;
       } else {
         error = false;
       }
-      res.render('examples/form-validation-single-question-radio', {'assetPath' : assetPath, 'age': age, 'error': error});
+      res.render('examples/form-validation-single-question-radio', {'assetPath' : assetPath, 'country': country, 'error': error});
     });
 
     app.get('/examples/form-validation-multiple-questions', function (req, res) {

--- a/views/examples/form-validation-multiple-questions.html
+++ b/views/examples/form-validation-multiple-questions.html
@@ -15,7 +15,7 @@
 {{$headerClass}}with-proposition{{/headerClass}}
 
 {{$content}}
-<main id="content" role="main">
+<main class="error-example" id="content" role="main">
 
   <a href="/" class="example-back-link">Back to GOV.UK elements</a>
 

--- a/views/examples/form-validation-multiple-questions.html
+++ b/views/examples/form-validation-multiple-questions.html
@@ -33,7 +33,7 @@
   </form>
 
   <h2 class="heading-medium">Server-side validation</h2>
-  <h3 class="heading-small">When an error occurs</h3>
+  <h3 class="heading-small">When an error occurs:</h3>
   <ul class="list-bullet text">
     <li>
       add a 5px red left border to the field with the error

--- a/views/examples/form-validation-multiple-questions.html
+++ b/views/examples/form-validation-multiple-questions.html
@@ -15,30 +15,65 @@
 {{$headerClass}}with-proposition{{/headerClass}}
 
 {{$content}}
+
+<style>
+  .list-bullet .panel-indent {
+    margin-top: 5px;
+    margin-bottom: 15px;
+    background: #F5F2F0;
+    padding-right: 15px;
+  }
+</style>
 <main class="error-example" id="content" role="main">
 
   <a href="/" class="example-back-link">Back to GOV.UK elements</a>
-
-  <h1 class="heading-large">Error example</h1>
 
   <form method="post" action="/examples/form-validation-multiple-questions">
     {{> form_error_multiple_questions }}
   </form>
 
-  <h2 class="heading-medium">When an error occurs:</h2>
-  <ul class="list-bullet">
+  <h2 class="heading-medium">Server-side validation</h2>
+  <h3 class="heading-small">When an error occurs</h3>
+  <ul class="list-bullet text">
+    <li>add a 5px red left border to the field with the error</li>
     <li>show an error summary at the top of the page</li>
-    <li>keyboard focus should be moved to the start of the summary</li>
-    <li>to move keyboard focus to the summary, put tabindex="-1" on the containing div and use <code>obj.focus()</code></li>
-    <li>to indicate to screen readers that the containing div represents a collection of related information, put <code>role="group"</code> on the containing <code>div</code></li>
-    <li>use a heading in the summary</li>
-    <li>use <code>aria-labelledby</code> to associate the heading with the containing div, so that screen readers will automatically announce the heading as soon as focus is moved to the div</li>
-    <li>link from the error list in the summary to the fields with errors</li>
-    <li>an error message should be shown before each field with an error</li>
-    <li>add an ID to each error message and associate this with the field using <code>aria-describedby</code></li>
-    <li>consider using <code>aria-invalid</code>attribute to programmatically indicate that a field has an error</li>
-    <li>the value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error</a></li>
+    <li>move keyboard focus to the start of the summary
+      <p class="panel-indent">
+        to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
+      </p>
+    </li>
+    <li>
+      indicate to screenreaders that the summary represents a collection of information
+      <p class="panel-indent">
+        add the ARIA <code>role="group"</code> to the containing <code>div</code>
+      </p>
+    </li>
+    <li>
+      use a heading at the top of the summary
+    </li>
+    <li>
+      associate the heading with the summary box
+      <div class="panel-indent">
+        use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
+      </div>
+    </li>
+    <li>
+      link from the error list in the summary to the fields with errors
+    </li>
+    <li>
+      show an error message before each field with an error
+    </li>
+    <li>
+      associate each error message with the corresponding field</li>
+      <div class="panel-indent">
+         add an ID to each error message and associate this with the field using <code>aria-describedby</code>
+      </div>
+    </li>
   </ul>
+
+  <p class="text"> 
+    Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
+  </p>
 
 </main>
 {{/content}}

--- a/views/examples/form-validation-multiple-questions.html
+++ b/views/examples/form-validation-multiple-questions.html
@@ -35,27 +35,32 @@
   <h2 class="heading-medium">Server-side validation</h2>
   <h3 class="heading-small">When an error occurs</h3>
   <ul class="list-bullet text">
-    <li>add a 5px red left border to the field with the error</li>
-    <li>show an error summary at the top of the page</li>
-    <li>move keyboard focus to the start of the summary
-      <p class="panel-indent">
+    <li>
+      add a 5px red left border to the field with the error
+    </li>
+    <li>
+      show an error summary at the top of the page
+    </li>
+    <li>
+      move keyboard focus to the start of the summary
+      <span class="panel-indent">
         to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
-      </p>
+      </span>
     </li>
     <li>
       indicate to screenreaders that the summary represents a collection of information
-      <p class="panel-indent">
+      <span class="panel-indent">
         add the ARIA <code>role="group"</code> to the containing <code>div</code>
-      </p>
+      </span>
     </li>
     <li>
       use a heading at the top of the summary
     </li>
     <li>
       associate the heading with the summary box
-      <p class="panel-indent">
+      <span class="panel-indent">
         use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
-      </p>
+      </span>
     </li>
     <li>
       link from the error list in the summary to the fields with errors
@@ -64,10 +69,10 @@
       show an error message before each field with an error
     </li>
     <li>
-      associate each error message with the corresponding field</li>
-      <p class="panel-indent">
+      associate each error message with the corresponding field
+      <span class="panel-indent">
          add an ID to each error message and associate this with the field using <code>aria-describedby</code>
-      </p>
+      </span>
     </li>
   </ul>
 

--- a/views/examples/form-validation-multiple-questions.html
+++ b/views/examples/form-validation-multiple-questions.html
@@ -53,9 +53,9 @@
     </li>
     <li>
       associate the heading with the summary box
-      <div class="panel-indent">
+      <p class="panel-indent">
         use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
-      </div>
+      </p>
     </li>
     <li>
       link from the error list in the summary to the fields with errors
@@ -65,9 +65,9 @@
     </li>
     <li>
       associate each error message with the corresponding field</li>
-      <div class="panel-indent">
+      <p class="panel-indent">
          add an ID to each error message and associate this with the field using <code>aria-describedby</code>
-      </div>
+      </p>
     </li>
   </ul>
 

--- a/views/examples/form-validation-multiple-questions.html
+++ b/views/examples/form-validation-multiple-questions.html
@@ -24,7 +24,7 @@
     padding-right: 15px;
   }
 </style>
-<main class="error-example" id="content" role="main">
+<main class="js-error-example" id="content" role="main">
 
   <a href="/" class="example-back-link">Back to GOV.UK elements</a>
 

--- a/views/examples/form-validation-multiple-questions.html
+++ b/views/examples/form-validation-multiple-questions.html
@@ -28,10 +28,16 @@
   <h2 class="heading-medium">When an error occurs:</h2>
   <ul class="list-bullet">
     <li>show an error summary at the top of the page</li>
-    <li>use a heading in the summary, which is associated with the summary container using <code>aria-labelledby</code></li>
+    <li>keyboard focus should be moved to the start of the summary</li>
+    <li>to move keyboard focus to the summary, put tabindex="-1" on the containing div and use <code>obj.focus()</code></li>
+    <li>to indicate to screen readers that the containing div represents a collection of related information, put <code>role="group"</code> on the containing <code>div</code></li>
+    <li>use a heading in the summary</li>
+    <li>use <code>aria-labelledby</code> to associate the heading with the containing div, so that screen readers will automatically announce the heading as soon as focus is moved to the div</li>
     <li>link from the error list in the summary to the fields with errors</li>
     <li>an error message should be shown before each field with an error</li>
     <li>add an ID to each error message and associate this with the field using <code>aria-describedby</code></li>
+    <li>consider using <code>aria-invalid</code>attribute to programmatically indicate that a field has an error</li>
+    <li>the value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error</a></li>
   </ul>
 
 </main>

--- a/views/examples/form-validation-multiple-questions.html
+++ b/views/examples/form-validation-multiple-questions.html
@@ -1,0 +1,44 @@
+{{<govuk_template}}
+
+{{$cookieMessage}}
+  {{>cookie_message}}
+{{/cookieMessage}}
+
+{{$head}}
+  {{>head}}
+{{/head}}
+
+{{$propositionHeader}}
+  {{>propositional_navigation}}
+{{/propositionHeader}}
+
+{{$headerClass}}with-proposition{{/headerClass}}
+
+{{$content}}
+<main id="content" role="main">
+
+  <a href="/" class="example-back-link">Back to GOV.UK elements</a>
+
+  <h1 class="heading-large">Error example</h1>
+
+  <form method="post" action="/examples/form-validation-multiple-questions">
+    {{> form_error_multiple_questions }}
+  </form>
+
+  <h2 class="heading-medium">When an error occurs:</h2>
+  <ul class="list-bullet">
+    <li>show an error summary at the top of the page</li>
+    <li>use a heading in the summary, which is associated with the summary container using <code>aria-labelledby</code></li>
+    <li>link from the error list in the summary to the fields with errors</li>
+    <li>an error message should be shown before each field with an error</li>
+    <li>add an ID to each error message and associate this with the field using <code>aria-describedby</code></li>
+  </ul>
+
+</main>
+{{/content}}
+
+{{$bodyEnd}}
+  {{>scripts}}
+{{/bodyEnd}}
+
+{{/govuk_template}}

--- a/views/examples/form-validation-multiple-questions.html
+++ b/views/examples/form-validation-multiple-questions.html
@@ -18,6 +18,7 @@
 
 <style>
   .list-bullet .panel-indent {
+    display: block;
     margin-top: 5px;
     margin-bottom: 15px;
     background: #F5F2F0;
@@ -32,8 +33,7 @@
     {{> form_error_multiple_questions }}
   </form>
 
-  <h2 class="heading-medium">Server-side validation</h2>
-  <h3 class="heading-small">When an error occurs:</h3>
+  <h2 class="heading-small">When an error occurs:</h2>
   <ul class="list-bullet text">
     <li>
       add a 5px red left border to the field with the error

--- a/views/examples/form-validation-single-question-radio.html
+++ b/views/examples/form-validation-single-question-radio.html
@@ -15,7 +15,7 @@
 {{$headerClass}}with-proposition{{/headerClass}}
 
 {{$content}}
-<main id="content" role="main">
+<main class="error-example" id="content" role="main">
 
   <a href="/" class="example-back-link">Back to GOV.UK elements</a>
 

--- a/views/examples/form-validation-single-question-radio.html
+++ b/views/examples/form-validation-single-question-radio.html
@@ -24,9 +24,8 @@
   </form>
   
   <h2 class="heading-medium">Server-side validation</h2>
-  <h3 class="heading-small">When an error occurs</h3>
+  <h3 class="heading-small">When an error occurs:</h3>
   <ul class="list-bullet">
-    <li>the <code>&lt;label&gt;</code> must be red and bold</li>
     <li>add a 5px red left border to the field with the error</li>
     <li>the error message be red and bold and appear above the question</li>
     <li>the error message must sit inside the <code>&lt;legend&gt;</code></li>

--- a/views/examples/form-validation-single-question-radio.html
+++ b/views/examples/form-validation-single-question-radio.html
@@ -1,0 +1,43 @@
+{{<govuk_template}}
+
+{{$cookieMessage}}
+  {{>cookie_message}}
+{{/cookieMessage}}
+
+{{$head}}
+  {{>head}}
+{{/head}}
+
+{{$propositionHeader}}
+  {{>propositional_navigation}}
+{{/propositionHeader}}
+
+{{$headerClass}}with-proposition{{/headerClass}}
+
+{{$content}}
+<main id="content" role="main">
+
+  <a href="/" class="example-back-link">Back to GOV.UK elements</a>
+
+  <h1 class="heading-large">Error example</h1>
+
+  <form method="post" action="/examples/form-validation-single-question-radio">
+    {{> form_error_single_question_radio }}
+  </form>
+
+  <h2 class="heading-medium">When an error occurs:</h2>
+  <ul class="list-bullet">
+    <li>add a red left border to the field with the error</li>
+    <li>the label should be red and bold</li>
+    <li>the error message should appear above the field</li>
+    <li>the error message should appear inside the <code>&lt;legend&gt;</code></li>
+  </ul>
+
+</main>
+{{/content}}
+
+{{$bodyEnd}}
+  {{>scripts}}
+{{/bodyEnd}}
+
+{{/govuk_template}}

--- a/views/examples/form-validation-single-question-radio.html
+++ b/views/examples/form-validation-single-question-radio.html
@@ -15,7 +15,7 @@
 {{$headerClass}}with-proposition{{/headerClass}}
 
 {{$content}}
-<main class="error-example" id="content" role="main">
+<main class="js-error-example" id="content" role="main">
 
   <a href="/" class="example-back-link">Back to GOV.UK elements</a>
   

--- a/views/examples/form-validation-single-question-radio.html
+++ b/views/examples/form-validation-single-question-radio.html
@@ -27,10 +27,13 @@
 
   <h2 class="heading-medium">When an error occurs:</h2>
   <ul class="list-bullet">
-    <li>add a red left border to the field with the error</li>
-    <li>the label should be red and bold</li>
-    <li>the error message should appear above the field</li>
-    <li>the error message should appear inside the <code>&lt;legend&gt;</code></li>
+    <li>add a 5px red left border to the field with the error</li>
+    <li>the <code>label</code> should be red and bold</li>
+    <li>the error message be red and bold and appear above the field</li>
+    <li>the error message should sit inside the <code>&lt;legend&gt;</code></li>
+    <li>keyboard focus should be moved to the first radio button</li>
+    <li>consider using <code>aria-invalid</code> attribute to programmatically indicate that a field has an error</li>
+    <li>the value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error</a></li>
   </ul>
 
 </main>

--- a/views/examples/form-validation-single-question-radio.html
+++ b/views/examples/form-validation-single-question-radio.html
@@ -35,11 +35,6 @@
     Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
   </p>
   
-  <h2 class="heading-medium">Additional client-side validation</h2>
-  <p class="text">
-    For longer sets of questions, if the page isn't refreshed - consider adding a duplicate error message, which sits above the continue button.
-  </p>
-
 </main>
 {{/content}}
 

--- a/views/examples/form-validation-single-question-radio.html
+++ b/views/examples/form-validation-single-question-radio.html
@@ -25,17 +25,17 @@
     {{> form_error_single_question_radio }}
   </form>
 
-  <h2 class="heading-medium">When an error occurs:</h2>
+  <h2 class="heading-medium">When an error occurs</h2>
   <ul class="list-bullet">
+    <li>the <code>&lt;label&gt;</code> should be red and bold</li>
     <li>add a 5px red left border to the field with the error</li>
-    <li>the <code>label</code> should be red and bold</li>
     <li>the error message be red and bold and appear above the field</li>
-    <li>the error message should sit inside the <code>&lt;legend&gt;</code></li>
-    <li>keyboard focus should be moved to the first radio button</li>
-    <li>consider using <code>aria-invalid</code> attribute to programmatically indicate that a field has an error</li>
-    <li>the value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error</a></li>
+    <li>the error message must sit inside the <code>&lt;legend&gt;</code></li>
+    <li>keyboard focus must be moved to the first radio button</li>
   </ul>
-
+  <p class="text">
+    Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
+  </p>
 </main>
 {{/content}}
 

--- a/views/examples/form-validation-single-question-radio.html
+++ b/views/examples/form-validation-single-question-radio.html
@@ -23,8 +23,7 @@
     {{> form_error_single_question_radio }}
   </form>
   
-  <h2 class="heading-medium">Server-side validation</h2>
-  <h3 class="heading-small">When an error occurs:</h3>
+  <h2 class="heading-small">When an error occurs:</h2>
   <ul class="list-bullet">
     <li>add a 5px red left border to the field with the error</li>
     <li>the error message be red and bold and appear above the question</li>

--- a/views/examples/form-validation-single-question-radio.html
+++ b/views/examples/form-validation-single-question-radio.html
@@ -18,24 +18,29 @@
 <main class="error-example" id="content" role="main">
 
   <a href="/" class="example-back-link">Back to GOV.UK elements</a>
-
-  <h1 class="heading-large">Error example</h1>
-
+  
   <form method="post" action="/examples/form-validation-single-question-radio">
     {{> form_error_single_question_radio }}
   </form>
-
-  <h2 class="heading-medium">When an error occurs</h2>
+  
+  <h2 class="heading-medium">Server-side validation</h2>
+  <h3 class="heading-small">When an error occurs</h3>
   <ul class="list-bullet">
-    <li>the <code>&lt;label&gt;</code> should be red and bold</li>
+    <li>the <code>&lt;label&gt;</code> must be red and bold</li>
     <li>add a 5px red left border to the field with the error</li>
-    <li>the error message be red and bold and appear above the field</li>
+    <li>the error message be red and bold and appear above the question</li>
     <li>the error message must sit inside the <code>&lt;legend&gt;</code></li>
-    <li>keyboard focus must be moved to the first radio button</li>
+    <li>keyboard focus must be moved to the first radio button in the fieldset</li>
   </ul>
   <p class="text">
     Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
   </p>
+  
+  <h2 class="heading-medium">Additional client-side validation</h2>
+  <p class="text">
+    For longer sets of questions, if the page isn't refreshed - consider adding a duplicate error message, which sits above the continue button.
+  </p>
+
 </main>
 {{/content}}
 

--- a/views/examples/form-validation-single-question.html
+++ b/views/examples/form-validation-single-question.html
@@ -15,7 +15,7 @@
 {{$headerClass}}with-proposition{{/headerClass}}
 
 {{$content}}
-<main id="content" role="main">
+<main class="error-example" id="content" role="main">
 
   <a href="/" class="example-back-link">Back to GOV.UK elements</a>
 

--- a/views/examples/form-validation-single-question.html
+++ b/views/examples/form-validation-single-question.html
@@ -15,7 +15,7 @@
 {{$headerClass}}with-proposition{{/headerClass}}
 
 {{$content}}
-<main class="error-example" id="content" role="main">
+<main class="js-error-example" id="content" role="main">
 
   <a href="/" class="example-back-link">Back to GOV.UK elements</a>
   

--- a/views/examples/form-validation-single-question.html
+++ b/views/examples/form-validation-single-question.html
@@ -32,11 +32,20 @@
     <li>the error message must sit inside the <code>&lt;label&gt;</code></li>
     <li>keyboard focus must be moved to the input</li>
   </ul>
-
-  <p class="text">
-    Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
-  </p>
-
+  
+  <div class="text">
+    <p class="text">
+      Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
+    </p>
+    <h3 class="heading-medium">For pages with content above the question</h3>
+    <p>
+      If there is lots of content above the question on the page, it may be useful to also show a summary box at the top of the page.
+      with a link to correct the error. 
+    </p>
+    <p>
+      <a href="/Link to multiple questions example.">View an example with a summary box</a>
+    </p>
+  </div>
 </main>
 {{/content}}
 

--- a/views/examples/form-validation-single-question.html
+++ b/views/examples/form-validation-single-question.html
@@ -1,0 +1,43 @@
+{{<govuk_template}}
+
+{{$cookieMessage}}
+  {{>cookie_message}}
+{{/cookieMessage}}
+
+{{$head}}
+  {{>head}}
+{{/head}}
+
+{{$propositionHeader}}
+  {{>propositional_navigation}}
+{{/propositionHeader}}
+
+{{$headerClass}}with-proposition{{/headerClass}}
+
+{{$content}}
+<main id="content" role="main">
+
+  <a href="/" class="example-back-link">Back to GOV.UK elements</a>
+
+  <h1 class="heading-large">Error example</h1>
+
+  <form method="post" action="/examples/form-validation-single-question">
+    {{> form_error_single_question }}
+  </form>
+
+  <h2 class="heading-medium">When an error occurs:</h2>
+  <ul class="list-bullet">
+    <li>add a red left border to the field with the error</li>
+    <li>the label should be red and bold</li>
+    <li>the error message should appear above the field</li>
+    <li>the error message should appear inside the <code>&lt;label&gt;</code></li>
+  </ul>
+
+</main>
+{{/content}}
+
+{{$bodyEnd}}
+  {{>scripts}}
+{{/bodyEnd}}
+
+{{/govuk_template}}

--- a/views/examples/form-validation-single-question.html
+++ b/views/examples/form-validation-single-question.html
@@ -19,7 +19,7 @@
 
   <a href="/" class="example-back-link">Back to GOV.UK elements</a>
 
-  <h1 class="heading-large">Error example</h1>
+  <h1 class="heading-large">Example: one question per page</h1>
 
   <form method="post" action="/examples/form-validation-single-question">
     {{> form_error_single_question }}
@@ -28,14 +28,15 @@
   <h2 class="heading-medium">When an error occurs:</h2>
   <ul class="list-bullet">
     <li>add a 5px red left border to the field with the error</li>
-    <li>the <code>label</code> should be red and bold</li>
-    <li>the error message be red and bold and appear above the field</li>
-    <li>the error message should sit inside the <code>&lt;label&gt;</code></li>
-    <li>keyboard focus should be moved to the input</li>
-    <li>consider using <code>aria-invalid</code> attribute to programmatically indicate that a field has an error</li>
-    <li>the value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error</a></li>
+    <li>the <code>&lt;label&gt;</code> must be red and bold</li>
+    <li>the error message must be red and bold and appear above the field</li>
+    <li>the error message must sit inside the <code>&lt;label&gt;</code></li>
+    <li>keyboard focus must be moved to the input</li>
   </ul>
-  </ul>
+  
+  <p class="text">
+    Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
+  </p>
 
 </main>
 {{/content}}

--- a/views/examples/form-validation-single-question.html
+++ b/views/examples/form-validation-single-question.html
@@ -24,11 +24,10 @@
   </form>
 
   <h2 class="heading-medium">Server-side validation</h2>
-  <h3 class="heading-small">When an error occurs</h3>
+  <h3 class="heading-small">When an error occurs:</h3>
   <ul class="list-bullet">
     <li>add a 5px red left border to the field with the error</li>
-    <li>the <code>&lt;label&gt;</code> must be red and bold</li>
-    <li>the error message must be red and bold and appear above the field</li>
+    <li>the error message be red and bold and appear above the question</li>
     <li>the error message must sit inside the <code>&lt;label&gt;</code></li>
     <li>keyboard focus must be moved to the input</li>
   </ul>

--- a/views/examples/form-validation-single-question.html
+++ b/views/examples/form-validation-single-question.html
@@ -31,19 +31,10 @@
     <li>the error message must sit inside the <code>&lt;label&gt;</code></li>
     <li>keyboard focus must be moved to the input</li>
   </ul>
+  <p class="text">
+    Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
+  </p>
   
-  <div class="text">
-    <p class="text">
-      Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
-    </p>
-    <h3 class="heading-medium">For pages with content above the question</h3>
-    <p>
-      If there is lots of content above the question on the page, it may be useful to also show a summary box at the top of the page.
-      with a link to correct the error. 
-    </p>
-    <p>
-      <a href="/Link to multiple questions example.">View an example with a summary box</a>
-    </p>
   </div>
 </main>
 {{/content}}

--- a/views/examples/form-validation-single-question.html
+++ b/views/examples/form-validation-single-question.html
@@ -27,10 +27,14 @@
 
   <h2 class="heading-medium">When an error occurs:</h2>
   <ul class="list-bullet">
-    <li>add a red left border to the field with the error</li>
-    <li>the label should be red and bold</li>
-    <li>the error message should appear above the field</li>
-    <li>the error message should appear inside the <code>&lt;label&gt;</code></li>
+    <li>add a 5px red left border to the field with the error</li>
+    <li>the <code>label</code> should be red and bold</li>
+    <li>the error message be red and bold and appear above the field</li>
+    <li>the error message should sit inside the <code>&lt;label&gt;</code></li>
+    <li>keyboard focus should be moved to the input</li>
+    <li>consider using <code>aria-invalid</code> attribute to programmatically indicate that a field has an error</li>
+    <li>the value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error</a></li>
+  </ul>
   </ul>
 
 </main>

--- a/views/examples/form-validation-single-question.html
+++ b/views/examples/form-validation-single-question.html
@@ -22,9 +22,8 @@
   <form method="post" action="/examples/form-validation-single-question">
     {{> form_error_single_question }}
   </form>
-
-  <h2 class="heading-medium">Server-side validation</h2>
-  <h3 class="heading-small">When an error occurs:</h3>
+  
+  <h2 class="heading-small">When an error occurs:</h2>
   <ul class="list-bullet">
     <li>add a 5px red left border to the field with the error</li>
     <li>the error message be red and bold and appear above the question</li>
@@ -35,7 +34,6 @@
     Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
   </p>
   
-  </div>
 </main>
 {{/content}}
 

--- a/views/examples/form-validation-single-question.html
+++ b/views/examples/form-validation-single-question.html
@@ -18,14 +18,13 @@
 <main class="error-example" id="content" role="main">
 
   <a href="/" class="example-back-link">Back to GOV.UK elements</a>
-
-  <h1 class="heading-large">Example: one question per page</h1>
-
+  
   <form method="post" action="/examples/form-validation-single-question">
     {{> form_error_single_question }}
   </form>
 
-  <h2 class="heading-medium">When an error occurs:</h2>
+  <h2 class="heading-medium">Server-side validation</h2>
+  <h3 class="heading-small">When an error occurs</h3>
   <ul class="list-bullet">
     <li>add a 5px red left border to the field with the error</li>
     <li>the <code>&lt;label&gt;</code> must be red and bold</li>
@@ -33,7 +32,7 @@
     <li>the error message must sit inside the <code>&lt;label&gt;</code></li>
     <li>keyboard focus must be moved to the input</li>
   </ul>
-  
+
   <p class="text">
     Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
   </p>

--- a/views/index.html
+++ b/views/index.html
@@ -975,9 +975,6 @@
 
     <h2 class="heading-large heading-with-border">8. Errors and validation</h2>
     <div class="text">
-      <p>
-         Form validation must identify all errors. 
-      </p>
       <h3 class="heading-medium">If the page has one question with an error</h3>
       <p class="lead-in">
         You must:
@@ -1010,14 +1007,14 @@
     </div>
     
     <p class="text">
-    Use the <code>$error-colour</code> Sass variable &ndash; find this in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_colours.scss">colours.scss</a> file
+      For red, use the <code>$error-colour</code> Sass variable &ndash; find this in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_colours.scss">colours.scss</a> file
     </p>
 
     <!-- Single question radio example -->
     
     <div class="text">
-      <h3 class="heading-medium">If the page has more than one question with errors</h3>
-      <p class="lead-in">You need to:</p>
+      <h3 class="heading-medium">If the page has more than one question</h3>
+      <p class="lead-in">You must:</p>
       <ul class="list-bullet">
         <li>show an error summary at the top of the page</li>
         <li>include a heading to alert the user to the error</li>
@@ -1068,6 +1065,13 @@
       </div>
 
       <input class="button" type="submit" value="Continue">
+    </div>
+
+    <div class="text">
+      <h3 class="heading-medium">If the page has more than one error</h3>
+      <p>
+        If users are making more than one error on a page, this is a strong indication that your page has too many questions. Iterate the page to make it simpler. 
+      </p>
     </div>
 
     <!--

--- a/views/index.html
+++ b/views/index.html
@@ -1049,7 +1049,7 @@
           Message to alert the user to a problem goes here
         </h3>
         <ul class="error-summary-list">
-          <li><a href="#full-name">A link to a question with a problem</a></li>
+          <li><a href="#full-name">A link to the first question with a problem</a></li>
           <li><a href="#ni-number">A link to the second question with a problem</a></li>
         </ul>
       </div>

--- a/views/index.html
+++ b/views/index.html
@@ -978,7 +978,7 @@
       <p>
          Form validation must identify all errors. 
       </p>
-      <h3 class="heading-medium">If the page has just one question, and that question has an error</h3>
+      <h3 class="heading-medium">If the page has one question with an error</h3>
       <p class="lead-in">
         You must:
       </p>
@@ -1016,29 +1016,16 @@
     <!-- Single question radio example -->
     
     <div class="text">
-      <h3 class="heading-medium">If the page has more than one question, and one question has an error</h3>
-      <p class="lead-in">You need both:</p>
+      <h3 class="heading-medium">If the page has more than one question with errors</h3>
+      <p class="lead-in">You need to:</p>
       <ul class="list-bullet">
-        <li>an error message for the problematic question, as described above</li>
-        <li>an error summary</li>
+        <li>show an error summary at the top of the page</li>
+        <li>include a heading to alert the user to the error</li>
+        <li>link to each of the problematic questions</li>
       </ul>
-
       <h4 class="heading-small panel-indent">
         The error summary must appear at the top of the page, so it is visible when the page is refreshed and is immediately read out by assistive technology.
       </h4>
-      
-      <p class="lead-in">The error summary must include:</p>
-      <ul class="list-bullet">
-        <li>a heading to alert the user to the error</li>
-        <li>a list of all the errors, each of which is a link to the corresponding question</li>
-      </ul>
-    
-      <h3 class="heading-medium">If the page has more than one question, and more than one question has an error</h3>
-      <p class="lead-in">You need to add to the error summary:</p>
-      <ul class="list-bullet">
-        <li>a message to alert the user to all the errors</li>
-        <li>a link to each of the problematic questions</li>
-      </ul>
     </div>
 
     <!-- Multiple questions and summary example -->
@@ -1082,7 +1069,7 @@
 
       <input class="button" type="submit" value="Continue">
     </div>
-    
+
     <!--
     <h3 class="heading-medium" id="error-message-examples">Examples</h3>
     <ul class="list-bullet text">

--- a/views/index.html
+++ b/views/index.html
@@ -1036,11 +1036,11 @@
     <div class="example example-error">
 
       <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1" style="">
-        <h3 class="heading-medium error-summary-heading" id="error-summary-heading">There was a problem submitting the form</h3>
-        <p>Please try the following:</p>
+        <h3 class="heading-medium error-summary-heading" id="error-summary-heading">There's a problem</h3>
+        <p>Check your information. You must:</p>
         <ul class="error-summary-list">
-          <li><a href="#full-name">Enter your full name</a></li>
-          <li><a href="#ni-number">Enter your National Insurance number</a></li>
+          <li><a href="#full-name">enter your full name</a></li>
+          <li><a href="#ni-number">enter your National Insurance number</a></li>
         </ul>
       </div>
 
@@ -1053,8 +1053,8 @@
           Full name
           <span class="form-hint">As shown on your birth certificate or passport</span>
         </label>
-        <p class="error-message" id="error-full-name">Enter your
-          Full name
+        <p class="error-message" id="error-full-name">
+          Enter your full name
         </p>
         <input type="text" class="form-control" id="full-name" aria-describedby="error-full-name">
       </div>
@@ -1068,8 +1068,8 @@
             For example, 'VO 12 34 56 D'.
           </span>
         </label>
-        <p class="error-message" id="error-ni-number">Enter your
-          National Insurance number
+        <p class="error-message" id="error-ni-number">
+          Enter your National Insurance number
         </p>
         <input type="text" class="form-control" id="ni-number" aria-describedby="error-ni-number">
       </div>

--- a/views/index.html
+++ b/views/index.html
@@ -975,7 +975,10 @@
 
     <h2 class="heading-large heading-with-border">8. Errors and validation</h2>
     <div class="text">
-      <h3 class="heading-medium">If the page has one question with an error</h3>
+      <p>
+        The simplest page is a short page with a single question, where the error message will be immediately visible when the page is refreshed. 
+      </p>
+      <h3 class="heading-medium">If the page has one question</h3>
       <p class="lead-in">
         You must:
       </p>
@@ -1010,7 +1013,9 @@
       For red, use the <code>$error-colour</code> Sass variable &ndash; find this in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_colours.scss">colours.scss</a> file
     </p>
 
-    <!-- Single question radio example -->
+    <p>
+      If the page is more complex, it may be useful to also include a summary box at the top of the page.
+    </p>
     
     <div class="text">
       <h3 class="heading-medium">If the page has more than one question</h3>

--- a/views/index.html
+++ b/views/index.html
@@ -974,93 +974,102 @@
   <div id="guide-errors">
 
     <h2 class="heading-large heading-with-border">8. Errors and validation</h2>
-    <p class="text">
-      Form validation should identify all errors, ensuring error copy is specific to the question.
-    </p>
+    <div class="text">
+      <p>
+         Form validation must identify all errors. 
+      </p>
+      <h3 class="heading-medium">If the page has just one question, and that question has an error</h3>
+      <p class="lead-in">
+        You must:
+      </p>
+      <ul class="list-bullet">
+        <li>write a message that helps the user to understand why the error occurred and what to do about it</li>
+        <li>put the message in the <code>&lt;label&gt;</code> for the question, before the question text, in red</li>
+        <li>use a red border to visually connect the message and the question it belongs to</li>
+        <li>apply the same colour to the area of the form where an error has occurred</li>
+      </ul>
+    </div>
 
-    <h3 class="heading-medium" id="error-messages">Error messages</h3>
-    <ul class="list-bullet text">
-      <li>use a red border on the box to visually connect the errors and messages in the form</li>
-      <li>apply the same colour to the area of the form where an error has occurred</li>
-      <li>errors should not cause pre-filled fields to clear</li>
-    </ul>
-
-    <!-- <div class="example example-error">
-
+    <!-- Single question example -->
+    <div class="example example-error">
       <div class="form-group error">
-        <label class="form-label-bold" for="ni-no">
+        <label class="form-label-bold" for="error-example-ni-number">
+          <span class="error-message">Error message goes here</span>
+          
           What is your National Insurance number?
           <span class="form-hint">
             It's on your National Insurance card, benefit letter, payslip or P60.
             <br>
             For example, 'VO 12 34 56 D'.
           </span>
-          <span class="error-message">Enter your National Insurance number</span>
+          
         </label>
-        <input type="text" class="form-control" id="ni-no">
+        <input type="text" class="form-control" id="error-example-ni-number" name="niNumber" value="">
       </div>
       <input class="button" type="submit" value="Continue">
-
-    </div> -->
-
-    <!-- <div class="example example-error">
-
-      <div class="form-group error">
-        <fieldset class="inline">
-          <legend class="form-label-bold">
-            Are you 19 or over?
-            <span class="error-message">Please answer the question</span>
-          </legend>
-          <label class="block-label" for="age-yes">
-            <input id="age-yes" name="age19YearsOrOver" value="true" type="radio">
-              <span></span>Yes
-          </label>
-          <label class="block-label" for="age-no">
-            <input id="age-no" name="age19YearsOrOver" value="false" type="radio">
-              <span></span>No
-          </label>
-        </fieldset>
-      </div>
-      <input class="button" type="submit" value="Continue">
-
-    </div> -->
-
-    <h3 class="heading-medium">Error summary</h3>
+    </div>
+    
     <p class="text">
-      An error summary is recommended if your form has more than one question per page. This summary should contain a heading - indicating there are errors and also a list of all the errors, each of which is a link to the corresponding field.
-    </p>
-    <p class="text">
-      The error summary should appear at the top of the page, so it is visible when the page is refreshed and is immediately read out by assistive technology.
+    Use the <code>$error-colour</code> Sass variable &ndash; find this in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_colours.scss">colours.scss</a> file
     </p>
 
-    <!-- <div class="example example-error">
+    <!-- Single question radio example -->
+    
+    <div class="text">
+      <h3 class="heading-medium">If the page has more than one question, and one question has an error</h3>
+      <p class="lead-in">You need both:</p>
+      <ul class="list-bullet">
+        <li>an error message for the problematic question, as described above</li>
+        <li>an error summary</li>
+      </ul>
 
-      <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1" style="">
-        <h3 class="heading-medium error-summary-heading" id="error-summary-heading">There's a problem</h3>
-        <p>Check your information. You must:</p>
+      <h4 class="heading-small panel-indent">
+        The error summary must appear at the top of the page, so it is visible when the page is refreshed and is immediately read out by assistive technology.
+      </h4>
+      
+      <p class="lead-in">The error summary must include:</p>
+      <ul class="list-bullet">
+        <li>a heading to alert the user to the error</li>
+        <li>a list of all the errors, each of which is a link to the corresponding question</li>
+      </ul>
+    
+      <h3 class="heading-medium">If the page has more than one question, and more than one question has an error</h3>
+      <p class="lead-in">You need to add to the error summary:</p>
+      <ul class="list-bullet">
+        <li>a message to alert the user to all the errors</li>
+        <li>a link to each of the problematic questions</li>
+      </ul>
+    </div>
+
+    <!-- Multiple questions and summary example -->
+    <div class="example example-error">
+      
+      <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
+        <h3 class="heading-medium error-summary-heading" id="error-summary-heading">
+          Message to alert the user to a problem goes here
+        </h3>
         <ul class="error-summary-list">
-          <li><a href="#full-name">enter your full name</a></li>
-          <li><a href="#ni-number">enter your National Insurance number</a></li>
+          <li><a href="#full-name">A link to a question with a problem</a></li>
+          <li><a href="#ni-number">A link to the second question with a problem</a></li>
         </ul>
       </div>
-
+      
       <h1 class="form-title heading-large">
         Your details
       </h1>
 
       <div class="form-group error">
         <label class="form-label-bold" for="full-name">
+          <span class="error-message" id="error-full-name">Error message for first question goes here</span>
           Full name
           <span class="form-hint">As shown on your birth certificate or passport</span>
         </label>
-        <p class="error-message" id="error-full-name">
-          Enter your full name
-        </p>
-        <input type="text" class="form-control" id="full-name" aria-describedby="error-full-name">
+        <input type="text" class="form-control" id="full-name" name="fullName" value="" aria-describedby="error-full-name">
       </div>
 
       <div class="form-group error">
-        <label class="form-label-bold" for="ni-no-example">
+        <label class="form-label-bold" for="error-example-ni-number-2">
+          <span class="error-message" id="error-ni-number">Error message for second question goes here</span>
           National Insurance number
           <span class="form-hint">
             It's on your National Insurance card, benefit letter, payslip or P60.
@@ -1068,34 +1077,32 @@
             For example, 'VO 12 34 56 D'.
           </span>
         </label>
-        <p class="error-message" id="error-ni-no-example">
-          Enter your National Insurance number
-        </p>
-        <input type="text" class="form-control" id="ni-no-example" aria-describedby="error-ni-no-example">
+        <input type="text" class="form-control" id="error-example-ni-number-2" name="niNo" value="" aria-describedby="error-ni-number">
       </div>
 
       <input class="button" type="submit" value="Continue">
-
-    </div> -->
-
-    <h3 class="heading-medium" id="error-message-examples">Error message examples</h3>
+    </div>
+    
+    <!--
+    <h3 class="heading-medium" id="error-message-examples">Examples</h3>
     <ul class="list-bullet text">
       <li>
         <a href="{{ site.baseurl}}/examples/form-validation-single-question">
-          An example form with a single text input
+          Example with one question, a single text input
         </a>
       </li>
       <li>
         <a href="{{ site.baseurl}}/examples/form-validation-single-question-radio">
-          An example form with a radio button
+          Example with one question, a group of radio buttons
         </a>
       </li>
       <li>
         <a href="{{ site.baseurl}}/examples/form-validation-multiple-questions">
-          An example form with an error summary at the top of the page
+          Example with multiple questions, with an error summary at the top of the page
         </a>
       </li>
     </ul>
+    -->
 
     <p>
       <a href="https://designpatterns.hackpad.com/Error-messaging-and-validation-HiGXPZ7XiG0" rel="external">Discuss errors on our Hackpad</a>

--- a/views/index.html
+++ b/views/index.html
@@ -1077,7 +1077,7 @@
       </p>
     </div>
 
-    <!--
+    
     <h3 class="heading-medium" id="error-message-examples">Examples</h3>
     <ul class="list-bullet text">
       <li>
@@ -1085,6 +1085,7 @@
           Example with one question, a single text input
         </a>
       </li>
+    <!--
       <li>
         <a href="{{ site.baseurl}}/examples/form-validation-single-question-radio">
           Example with one question, a group of radio buttons
@@ -1095,9 +1096,9 @@
           Example with multiple questions, with an error summary at the top of the page
         </a>
       </li>
+      -->
     </ul>
-    -->
-
+    
     <p>
       <a href="https://designpatterns.hackpad.com/Error-messaging-and-validation-HiGXPZ7XiG0" rel="external">Discuss errors on our Hackpad</a>
     </p>

--- a/views/index.html
+++ b/views/index.html
@@ -989,7 +989,7 @@
         <li>write a message that helps the user to understand why the error occurred and what to do about it</li>
         <li>put the message in the <code>&lt;label&gt;</code> for the question, before the question text, in red</li>
         <li>use a red border to visually connect the message and the question it belongs to</li>
-        <li>apply the same colour to the area of the form where an error has occurred</li>
+        <li>if the error relates to specific text fields within the question, give these a red border as well</li>
       </ul>
     </div>
 

--- a/views/index.html
+++ b/views/index.html
@@ -975,12 +975,15 @@
 
     <h2 class="heading-large heading-with-border">8. Errors and validation</h2>
     <div class="text">
+      
+      <h3 class="heading-medium">Minimise the number of errors on a page</h3>
       <p>
-        The simplest page is a short page with a single question, where the error message will be immediately visible when the page is refreshed. 
+        Recovering from errors is hard, especially if a page contains multiple errors. Avoid this by splitting long forms across multiple pages, with each page asking a single question.
       </p>
-      <h3 class="heading-medium">If the page has one question</h3>
+
+      <h3 class="heading-medium">Highlight errors in forms</h3>
       <p class="lead-in">
-        You must:
+        For each error:
       </p>
       <ul class="list-bullet">
         <li>write a message that helps the user to understand why the error occurred and what to do about it</li>
@@ -993,7 +996,7 @@
     <!-- Single question example -->
     <div class="example example-error">
       <div class="form-group error">
-        <label class="form-label-bold error-label" for="error-example-ni-number">
+        <label class="form-label-bold" for="error-example-ni-number">
           <span class="error-message">Error message goes here</span>
           
           What is your National Insurance number?
@@ -1008,26 +1011,31 @@
       </div>
       <input class="button" type="submit" value="Continue">
     </div>
-    
-    <p class="text">
-      For red, use the <code>$error-colour</code> Sass variable &ndash; find this in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_colours.scss">colours.scss</a> file
-    </p>
 
-    <p>
-      If the page is more complex, it may be useful to also include a summary box at the top of the page.
-    </p>
-    
     <div class="text">
-      <h3 class="heading-medium">If the page has more than one question</h3>
-      <p class="lead-in">You must:</p>
+      
+      <p>
+        For red, use the <code>$error-colour</code> Sass variable &ndash; find this in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_colours.scss">colours.scss</a> file
+      </p>
+    
+      <h3 class="heading-medium">
+        Summarise errors at the top of the page
+      </h3>
+      
+      <p class="lead-in">
+        If you have multiple errors on a page, or the error appears a long way down the page, you must:
+      </p>
+      
       <ul class="list-bullet">
         <li>show an error summary at the top of the page</li>
         <li>include a heading to alert the user to the error</li>
         <li>link to each of the problematic questions</li>
       </ul>
+     
       <h4 class="heading-small panel-indent">
         The error summary must appear at the top of the page, so it is visible when the page is refreshed and is immediately read out by assistive technology.
       </h4>
+
     </div>
 
     <!-- Multiple questions and summary example -->
@@ -1037,9 +1045,12 @@
         <h3 class="heading-medium error-summary-heading" id="error-summary-heading">
           Message to alert the user to a problem goes here
         </h3>
+        <p>
+          Description of the errors and how to correct them
+        </p>
         <ul class="error-summary-list">
-          <li><a href="#full-name">A link to the first question with a problem</a></li>
-          <li><a href="#ni-number">A link to the second question with a problem</a></li>
+          <li><a href="#full-name">Error message goes here</a></li>
+          <li><a href="#ni-number">Error message goes here</a></li>
         </ul>
       </div>
       
@@ -1048,8 +1059,8 @@
       </h1>
 
       <div class="form-group error">
-        <label class="form-label-bold error-label" for="full-name">
-          <span class="error-message" id="error-full-name">Error message for first question goes here</span>
+        <label class="form-label-bold" for="full-name">
+          <span class="error-message" id="error-full-name">Error message goes here</span>
           Full name
           <span class="form-hint">As shown on your birth certificate or passport</span>
         </label>
@@ -1057,8 +1068,8 @@
       </div>
 
       <div class="form-group error">
-        <label class="form-label-bold error-label" for="error-example-ni-number-2">
-          <span class="error-message" id="error-ni-number">Error message for second question goes here</span>
+        <label class="form-label-bold" for="error-example-ni-number-2">
+          <span class="error-message" id="error-ni-number">Error message goes here</span>
           National Insurance number
           <span class="form-hint">
             It's on your National Insurance card, benefit letter, payslip or P60.
@@ -1071,18 +1082,15 @@
 
       <input class="button" type="submit" value="Continue">
     </div>
-
+    
     <div class="text">
-      <h3 class="heading-medium">If the page has more than one error</h3>
       <p>
-        If users are making more than one error on a page, this is a strong indication that your page has too many questions.
+        Simple pages with a single question do not need error summaries.
       </p>
       <p>
-        Iterate the page to make it simpler. 
+        If users are regularly making multiple errors on a page this indicates that your page has too many questions. Simplify the page by removing questions or splitting them across multiple pages.
       </p>
     </div>
-
-    
     <h3 class="heading-medium" id="error-message-examples">Examples</h3>
     <ul class="list-bullet text">
       <li>

--- a/views/index.html
+++ b/views/index.html
@@ -990,7 +990,7 @@
     <!-- Single question example -->
     <div class="example example-error">
       <div class="form-group error">
-        <label class="form-label-bold" for="error-example-ni-number">
+        <label class="form-label-bold error-label" for="error-example-ni-number">
           <span class="error-message">Error message goes here</span>
           
           What is your National Insurance number?
@@ -1043,7 +1043,7 @@
       </h1>
 
       <div class="form-group error">
-        <label class="form-label-bold" for="full-name">
+        <label class="form-label-bold error-label" for="full-name">
           <span class="error-message" id="error-full-name">Error message for first question goes here</span>
           Full name
           <span class="form-hint">As shown on your birth certificate or passport</span>
@@ -1052,7 +1052,7 @@
       </div>
 
       <div class="form-group error">
-        <label class="form-label-bold" for="error-example-ni-number-2">
+        <label class="form-label-bold error-label" for="error-example-ni-number-2">
           <span class="error-message" id="error-ni-number">Error message for second question goes here</span>
           National Insurance number
           <span class="form-hint">

--- a/views/index.html
+++ b/views/index.html
@@ -1085,12 +1085,12 @@
           Example with one question, a single text input
         </a>
       </li>
-    <!--
       <li>
         <a href="{{ site.baseurl}}/examples/form-validation-single-question-radio">
           Example with one question, a group of radio buttons
         </a>
       </li>
+     <!--
       <li>
         <a href="{{ site.baseurl}}/examples/form-validation-multiple-questions">
           Example with multiple questions, with an error summary at the top of the page
@@ -1098,7 +1098,7 @@
       </li>
       -->
     </ul>
-    
+
     <p>
       <a href="https://designpatterns.hackpad.com/Error-messaging-and-validation-HiGXPZ7XiG0" rel="external">Discuss errors on our Hackpad</a>
     </p>

--- a/views/index.html
+++ b/views/index.html
@@ -1070,7 +1070,10 @@
     <div class="text">
       <h3 class="heading-medium">If the page has more than one error</h3>
       <p>
-        If users are making more than one error on a page, this is a strong indication that your page has too many questions. Iterate the page to make it simpler. 
+        If users are making more than one error on a page, this is a strong indication that your page has too many questions.
+      </p>
+      <p>
+        Iterate the page to make it simpler. 
       </p>
     </div>
 

--- a/views/index.html
+++ b/views/index.html
@@ -1090,13 +1090,11 @@
           Example with one question, a group of radio buttons
         </a>
       </li>
-     <!--
       <li>
         <a href="{{ site.baseurl}}/examples/form-validation-multiple-questions">
           Example with multiple questions, with an error summary at the top of the page
         </a>
       </li>
-      -->
     </ul>
 
     <p>

--- a/views/index.html
+++ b/views/index.html
@@ -985,7 +985,7 @@
       <li>errors should not cause pre-filled fields to clear</li>
     </ul>
 
-    <div class="example example-error">
+    <!-- <div class="example example-error">
 
       <div class="form-group error">
         <label class="form-label-bold" for="ni-no">
@@ -1001,9 +1001,9 @@
       </div>
       <input class="button" type="submit" value="Continue">
 
-    </div>
+    </div> -->
 
-    <div class="example example-error">
+    <!-- <div class="example example-error">
 
       <div class="form-group error">
         <fieldset class="inline">
@@ -1023,7 +1023,7 @@
       </div>
       <input class="button" type="submit" value="Continue">
 
-    </div>
+    </div> -->
 
     <h3 class="heading-medium">Error summary</h3>
     <p class="text">
@@ -1033,7 +1033,7 @@
       The error summary should appear at the top of the page, so it is visible when the page is refreshed and is immediately read out by assistive technology.
     </p>
 
-    <div class="example example-error">
+    <!-- <div class="example example-error">
 
       <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1" style="">
         <h3 class="heading-medium error-summary-heading" id="error-summary-heading">There's a problem</h3>
@@ -1076,7 +1076,7 @@
 
       <input class="button" type="submit" value="Continue">
 
-    </div>
+    </div> -->
 
     <h3 class="heading-medium" id="error-message-examples">Error message examples</h3>
     <ul class="list-bullet text">
@@ -1092,7 +1092,7 @@
       </li>
       <li>
         <a href="{{ site.baseurl}}/examples/form-validation-multiple-questions">
-          An example with an error summary at the top of the page
+          An example form with an error summary at the top of the page
         </a>
       </li>
     </ul>

--- a/views/index.html
+++ b/views/index.html
@@ -975,19 +975,126 @@
 
     <h2 class="heading-large heading-with-border">8. Errors and validation</h2>
     <p class="text">
-       Summarise validation errors in a box at the top of your page.
-       Use jump links in the summary box to reach the errors in the form.
-    </p>
-    <p class="text">
-       Ensure error messages make sense when read by screen readers.
+      Form validation should identify all errors, ensuring error copy is specific to the question.
     </p>
 
-    <h3 class="heading-medium" id="error-form-validation">Form validation</h3>
+    <h3 class="heading-medium" id="error-messages">Error messages</h3>
     <ul class="list-bullet text">
       <li>use a red border on the box to visually connect the errors and messages in the form</li>
       <li>apply the same colour to the area of the form where an error has occurred</li>
-      <li>error copy should be specific to the question and validation should identify all errors</li>
       <li>errors should not cause pre-filled fields to clear</li>
+    </ul>
+
+    <div class="example example-error">
+
+      <div class="form-group error">
+        <label class="form-label-bold" for="ni-number">
+          What is your National Insurance number?
+          <span class="form-hint">
+            It's on your National Insurance card, benefit letter, payslip or P60.
+            <br>
+            For example, 'VO 12 34 56 D'.
+          </span>
+          <span class="error-message">Enter your National Insurance number</span>
+        </label>
+        <input type="text" class="form-control" id="ni-number">
+      </div>
+      <input class="button" type="submit" value="Continue">
+
+    </div>
+
+    <div class="example example-error">
+
+      <div class="form-group error">
+        <fieldset class="inline">
+          <legend class="form-label-bold">
+            Are you 19 or over?
+            <span class="error-message">Please answer the question</span>
+          </legend>
+          <label class="block-label" for="age-yes">
+            <input id="age-yes" name="age19YearsOrOver" value="true" type="radio">
+              <span></span>Yes
+          </label>
+          <label class="block-label" for="age-no">
+            <input id="age-no" name="age19YearsOrOver" value="false" type="radio">
+              <span></span>No
+          </label>
+        </fieldset>
+      </div>
+      <input class="button" type="submit" value="Continue">
+
+    </div>
+
+    <h3 class="heading-medium">Error summary</h3>
+    <p class="text">
+      An error summary is recommended if your form has more than one question per page. This summary should contain a heading - indicating there are errors and also a list of all the errors, each of which is a link to the corresponding field.
+    </p>
+    <p class="text">
+      The error summary should appear at the top of the page, so it is visible when the page is refreshed and is immediately read out by assistive technology.
+    </p>
+
+    <div class="example example-error">
+
+      <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1" style="">
+        <h3 class="heading-medium error-summary-heading" id="error-summary-heading">There was a problem submitting the form</h3>
+        <p>Please try the following:</p>
+        <ul class="error-summary-list">
+          <li><a href="#full-name">Enter your full name</a></li>
+          <li><a href="#ni-number">Enter your National Insurance number</a></li>
+        </ul>
+      </div>
+
+      <h1 class="form-title heading-large">
+        Your details
+      </h1>
+
+      <div class="form-group error">
+        <label class="form-label-bold" for="full-name">
+          Full name
+          <span class="form-hint">As shown on your birth certificate or passport</span>
+        </label>
+        <p class="error-message" id="error-full-name">Enter your
+          Full name
+        </p>
+        <input type="text" class="form-control" id="full-name" aria-describedby="error-full-name">
+      </div>
+
+      <div class="form-group error">
+        <label class="form-label-bold" for="ni-number">
+          National Insurance number
+          <span class="form-hint">
+            It's on your National Insurance card, benefit letter, payslip or P60.
+            <br>
+            For example, 'VO 12 34 56 D'.
+          </span>
+        </label>
+        <p class="error-message" id="error-ni-number">Enter your
+          National Insurance number
+        </p>
+        <input type="text" class="form-control" id="ni-number" aria-describedby="error-ni-number">
+      </div>
+
+      <input class="button" type="submit" value="Continue">
+
+    </div>
+
+    <h3 class="heading-medium" id="error-message-examples">Error message examples</h3>
+    <ul class="list-bullet text">
+      <li>
+        <a href="{{ site.baseurl}}/examples/form-validation-single-question">
+          An example form with a single text input
+        </a>
+      </li>
+      <li>
+        <a href="{{ site.baseurl}}/examples/form-validation-single-question-radio">
+          An example form with a radio button
+        </a>
+      </li>
+      <li>
+        <a href="{{ site.baseurl}}/examples/form-validation-multiple-questions">
+          An example with an error summary at the top of the page
+        </a>
+      </li>
     </ul>
 
     <p>

--- a/views/index.html
+++ b/views/index.html
@@ -988,7 +988,7 @@
     <div class="example example-error">
 
       <div class="form-group error">
-        <label class="form-label-bold" for="ni-number">
+        <label class="form-label-bold" for="ni-no">
           What is your National Insurance number?
           <span class="form-hint">
             It's on your National Insurance card, benefit letter, payslip or P60.
@@ -997,7 +997,7 @@
           </span>
           <span class="error-message">Enter your National Insurance number</span>
         </label>
-        <input type="text" class="form-control" id="ni-number">
+        <input type="text" class="form-control" id="ni-no">
       </div>
       <input class="button" type="submit" value="Continue">
 
@@ -1060,7 +1060,7 @@
       </div>
 
       <div class="form-group error">
-        <label class="form-label-bold" for="ni-number">
+        <label class="form-label-bold" for="ni-no-example">
           National Insurance number
           <span class="form-hint">
             It's on your National Insurance card, benefit letter, payslip or P60.
@@ -1068,10 +1068,10 @@
             For example, 'VO 12 34 56 D'.
           </span>
         </label>
-        <p class="error-message" id="error-ni-number">
+        <p class="error-message" id="error-ni-no-example">
           Enter your National Insurance number
         </p>
-        <input type="text" class="form-control" id="ni-number" aria-describedby="error-ni-number">
+        <input type="text" class="form-control" id="ni-no-example" aria-describedby="error-ni-no-example">
       </div>
 
       <input class="button" type="submit" value="Continue">
@@ -1111,7 +1111,7 @@
       You have to use an alpha banner if your thing is in alpha, and a beta banner if it’s in beta.
     </p>
 
-    <h3 class="heading-medium" id="error-form-validation">Things on the service.gov.uk subdomain</h3>
+    <h3 class="heading-medium" id="guide-alpha-beta-service-govuk">Things on the service.gov.uk subdomain</h3>
     <p class="text">
       If your service is in beta or alpha, you must show the relevant banner in the header.
       It should sit directly underneath the black GOV.UK header and colour bar.
@@ -1125,7 +1125,7 @@
       {{> phase_banner_beta }}
     </div>
 
-    <h3 class="heading-medium" id="error-form-validation">Things on GOV.UK</h3>
+    <h3 class="heading-medium" id="guide-alpha-beta-govuk">Things on GOV.UK</h3>
     <p class="text">
       If your GOV.UK content is in beta or alpha, show the relevant banner below the page title, but above the body content. You can see what they should look like in <a href="https://designnotes.blog.gov.uk/2014/03/26/betas-on-gov-uk/">this blog post</a>.
     </p>

--- a/views/snippets.html
+++ b/views/snippets.html
@@ -307,12 +307,39 @@
 </pre>
 
 <!-- 8. Errors and validation -->
-<!-- TODO :
+
 <h2 class="heading-medium" id="guide-errors">8. Errors and validation</h2>
 
-<pre><code class="language-markup">
-</code></pre>
--->
+<h3 class="heading-medium" id="error-form-single">One question per page</h3>
+
+<div class="example">
+  {{> form_error_single_question }}
+</div>
+<pre>
+<code class="language-markup">
+  {{> form_error_single_question }}
+</code>
+</pre>
+
+<div class="example">
+  {{> form_error_single_question_radio }}
+</div>
+<pre>
+<code class="language-markup">
+ {{> form_error_single_question_radio }}
+</code>
+</pre>
+
+<h3 class="heading-medium" id="error-form-multiple">Multiple questions per page</h3>
+
+<div class="example">
+  {{> form_error_multiple_questions }}
+</div>
+<pre>
+<code class="language-markup">
+  {{> form_error_multiple_questions }}
+</code>
+</pre>
 
 <!-- 9. Alpha beta banners -->
 

--- a/views/snippets/form_error_multiple_questions.html
+++ b/views/snippets/form_error_multiple_questions.html
@@ -4,8 +4,8 @@
   <h3 class="heading-medium error-summary-heading" id="error-summary-heading">There was a problem submitting the form</h3>
   <p>Please try the following:</p>
   <ul class="error-summary-list">
-    {{^fullName}}<li><a href='#"+inputID+"'>Enter your full name</a></li>{{/fullName}}
-    {{^niNo}}<li><a href='#"+inputID+"'>Enter your National Insurance number</a></li>{{/niNo}}
+    {{^fullName}}<li><a href='#full-name'>Enter your full name</a></li>{{/fullName}}
+    {{^niNo}}<li><a href='#ni-number'>Enter your National Insurance number</a></li>{{/niNo}}
   </ul>
 </div>
 {{/error}}
@@ -18,9 +18,9 @@
   <label class="form-label-bold" for="full-name">
     Full name
     <span class="form-hint">As shown on your birth certificate or passport</span>
-    {{#error}}{{^fullName}}<span class="error-message">Enter your full name</span>{{/fullName}}{{/error}}
+    {{#error}}{{^fullName}}<span class="error-message" id="error-full-name">Enter your full name</span>{{/fullName}}{{/error}}
   </label>
-  <input type="text" class="form-control" id="full-name" name="fullName" value="{{fullName}}">
+  <input type="text" class="form-control" id="full-name" name="fullName" value="{{fullName}}" {{#error}}{{^fullName}}aria-describedby="error-full-name"{{/fullName}}{{/error}}>
 </div>
 
 <div class="form-group {{#error}}{{^niNo}}error{{/niNo}}{{/error}}">
@@ -31,9 +31,9 @@
       <br>
       For example, 'VO 12 34 56 D'.
     </span>
-    {{#error}}{{^niNo}}<span class="error-message">Enter your National Insurance number</span>{{/niNo}}{{/error}}
+    {{#error}}{{^niNo}}<span class="error-message" id="error-ni-number">Enter your National Insurance number</span>{{/niNo}}{{/error}}
   </label>
-  <input type="text" class="form-control" id="ni-number" name="niNo" value="{{niNo}}">
+  <input type="text" class="form-control" id="ni-number" name="niNo" value="{{niNo}}" {{#error}}{{^niNo}}aria-describedby="error-ni-number"{{/niNo}}{{/error}}>
 </div>
 
 <input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_multiple_questions.html
+++ b/views/snippets/form_error_multiple_questions.html
@@ -1,23 +1,29 @@
+
+{{#error}}
 <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
   <h3 class="heading-medium error-summary-heading" id="error-summary-heading">There was a problem submitting the form</h3>
   <p>Please try the following:</p>
   <ul class="error-summary-list">
+    {{^fullName}}<li><a href='#"+inputID+"'>Enter your full name</a></li>{{/fullName}}
+    {{^niNo}}<li><a href='#"+inputID+"'>Enter your National Insurance number</a></li>{{/niNo}}
   </ul>
 </div>
+{{/error}}
 
 <h1 class="form-title heading-large">
   Your details
 </h1>
 
-<div class="form-group">
+<div class="form-group {{#error}}{{^fullName}}error{{/fullName}}{{/error}}">
   <label class="form-label-bold" for="full-name">
     Full name
     <span class="form-hint">As shown on your birth certificate or passport</span>
+    {{#error}}{{^fullName}}<span class="error-message">Enter your full name</span>{{/fullName}}{{/error}}
   </label>
-  <input type="text" class="form-control" id="full-name">
+  <input type="text" class="form-control" id="full-name" name="fullName" value="{{fullName}}">
 </div>
 
-<div class="form-group">
+<div class="form-group {{#error}}{{^niNo}}error{{/niNo}}{{/error}}">
   <label class="form-label-bold" for="ni-number">
     National Insurance number
     <span class="form-hint">
@@ -25,8 +31,9 @@
       <br>
       For example, 'VO 12 34 56 D'.
     </span>
+    {{#error}}{{^niNo}}<span class="error-message">Enter your National Insurance number</span>{{/niNo}}{{/error}}
   </label>
-  <input type="text" class="form-control" id="ni-number">
+  <input type="text" class="form-control" id="ni-number" name="niNo" value="{{niNo}}">
 </div>
 
 <input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_multiple_questions.html
+++ b/views/snippets/form_error_multiple_questions.html
@@ -1,11 +1,11 @@
 
 {{#error}}
 <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
-  <h3 class="heading-medium error-summary-heading" id="error-summary-heading">There was a problem submitting the form</h3>
-  <p>Please try the following:</p>
+  <h3 class="heading-medium error-summary-heading" id="error-summary-heading">There's a problem</h3>
+  <p>Check your information. You must:</p>
   <ul class="error-summary-list">
-    {{^fullName}}<li><a href='#full-name'>Enter your full name</a></li>{{/fullName}}
-    {{^niNo}}<li><a href='#ni-number'>Enter your National Insurance number</a></li>{{/niNo}}
+    {{^fullName}}<li><a href='#full-name'>enter your full name</a></li>{{/fullName}}
+    {{^niNo}}<li><a href='#ni-number'>enter your National Insurance number</a></li>{{/niNo}}
   </ul>
 </div>
 {{/error}}

--- a/views/snippets/form_error_multiple_questions.html
+++ b/views/snippets/form_error_multiple_questions.html
@@ -2,22 +2,25 @@
 {{#error}}
 <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
   <h3 class="heading-medium error-summary-heading" id="error-summary-heading">
-    There was a problem submitting the form
+    Message to alert the user to a problem goes here
   </h3>
+  <p>
+    Description of the errors and how to correct them
+  </p>
   <ul class="error-summary-list">
-    {{^fullName}}<li><a href='#full-name'>Enter your full name</a></li>{{/fullName}}
-    {{^niNo}}<li><a href='#ni-number'>Enter your National Insurance number</a></li>{{/niNo}}
+    {{^fullName}}<li><a href='#full-name'>Error message goes here</a></li>{{/fullName}}
+    {{^niNo}}<li><a href='#ni-number'>Error message goes here</a></li>{{/niNo}}
   </ul>
 </div>
 {{/error}}
 
-<h1 class="form-title heading-large">
+<h1 class="heading-large form-title">
   Your details
 </h1>
 
 <div class="form-group {{#error}}{{^fullName}}error{{/fullName}}{{/error}}">
-  <label class="form-label-bold {{#error}}{{^fullName}}error-label{{/fullName}}{{/error}}" for="full-name">
-    {{#error}}{{^fullName}}<span class="error-message" id="error-full-name">Enter your full name</span>{{/fullName}}{{/error}}
+  <label class="form-label-bold" for="full-name">
+    {{#error}}{{^fullName}}<span class="error-message" id="error-full-name">Error message goes here</span>{{/fullName}}{{/error}}
     Full name
     <span class="form-hint">As shown on your birth certificate or passport</span>
   </label>
@@ -25,8 +28,8 @@
 </div>
 
 <div class="form-group {{#error}}{{^niNo}}error{{/niNo}}{{/error}}">
-  <label class="form-label-bold {{#error}}{{^niNo}}error-label{{/niNo}}{{/error}}" for="ni-number">
-    {{#error}}{{^niNo}}<span class="error-message" id="error-ni-number">Enter your National Insurance number</span>{{/niNo}}{{/error}}
+  <label class="form-label-bold" for="ni-number">
+    {{#error}}{{^niNo}}<span class="error-message" id="error-ni-number">Error message goes here</span>{{/niNo}}{{/error}}
     National Insurance number
     <span class="form-hint">
       It's on your National Insurance card, benefit letter, payslip or P60.

--- a/views/snippets/form_error_multiple_questions.html
+++ b/views/snippets/form_error_multiple_questions.html
@@ -1,11 +1,12 @@
 
 {{#error}}
 <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
-  <h3 class="heading-medium error-summary-heading" id="error-summary-heading">There's a problem</h3>
-  <p>Check your information. You must:</p>
+  <h3 class="heading-medium error-summary-heading" id="error-summary-heading">
+    There was a problem submitting the form
+  </h3>
   <ul class="error-summary-list">
-    {{^fullName}}<li><a href='#full-name'>enter your full name</a></li>{{/fullName}}
-    {{^niNo}}<li><a href='#ni-number'>enter your National Insurance number</a></li>{{/niNo}}
+    {{^fullName}}<li><a href='#full-name'>Enter your full name</a></li>{{/fullName}}
+    {{^niNo}}<li><a href='#ni-number'>Enter your National Insurance number</a></li>{{/niNo}}
   </ul>
 </div>
 {{/error}}
@@ -15,23 +16,23 @@
 </h1>
 
 <div class="form-group {{#error}}{{^fullName}}error{{/fullName}}{{/error}}">
-  <label class="form-label-bold" for="full-name">
+  <label class="form-label-bold {{#error}}{{^fullName}}error-label{{/fullName}}{{/error}}" for="full-name">
+    {{#error}}{{^fullName}}<span class="error-message" id="error-full-name">Enter your full name</span>{{/fullName}}{{/error}}
     Full name
     <span class="form-hint">As shown on your birth certificate or passport</span>
-    {{#error}}{{^fullName}}<span class="error-message" id="error-full-name">Enter your full name</span>{{/fullName}}{{/error}}
   </label>
   <input type="text" class="form-control" id="full-name" name="fullName" value="{{fullName}}" {{#error}}{{^fullName}}aria-describedby="error-full-name"{{/fullName}}{{/error}}>
 </div>
 
 <div class="form-group {{#error}}{{^niNo}}error{{/niNo}}{{/error}}">
-  <label class="form-label-bold" for="ni-number">
+  <label class="form-label-bold {{#error}}{{^niNo}}error-label{{/niNo}}{{/error}}" for="ni-number">
+    {{#error}}{{^niNo}}<span class="error-message" id="error-ni-number">Enter your National Insurance number</span>{{/niNo}}{{/error}}
     National Insurance number
     <span class="form-hint">
       It's on your National Insurance card, benefit letter, payslip or P60.
       <br>
       For example, 'VO 12 34 56 D'.
     </span>
-    {{#error}}{{^niNo}}<span class="error-message" id="error-ni-number">Enter your National Insurance number</span>{{/niNo}}{{/error}}
   </label>
   <input type="text" class="form-control" id="ni-number" name="niNo" value="{{niNo}}" {{#error}}{{^niNo}}aria-describedby="error-ni-number"{{/niNo}}{{/error}}>
 </div>

--- a/views/snippets/form_error_multiple_questions.html
+++ b/views/snippets/form_error_multiple_questions.html
@@ -1,0 +1,32 @@
+<div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
+  <h3 class="heading-medium error-summary-heading" id="error-summary-heading">There was a problem submitting the form</h3>
+  <p>Please try the following:</p>
+  <ul class="error-summary-list">
+  </ul>
+</div>
+
+<h1 class="form-title heading-large">
+  Your details
+</h1>
+
+<div class="form-group">
+  <label class="form-label-bold" for="full-name">
+    Full name
+    <span class="form-hint">As shown on your birth certificate or passport</span>
+  </label>
+  <input type="text" class="form-control" id="full-name">
+</div>
+
+<div class="form-group">
+  <label class="form-label-bold" for="ni-number">
+    National Insurance number
+    <span class="form-hint">
+      It's on your National Insurance card, benefit letter, payslip or P60.
+      <br>
+      For example, 'VO 12 34 56 D'.
+    </span>
+  </label>
+  <input type="text" class="form-control" id="ni-number">
+</div>
+
+<input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_single_question.html
+++ b/views/snippets/form_error_single_question.html
@@ -1,0 +1,13 @@
+<div class="form-group">
+  <label class="form-label-bold" for="ni-number">
+    What is your National Insurance number?
+    <span class="form-hint">
+      It's on your National Insurance card, benefit letter, payslip or P60.
+      <br>
+      For example, 'VO 12 34 56 D'.
+    </span>
+  </label>
+  <input type="text" class="form-control" id="ni-number">
+</div>
+
+<input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_single_question.html
+++ b/views/snippets/form_error_single_question.html
@@ -1,8 +1,8 @@
 <div class="form-group {{#error}}error{{/error}}">
 
-  <label class="form-label-bold error-label" for="ni-number">
+  <label class="form-label" for="ni-number">
     
-    {{#error}}<span class="error-message" aria-hidden="true">Please enter your National Insurance number</span>{{/error}}
+    {{#error}}<span class="error-message" aria-hidden="true">Error message goes here</span>{{/error}}
     
     What is your National Insurance number?
     <span class="form-hint">
@@ -13,7 +13,7 @@
     
     <input type="text" class="form-control" id="ni-number" name="niNumber" value="{{niNumber}}">
 
-    {{#error}}<span class="error-message visuallyhidden">Please enter your National Insurance number</span>{{/error}}
+    {{#error}}<span class="error-message visuallyhidden">Error message goes here</span>{{/error}}
 
   </label>
 

--- a/views/snippets/form_error_single_question.html
+++ b/views/snippets/form_error_single_question.html
@@ -1,6 +1,8 @@
 <div class="form-group {{#error}}error{{/error}}">
+
   <label class="form-label-bold error-label" for="ni-number">
-    {{#error}}<span class="error-message">Please enter your National Insurance number</span>{{/error}}
+    
+    {{#error}}<span class="error-message" aria-hidden="true">Please enter your National Insurance number</span>{{/error}}
     
     What is your National Insurance number?
     <span class="form-hint">
@@ -9,8 +11,12 @@
       For example, 'VO 12 34 56 D'.
     </span>
     
+    <input type="text" class="form-control" id="ni-number" name="niNumber" value="{{niNumber}}">
+
+    {{#error}}<span class="error-message visuallyhidden">Please enter your National Insurance number</span>{{/error}}
+
   </label>
-  <input type="text" class="form-control" id="ni-number" name="niNumber" value="{{niNumber}}">
+
 </div>
 
 <input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_single_question.html
+++ b/views/snippets/form_error_single_question.html
@@ -1,5 +1,5 @@
 <div class="form-group {{#error}}error{{/error}}">
-  <label class="form-label-bold" for="ni-number">
+  <label class="form-label-bold error-label" for="ni-number">
     {{#error}}<span class="error-message">Please enter your National Insurance number</span>{{/error}}
     
     What is your National Insurance number?

--- a/views/snippets/form_error_single_question.html
+++ b/views/snippets/form_error_single_question.html
@@ -1,13 +1,16 @@
 <div class="form-group {{#error}}error{{/error}}">
   <label class="form-label-bold" for="ni-number">
+    {{#error}}<span class="error-message">Please enter your National Insurance number</span>{{/error}}
+    
     What is your National Insurance number?
     <span class="form-hint">
       It's on your National Insurance card, benefit letter, payslip or P60.
       <br>
       For example, 'VO 12 34 56 D'.
     </span>
-    {{#error}}<span class="error-message">Enter your National Insurance number</span>{{/error}}
+    
   </label>
   <input type="text" class="form-control" id="ni-number" name="niNumber" value="{{niNumber}}">
 </div>
+
 <input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_single_question.html
+++ b/views/snippets/form_error_single_question.html
@@ -1,4 +1,4 @@
-<div class="form-group">
+<div class="form-group {{#error}}error{{/error}}">
   <label class="form-label-bold" for="ni-number">
     What is your National Insurance number?
     <span class="form-hint">
@@ -6,8 +6,8 @@
       <br>
       For example, 'VO 12 34 56 D'.
     </span>
+    {{#error}}<span class="error-message">Enter your National Insurance number</span>{{/error}}
   </label>
-  <input type="text" class="form-control" id="ni-number">
+  <input type="text" class="form-control" id="ni-number" name="niNumber" value="{{niNumber}}">
 </div>
-
 <input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_single_question.html
+++ b/views/snippets/form_error_single_question.html
@@ -1,6 +1,6 @@
 <div class="form-group {{#error}}error{{/error}}">
 
-  <label class="form-label" for="ni-number">
+  <label class="form-label-bold" for="ni-number">
     
     {{#error}}<span class="error-message" aria-hidden="true">Error message goes here</span>{{/error}}
     

--- a/views/snippets/form_error_single_question_radio.html
+++ b/views/snippets/form_error_single_question_radio.html
@@ -1,20 +1,31 @@
-<h1 class="heading-medium">
-  These questions will help you choose a certified company
-</h1>
-
 <div class="form-group {{#error}}error{{/error}}">
-  <fieldset class="inline">
-    <legend class="form-label-bold">
-      {{#error}}<span class="error-message">Please select if you are 19 or over</span>{{/error}}
-      Are you 19 or over?
+  <fieldset>
+    <legend class="heading-large {{#error}}error-label{{/error}}">
+      {{#error}}<span class="error-message">Please choose where you live</span>{{/error}}
+      Where do you live?
     </legend>
-    <label class="block-label" for="age-yes">
-      <input id="age-yes" name="age19YearsOrOver" value="true" type="radio">
-        <span></span>Yes
+    <label class="block-label" for="country_residence_england">
+      <input id="country_residence_england" name="country" value="England" type="radio">
+      <span></span> England
     </label>
-    <label class="block-label" for="age-no">
-      <input id="age-no" name="age19YearsOrOver" value="false" type="radio">
-        <span></span>No
+    <label class="block-label" for="">
+      <input id="country_residence_scotland" name="country" value="Scotland" type="radio">
+      <span></span> Scotland
+    </label>
+    <label class="block-label" for="country_residence_wales">
+      <input id="country_residence_wales" name="country" value="Wales" type="radio">
+        <span></span> Wales
+    </label>
+    <label class="block-label" for="country_residence_northern_ireland">
+      <input id="country_residence_northern_ireland" name="country" value="Northern Ireland" type="radio">
+      <span></span> Northern Ireland
+    </label>
+    <p class="form-block">
+      or
+    </p>
+    <label class="block-label text" for="country_residence_abroad">
+      <input id="country_residence_abroad" name="country" value="Abroad" type="radio">
+      <span></span> British citizen living in another country (including the Channel Islands or Isle of Man)
     </label>
   </fieldset>
 </div>

--- a/views/snippets/form_error_single_question_radio.html
+++ b/views/snippets/form_error_single_question_radio.html
@@ -5,8 +5,8 @@
 <div class="form-group {{#error}}error{{/error}}">
   <fieldset class="inline">
     <legend class="form-label-bold">
+      {{#error}}<span class="error-message">Please select if you are 19 or over</span>{{/error}}
       Are you 19 or over?
-      {{#error}}<span class="error-message">Please answer the question</span>{{/error}}
     </legend>
     <label class="block-label" for="age-yes">
       <input id="age-yes" name="age19YearsOrOver" value="true" type="radio">

--- a/views/snippets/form_error_single_question_radio.html
+++ b/views/snippets/form_error_single_question_radio.html
@@ -1,0 +1,21 @@
+<h1 class="heading-medium">
+  These questions will help you choose a certified company
+</h1>
+
+<div class="form-group">
+  <fieldset class="inline">
+    <legend class="form-label-bold">
+      Are you 19 or over?
+    </legend>
+    <label class="block-label" for="age-yes">
+      <input id="age-yes" name="age19YearsOrOver" value="true" type="radio">
+        <span></span>Yes
+    </label>
+    <label class="block-label" for="age-no">
+      <input id="age-no" name="age19YearsOrOver" value="false" type="radio">
+        <span></span>No
+    </label>
+  </fieldset>
+</div>
+
+<input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_single_question_radio.html
+++ b/views/snippets/form_error_single_question_radio.html
@@ -2,10 +2,11 @@
   These questions will help you choose a certified company
 </h1>
 
-<div class="form-group">
+<div class="form-group {{#error}}error{{/error}}">
   <fieldset class="inline">
     <legend class="form-label-bold">
       Are you 19 or over?
+      {{#error}}<span class="error-message">Please answer the question</span>{{/error}}
     </legend>
     <label class="block-label" for="age-yes">
       <input id="age-yes" name="age19YearsOrOver" value="true" type="radio">

--- a/views/snippets/form_error_single_question_radio.html
+++ b/views/snippets/form_error_single_question_radio.html
@@ -1,9 +1,11 @@
 <div class="form-group {{#error}}error{{/error}}">
   <fieldset>
-    <legend class="heading-large {{#error}}error-label{{/error}}">
-      {{#error}}<span class="error-message">Please choose where you live</span>{{/error}}
+    
+    <legend class="heading-large">
+      {{#error}}<span class="error-message" aria-hidden="true">Error message goes here</span>{{/error}}
       Where do you live?
     </legend>
+    
     <label class="block-label" for="country_residence_england">
       <input id="country_residence_england" name="country" value="England" type="radio">
       <span></span> England
@@ -27,6 +29,9 @@
       <input id="country_residence_abroad" name="country" value="Abroad" type="radio">
       <span></span> British citizen living in another country (including the Channel Islands or Isle of Man)
     </label>
+    
+    {{#error}}<span class="error-message visuallyhidden">Error message goes here</span>{{/error}}
+
   </fieldset>
 </div>
 


### PR DESCRIPTION
Validation styles and guidance, plus examples.

This can be previewed here: http://govuk-elements-test.herokuapp.com/#guide-errors
with static error examples on the index page and three example pages, following Léonie's advice.

[1. A single question per page]
(http://govuk-elements-test.herokuapp.com/examples/form-validation-single-question)
[2. A single question per page - radio buttons]
(http://govuk-elements-test.herokuapp.com/examples/form-validation-single-question-radio)
[3. Multiple questions]
(http://govuk-elements-test.herokuapp.com/examples/form-validation-multiple-questions)

![gov uk elements](https://cloud.githubusercontent.com/assets/417754/6575316/a5c7b1d6-c725-11e4-8b87-6c9755ad7b3a.png)
![gov uk elements-2](https://cloud.githubusercontent.com/assets/417754/6575318/a8537f34-c725-11e4-842b-bb7ebbf893df.png)
![gov uk elements-3](https://cloud.githubusercontent.com/assets/417754/6575319/aac73fd0-c725-11e4-8473-4b2b773bf061.png)

 
![gov uk the best place to find government services and information](https://cloud.githubusercontent.com/assets/417754/6575368/fd2a6e5a-c725-11e4-943a-f253d4539a25.png)
![gov uk the best place to find government services and information](https://cloud.githubusercontent.com/assets/417754/6575381/12fa4192-c726-11e4-845c-83916b519591.png)

