### PR TITLE
Fix spaces within form fields

### DIFF
--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -26,11 +26,14 @@
   function addClickEvent(node, callback) {
     // Prevent space(32) from scrolling the page
     addEvent(node, 'keypress', function (e, target) {
-      if (e.keyCode === 32) {
-        if (e.preventDefault) {
-          e.preventDefault();
+      if (target.nodeName === "SUMMARY") {
+        if (e.keyCode === 32) {
+          if (e.preventDefault) {
+            e.preventDefault();
+          } else {
+            e.returnValue = false;
+          }
         }
-        else { e.returnValue = false; }
       }
     });
     // When the key comes up - check if it is enter(13) or space(32)

--- a/views/patterns/details_summary.html
+++ b/views/patterns/details_summary.html
@@ -20,13 +20,26 @@
 
   <a href="/" class="example-back-link">Back to GOV.UK elements</a>
   <h1 class="heading-xlarge">Details test page</h1>
-  <p> Support for HTML5's &lt;details&gt; and &lt;summary&gt;</p>
+  <p>
+    Support for HTML5's &lt;details&gt; and &lt;summary&gt;
+  </p>
+
+  <div class="form-group">
+    <label class="form-label-bold" for="driving-licence">
+      Driving licence number
+      <span class="form-hint">For example, NORGA657054SM91J</span>
+    </label>
+    <input class="form-control" id="driving-licence" type="text">
+  </div>
 
   <details>
-    <summary><span class="summary">Why aren't all prisons available?</span></summary>
+    <summary>
+      <span class="summary">Where to find your driving licence number</span>
+    </summary>
     <div class="panel-indent">
       <p>
-        You can’t make an online visit request for all prisons (eg high-security and private prisons). If you can’t enter the prison you're visiting, contact the prison to find out how to book.
+        Your driving licence number can be found in section 5<br>
+        of your driving licence photocard.
       </p>
     </div>
   </details>


### PR DESCRIPTION
The details polyfill was preventing the space key from being entered, for the
entire document. It now only prevents the space key for summary
elements, where it prevents the page from scrolling as the widget is
opened.