### PR TITLE
Add grunt scss lint

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -5,5 +5,7 @@ linters:
     enabled: false
   PropertySortOrder:
     enabled: false
+  IdSelector:
+    enabled: false
 exclude: public/sass/elements/_reset.scss
   

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -9,5 +9,7 @@ linters:
     enabled: false
   QualifyingElement:
     enabled: false
+  ImportantRule:
+    enabled: false
 exclude: public/sass/elements/_reset.scss
   

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -7,5 +7,7 @@ linters:
     enabled: false
   IdSelector:
     enabled: false
+  QualifyingElement:
+    enabled: false
 exclude: public/sass/elements/_reset.scss
   

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -5,3 +5,5 @@ linters:
     enabled: false
   PropertySortOrder:
     enabled: false
+exclude: public/sass/elements/_reset.scss
+  

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,7 @@
+linters:
+  StringQuotes:
+    enabled: false
+  Shorthand:
+    enabled: false
+  PropertySortOrder:
+    enabled: false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -119,6 +119,7 @@ module.exports = function (grunt) {
         bundleExec: false,
         colorizeOutput: true,
         config: '.scss-lint.yml',
+        force: true,
         reporterOutput: null
       },
     }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,7 +107,21 @@ module.exports = function(grunt){
                 logConcurrentOutput: true
             }
         }
+    },
+
+    // Lint scss files
+    scsslint: {
+      allFiles: [
+        'public/sass/elements/*.scss',
+      ],
+      options: {
+        bundleExec: false,
+        colorizeOutput: true,
+        config: '.scss-lint.yml',
+        reporterOutput: null
+      },
     }
+
   });
 
   [
@@ -116,7 +130,8 @@ module.exports = function(grunt){
     'grunt-sass',
     'grunt-nodemon',
     'grunt-text-replace',
-    'grunt-concurrent'
+    'grunt-concurrent',
+    'grunt-scss-lint'
   ].forEach(function (task) {
     grunt.loadNpmTasks(task);
   });
@@ -141,6 +156,7 @@ module.exports = function(grunt){
     'copy:govuk_frontend_toolkit_img',
     'replace',
     'sass',
+    'scsslint',
     'concurrent:target'
   ]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-module.exports = function(grunt){
+module.exports = function (grunt) {
 
   grunt.initConfig({
 
@@ -101,18 +101,19 @@ module.exports = function(grunt){
     },
 
     concurrent: {
-        target: {
-            tasks: ['watch', 'nodemon'],
-            options: {
-                logConcurrentOutput: true
-            }
+      target: {
+        tasks: ['watch', 'nodemon'],
+        options: {
+          logConcurrentOutput: true
         }
+      }
     },
 
     // Lint scss files
     scsslint: {
       allFiles: [
         'public/sass/elements/*.scss',
+        'public/sass/elements/forms/*.scss'
       ],
       options: {
         bundleExec: false,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "grunt-contrib-watch": "^0.5.3",
     "grunt-nodemon": "^0.3.0",
     "grunt-sass": "^0.16.1",
+    "grunt-scss-lint": "^0.3.6",
     "grunt-text-replace": "^0.3.12",
     "grunt-concurrent": "^0.4.3",
     "express-writer": "0.0.4"

--- a/public/sass/elements/_details.scss
+++ b/public/sass/elements/_details.scss
@@ -5,36 +5,36 @@
 
 details {
   display: block;
-}
 
-details summary {
-  display: inline-block;
-  color: $govuk-blue;
-  cursor: pointer;
-  position: relative;
-  margin-bottom: em(5);
-}
+  summary {
+    display: inline-block;
+    color: $govuk-blue;
+    cursor: pointer;
+    position: relative;
+    margin-bottom: em(5);
 
-details summary:hover {
-  color: $link-hover-colour;
-}
+    &:hover {
+      color: $link-hover-colour;
+    }
 
-details summary:focus {
-  outline: 3px solid $yellow;
-}
-
-// Underline only summary text (not the arrow)
-details .summary {
-  text-decoration: underline;
-}
-
-// Match fallback arrow spacing with -webkit default
-details .arrow {
-  margin-right: 0.35em;
-  font-style: normal;
-}
-
-// Remove top margin from bordered panel
-details .panel-indent {
-  margin-top: 0;
+    &:focus {
+      outline: 3px solid $yellow;
+    }
+  }
+  
+  // Underline only summary text (not the arrow)
+  .summary {
+    text-decoration: underline;
+  }
+  
+  // Match fallback arrow spacing with -webkit default
+  .arrow {
+    margin-right: .35em;
+    font-style: normal;
+  }
+  
+  // Remove top margin from bordered panel
+  .panel-indent {
+    margin-top: 0;
+  }
 }

--- a/public/sass/elements/_elements-typography.scss
+++ b/public/sass/elements/_elements-typography.scss
@@ -17,18 +17,23 @@ main {
 .font-xxlarge {
   @include core-80;
 }
+
 .font-xlarge {
   @include core-48;
 }
+
 .font-large {
   @include core-36;
 }
+
 .font-medium {
   @include core-24;
 }
+
 .font-small {
   @include core-19;
 }
+
 .font-xsmall {
   @include core-16;
 }
@@ -37,18 +42,23 @@ main {
 .bold-xxlarge {
   @include bold-80();
 }
+
 .bold-xlarge {
   @include bold-48();
 }
+
 .bold-large {
   @include bold-36();
 }
+
 .bold-medium {
   @include bold-24();
 }
+
 .bold-small {
   @include bold-19();
 }
+
 .bold-xsmall {
   @include bold-16();
 }
@@ -85,7 +95,7 @@ main {
   margin-bottom: em(10, 24);
 
   @include media(tablet) {
-    margin-top: em(45, 36 );
+    margin-top: em(45, 36);
     margin-bottom: em(20, 36);
   }
 
@@ -125,7 +135,7 @@ main {
 
 // Text
 p {
-  margin-top: em(5, 16 );
+  margin-top: em(5, 16);
   margin-bottom: em(20, 16);
 
   @include media(tablet) {
@@ -155,12 +165,15 @@ p {
   color: $link-colour;
   text-decoration: underline;
 }
+
 .link:visited {
   color: $link-visited-colour;
 }
+
 .link:hover {
   color: $link-hover-colour;
 }
+
 .link:active {
   color: $link-colour;
 }

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -6,16 +6,17 @@
 
 // Fieldset is used to group more than one .form-group
 fieldset {
-  width: 100%;
   @extend %contain-floats;
+  width: 100%;
 }
 
 // Form group is used to wrap label and input pairs
 .form-group {
+  @extend %contain-floats;
   float: left;
   width: 100%;
-  @extend %contain-floats;
   margin-bottom: $gutter-half;
+
   @include media(tablet) {
     margin-bottom: $gutter;
   }
@@ -23,6 +24,7 @@ fieldset {
 
 .form-group-related {
   margin-bottom: 10px;
+
   @include media(tablet) {
     margin-bottom: 20px;
   }
@@ -36,6 +38,7 @@ fieldset {
 // Form title
 .form-title {
   margin-bottom: $gutter;
+
   @include media(tablet) {
     margin-bottom: ($gutter*1.5);
   }
@@ -59,6 +62,7 @@ fieldset {
 .form-label-bold {
   @include bold-24;
   margin-bottom: 0;
+
   .form-hint {
     @include core-19;
   }
@@ -66,9 +70,9 @@ fieldset {
 
 // Used for paragraphs in-between form elements
 .form-block {
+  @extend %contain-floats;
   float: left;
   width: 100%;
-  @extend %contain-floats;
 }
 
 
@@ -79,21 +83,21 @@ fieldset {
   display: block;
   color: $secondary-text-colour;
   margin-bottom: 5px;
+
   @include media (tablet) {
     margin-top: 8px;
   }
 }
-
 
 // Form controls
 
 // By default, form controls are 50% width for desktop,
 // and 100% width for mobile
 .form-control {
-  @include core-19;
-
-  width: 100%;
   @include box-sizing(border-box);
+  @include core-19;
+  width: 100%;
+  
   padding: 4px;
   background-color: $white;
   border: 1px solid $border-colour;
@@ -111,6 +115,7 @@ fieldset {
 // Form control widths
 .form-control-3-4 {
   width: 100%;
+
   @include media(tablet) {
     width: 75%;
   }
@@ -118,6 +123,7 @@ fieldset {
 
 .form-control-1-2 {
   width: 100%;
+
   @include media(tablet) {
     width: 50%;
   }
@@ -136,10 +142,11 @@ fieldset {
 .form-radio {
   display: block;
   margin: 10px 0;
-}
-.form-radio input {
-  vertical-align: middle;
-  margin: -4px 5px 0 0;
+
+  input {
+    vertical-align: middle;
+    margin: -4px 5px 0 0;
+  }
 }
 
 
@@ -147,11 +154,13 @@ fieldset {
 .form-checkbox {
   display: block;
   margin: $gutter-half 0;
+  
+  input {
+    vertical-align: middle;
+    margin: -2px 5px 0 0;
+  }
 }
-.form-checkbox input {
-  vertical-align: middle;
-  margin: -2px 5px 0 0;
-}
+
 
 // Buttons
 .form .button {

--- a/public/sass/elements/_helpers.scss
+++ b/public/sass/elements/_helpers.scss
@@ -17,12 +17,14 @@
 // add this class to the body to see how grid padding is set
 .example-highlight-grid {
   .grid-row {
-    background:  $grey-2;
+    background: $grey-2;
   }
+
   .column-highlight {
     background: $grey-3;
     width: 100%;
   }
+
 }
 
 // Used to space the "back" link on example pages
@@ -36,8 +38,11 @@
   position: absolute;
   overflow: hidden;
   clip: rect(0 0 0 0);
-  height: 1px; width: 1px;
-  margin: -1px; padding: 0; border: 0;
+  height: 1px; 
+  width: 1px;
+  margin: -1px; 
+  padding: 0; 
+  border: 0;
 }
 
 // Hide, only when JavaScript is enabled

--- a/public/sass/elements/_icons.scss
+++ b/public/sass/elements/_icons.scss
@@ -8,85 +8,94 @@
 }
 
 .icon-calendar {
+  width: 27px;
+  height: 27px;
   background-image: file-url("icons/icon-calendar.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-calendar-2x.png");
     background-size: 100%;
   }
-  width: 27px;
-  height: 27px;
 }
 
 .icon-download {
+  width: 30px;
+  height: 39px;
   background-image: file-url("icons/icon-file-download.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-file-download-2x.png");
     background-size: 100%;
-  }
-  width: 30px;
-  height: 39px;
+  } 
 }
 
 .icon-important {
+  width: 34px;
+  height: 34px;
   background-image: file-url("icons/icon-important.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-important-2x.png");
     background-size: 100%;
   }
-  width: 34px;
-  height: 34px;
 }
 
 .icon-information {
+  width: 27px;
+  height: 27px;
   background-image: file-url("icons/icon-information.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-information-2x.png");
     background-size: 100%;
   }
-  width: 27px;
-  height: 27px;
 }
 
 .icon-locator {
+  width: 26px;
+  height: 36px;
   background-image: file-url("icons/icon-locator.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-locator-2x.png");
     background-size: 100%;
   }
-  width: 26px;
-  height: 36px;
 }
 
 .icon-search {
+  width: 30px;
+  height: 22px;
+  background-color: $black;
   background-image: file-url("icons/icon-search.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-search-2x.png");
     background-size: 100%;
   }
-  width: 30px;
-  height: 22px;
-  background-color: black;
 }
 
 // GOV.UK arrow icons
 .icon-pointer {
+  width: 30px;
+  height: 19px;
+  background-color: $black;
   background-image: file-url("icons/icon-pointer.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-pointer-2x.png");
     background-size: 100%;
   }
-  width: 30px;
-  height: 19px;
-  background-color: black;
 }
+
 .icon-pointer-black {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-pointer-black.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-pointer-black-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 // GOV.UK external link icons
@@ -94,131 +103,144 @@
 
 // GOV.UK step icons
 .icon-step-1 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-1.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-1-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-2 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-2.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-2-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-3 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-3.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-3-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-4 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-4.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-4-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-5 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-5.png");
+  
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-5-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-6 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-6.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-6-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-7 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-7.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-7-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-8 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-8.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-8-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-9 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-9.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-9-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-10 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-10.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-10-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-11 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-11.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-11-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-12 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-12.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-12-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-13 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-13.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-13-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }

--- a/public/sass/elements/_layout.scss
+++ b/public/sass/elements/_layout.scss
@@ -17,6 +17,7 @@
   @extend %site-width-container;
   @extend %contain-floats;
   padding-bottom: $gutter;
+  
   @include media(desktop) {
     padding-bottom: $gutter*3;
   }
@@ -26,7 +27,7 @@
 // Phase banner
 // ==========================================================================
 
-.phase-banner  {
+.phase-banner {
   @include phase-banner(alpha);
 }
 
@@ -54,14 +55,17 @@
 // Use .grid-column to create a grid column with 15px gutter
 // By default grid columns break to become full width at tablet size
 .column-quarter {
-  @include grid-column( 1/4 );
+  @include grid-column(1/4);
 }
+
 .column-half {
-  @include grid-column( 1/2 );
+  @include grid-column(1/2);
 }
+
 .column-third {
-  @include grid-column( 1/3 );
+  @include grid-column(1/3);
 }
+
 .column-two-thirds {
-  @include grid-column( 2/3 );
+  @include grid-column(2/3);
 }

--- a/public/sass/elements/_lists.scss
+++ b/public/sass/elements/_lists.scss
@@ -17,6 +17,7 @@ ol {
 .list-number {
   list-style-type: decimal;
   padding-left: 20px;
+  
   @include ie-lte(7) {
     padding-left: 28px;
   }

--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -12,18 +12,18 @@
 
   padding: 10px 0 10px $gutter-half;
   margin: ($gutter $gutter-half $gutter*1.5 0);
-}
 
-.panel-indent legend {
-  margin-top: 0;
-}
-
-// Remove bottom margin on last paragraph
-.panel-indent p:only-child,
-.panel-indent p:last-child {
-  margin-bottom: 0;
-}
-
-.panel-indent .form-group:last-child {
-  margin-bottom: 0;
+  legend {
+    margin-top: 0;
+  }
+  
+  // Remove bottom margin on last paragraph
+  p:only-child,
+  p:last-child {
+    margin-bottom: 0;
+  }
+  
+  .form-group:last-child {
+    margin-bottom: 0;
+  }
 }

--- a/public/sass/elements/_tables.scss
+++ b/public/sass/elements/_tables.scss
@@ -9,29 +9,28 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
   width: 100%;
-}
 
-table th,
-table td {
-  @include core-16;
-  padding: em(12, 16) em(20, 16) em(9, 16) 0;
+  th,
+  td {
+    @include core-16;
+    padding: em(12, 16) em(20, 16) em(9, 16) 0;
 
-  text-align: left;
-  color: #0b0c0c;
-  border-bottom: 1px solid $border-colour;
-}
+    text-align: left;
+    color: $black;
+    border-bottom: 1px solid $border-colour;
+  }
 
-table th {
-  font-weight: 700;
-}
+  th {
+    font-weight: 700;
+    // Right align headings for numeric content
+    &.numeric {
+      text-align: right;
+    } 
+  }
 
-// Right align headings for numeric content
-table th.numeric {
-  text-align: right;
-}
-
-// Use tabular numbers for numeric table cells
-table td.numeric {
-  @include core-16($tabular-numbers: true);
-  text-align: right;
+  // Use tabular numbers for numeric table cells
+  td.numeric {
+    @include core-16($tabular-numbers: true);
+    text-align: right;
+  }
 }

--- a/public/sass/elements/forms/_form-date.scss
+++ b/public/sass/elements/forms/_form-date.scss
@@ -5,10 +5,11 @@
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   -webkit-appearance: none;
-  margin: 0
+  margin: 0;
 }
+
 input[type=number] {
-  -moz-appearance: textfield
+  -moz-appearance: textfield;
 }
 
 .form-date {
@@ -29,11 +30,9 @@ input[type=number] {
     input {
       width: 100%;
     }
-
   }
 
   .form-group-year {
     width: 70px;
   }
-
 }

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -10,59 +10,41 @@
   padding: $gutter-half $gutter;
   margin-bottom: $gutter;
 
-  @include ie-lte(6){
+  @include ie-lte(6) {
     zoom: 1;
   }
-}
 
-.validation-summary ul {
-  margin-top: 10px;
-}
-
-.validation-summary li,
-.validation-summary p {
-  @include core-16;
-}
-
-.validation-summary p {
-  margin-top: $gutter-half;
-  margin-bottom: 5px;
-}
-
-.validation-summary a {
-  color: $error-colour;
-  @include ie-lte(6) {
-    color: $error-colour !important;
+  ul {
+    margin-top: 10px;
   }
+  
+  li,
+  p {
+    @include core-16;
+  }
+
+  p {
+    margin-top: $gutter-half;
+    margin-bottom: 5px;
+  }
+  
+  a {
+    color: $error-colour;
+    
+    @include ie-lte(6) {
+      color: $error-colour !important;
+    }
+  }
+  
+  .heading-small {
+    margin-top: $gutter-half;
+  }
+
 }
-
-.validation-summary .heading-small {
-  margin-top: $gutter-half;
-}
-
-
-// Validation error message box
-// .validation-error {
-//   clear: both;
-//   @extend %contain-floats;
-//   border-left: 3px solid $error-colour;
-//   padding: $gutter- $gutter;
-//   margin-bottom: $gutter-half;
-//   margin-left: -($gutter);
-// }
-
-// .validation-error .form-group {
-//   margin-bottom: 20px;
-// }
-
-// .validation-error p {
-//   margin-bottom: 10px;
-// }
-
 
 // Validation message
 .validation-message {
-  display: block;
   @include core-16;
+  display: block;
   color: $error-colour;
 }


### PR DESCRIPTION
Use grunt-scss lint to pick up any inconsistencies between the GOV.UK elements scss files.

The .scss-lint.yml file defines the rules we are ignoring for now, these are:
- allow double string quotes
- allow more verbose shorthand 
- allow ID selectors (there is only one ID used - for #content)
- allow qualifying elements (this is used for th.numeric and specific table styles)
- single line per selector (the reset.scss file hasn't been split onto multiple lines)

These changes include:
- adding an empty line between blocks
- removing spaces between params
- merging rules where possible
- replacing hex values with their corresponding colour variables