### PR TITLE
Add select box example

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -97,7 +97,7 @@ fieldset {
   @include box-sizing(border-box);
   @include core-19;
   width: 100%;
-  
+
   padding: 4px;
   background-color: $white;
   border: 1px solid $border-colour;
@@ -138,6 +138,28 @@ fieldset {
 }
 
 
+// Select boxes
+.form-control-select {
+  @include box-sizing(border-box);
+  @include core-19;
+
+  text-transform: none;
+  background-color: $white;
+  border: 1px solid $grey-2;
+
+  width: 100%;
+
+  @include media(tablet) {
+    width: 50%;
+  }
+
+  &:-moz-focusring {
+    color: transparent;
+    text-shadow: 0 0 0 $black;
+  }
+}
+
+
 // Radio buttons
 .form-radio {
   display: block;
@@ -154,7 +176,7 @@ fieldset {
 .form-checkbox {
   display: block;
   margin: $gutter-half 0;
-  
+
   input {
     vertical-align: middle;
     margin: -2px 5px 0 0;

--- a/views/index.html
+++ b/views/index.html
@@ -777,10 +777,15 @@
     </div>
 
     <h3 class="heading-medium" id="form-select-boxes">Drop-down lists</h3>
+    <p class="text">
+      Avoid using drop-down lists (the HTML select element) - use radio buttons or checkboxes instead.
+    </p>
+
+    <div class="example">
+      {{> form_select_box }}
+    </div>
+
     <div class="text">
-      <p>
-        Avoid using drop-down lists (the HTML select element) - use radio buttons or checkboxes instead.
-      </p>
       <p>
         <a href="https://www.youtube.com/watch?v=CUkMCQR4TpY" rel="external">Watch Alice Bartlett present the failings of select boxes to meet the needs of less technically capable users</a>.
       </p>

--- a/views/snippets.html
+++ b/views/snippets.html
@@ -205,6 +205,16 @@
 </code>
 </pre>
 
+<h3 class="heading-small">Drop-down lists (the HTML select element)</h3>
+<div class="example">
+  {{> form_select_box }}
+</div>
+<pre>
+<code class="language-markup">
+  {{> form_select_box }}
+</code>
+</pre>
+
 <h3 class="heading-small">Radio buttons</h3>
 
 <div class="example">

--- a/views/snippets/form_select_box.html
+++ b/views/snippets/form_select_box.html
@@ -1,0 +1,6 @@
+<label class="form-label" for="select-address">Select your address</label>
+<select class="form-control-select" id="select-address">
+  <option value="" >2 addresses found</option>
+  <option value="1" >Royal Guard Room, The Royal Mews, London, City Of Westminster</option>
+  <option value="2" >Queens Gallery And Royal Kitchen Buckingham Palace, The Mall, London, City Of Westminster</option>
+</select>


### PR DESCRIPTION
Add styles for select boxes, so these use the same font size and border as all other form controls.

Screenshots:
![gov uk elements - dropdowns](https://cloud.githubusercontent.com/assets/417754/7253810/ea96edea-e836-11e4-9a58-62b0b098685b.png)

![gov uk elements - dropdown - snippets](https://cloud.githubusercontent.com/assets/417754/7253809/e5814a4e-e836-11e4-9fcb-b25899553259.png)
