### PR TITLE
Use new colour variable names and hex values

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -327,7 +327,7 @@
         <div class="swatch swatch-yellow"></div>
         <ul>
           <li><b>#FFBF47</b></li>
-          <li>$yellow</li>
+          <li>$focus-colour</li>
         </ul>
       </div>
     </div>
@@ -357,7 +357,7 @@
 
         <div class="swatch swatch-error"></div>
         <ul>
-          <li><b>#df3034</b></li>
+          <li><b>#af1324</b></li>
           <li>$error-colour</li>
         </ul>
 
@@ -947,7 +947,7 @@
             <div class="swatch swatch-yellow"></div>
             <ul>
               <li><b>#FFBF47</b></li>
-              <li>$yellow</li>
+              <li>$focus-colour</li>
             </ul>
           </div>
 

--- a/views/snippets/form_focus.html
+++ b/views/snippets/form_focus.html
@@ -13,7 +13,7 @@
       <div class="swatch swatch-yellow"></div>
       <ul>
         <li><b>#FFBF47</b></li>
-        <li>$yellow</li>
+        <li>$focus-colour</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
There is now a `$focus-colour` variable, use this rather than `$yellow`.
Update the hex value for `$error-colour` to match the govuk front end
toolkit.

These changes show those in version 3.4.1 of the govuk frontend toolkit.
PR for reference: https://github.com/alphagov/govuk_frontend_toolkit/pull/181