### PR TITLE
Bump govuk frontend toolkit to 3.4.1

### DIFF
--- a/govuk/public/javascripts/govuk/analytics/google-analytics-classic-tracker.js
+++ b/govuk/public/javascripts/govuk/analytics/google-analytics-classic-tracker.js
@@ -104,8 +104,24 @@
 
   // https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingCustomVariables
   GoogleAnalyticsClassicTracker.prototype.setCustomVariable = function(index, value, name, scope) {
+    var PAGE_LEVEL_SCOPE = 3;
+    scope = scope || PAGE_LEVEL_SCOPE;
+
+    if (typeof index !== "number") {
+      index = parseInt(index, 10);
+    }
+
+    if (typeof scope !== "number") {
+      scope = parseInt(scope, 10);
+    }
+
     _gaq.push(['_setCustomVar', index, name, String(value), scope]);
   };
+
+  // Match tracker and universal API
+  GoogleAnalyticsClassicTracker.prototype.setDimension = function(index, value, name, scope) {
+    this.setCustomVariable(index, value, name, scope);
+  }
 
   GOVUK.GoogleAnalyticsClassicTracker = GoogleAnalyticsClassicTracker;
 })();

--- a/govuk/public/javascripts/govuk/analytics/tracker.js
+++ b/govuk/public/javascripts/govuk/analytics/tracker.js
@@ -42,17 +42,6 @@
     Check this for your app before using this
    */
   Tracker.prototype.setDimension = function(index, value, name, scope) {
-    var PAGE_LEVEL_SCOPE = 3;
-    scope = scope || PAGE_LEVEL_SCOPE;
-
-    if (typeof index !== "number") {
-      index = parseInt(index, 10);
-    }
-
-    if (typeof scope !== "number") {
-      scope = parseInt(scope, 10);
-    }
-
     this.universal.setDimension(index, value);
     this.classic.setCustomVariable(index, value, name, scope);
   };

--- a/govuk/public/sass/_colours.scss
+++ b/govuk/public/sass/_colours.scss
@@ -95,6 +95,7 @@ $link-active-colour: #2e8aca;
 $link-hover-colour: #2e8aca;
 $link-visited-colour: #4c2c92;
 $button-colour: #00823b;
+$focus-colour: $yellow;
 $text-colour: $black;             // Standard text colour
 $secondary-text-colour: $grey-1;  // Section headers, help text etc.
 $border-colour: $grey-2;          // Borders, seperators, rules, keylines etc.
@@ -105,5 +106,5 @@ $page-colour: $white;             // The page
 $alpha-colour: $pink;             // Alpha badges and banners
 $beta-colour: $orange;            // Beta badges and banners
 $banner-text-colour: #000;        // Text colour for Alpha & Beta banners
-$error-colour: $mellow-red;       // Error text and border colour
+$error-colour: #af1324;           // Error text and border colour
 $error-background: #fef7f7;       // Error background colour

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "consolidate": "^0.10.0",
     "readdir": "0.0.6",
     "node-sass": "^1.2.3",
-    "govuk_frontend_toolkit": "^3.3.0",
+    "govuk_frontend_toolkit": "^3.4.1",
     "govuk_template_mustache": "^0.12.0",
     "grunt": "^0.4.2",
     "grunt-contrib-clean": "^0.5.0",


### PR DESCRIPTION
# 3.4.1

- Fix: Make the error colour a darker red for greater contrast and to
meet WCAG 2.0 AAAA
(this was meant to go into 3.3.1 but was lost from history)
- Add `$focus-colour` variable (#180)

# 3.4.0

- multivariate-test.js: add support for using Google Content
Experiments as the reporting
backend for multivariate tests

# 3.3.1

- Fix: Make the error colour a darker red for greater contrast and to
meet WCAG 2.0 AAAA