### PR TITLE
New errors and validation guidance for review

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,8 @@ app.set('views', __dirname + '/views');
 // Middleware to serve static assets
 app.use('/public', express.static(__dirname + '/public'));
 app.use('/public', express.static(__dirname + '/govuk/public'));
+app.use(express.json());       // to support JSON-encoded bodies
+app.use(express.urlencoded()); // to support URL-encoded bodies
 
 // routes (found in routes.js)
 

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -132,3 +132,26 @@ $(document).ready(function() {
   toggleContent.showHideCheckboxToggledContent();
 
 });
+
+$(window).load(function() {
+
+  // Only set focus for the error example pages
+  if ($(".js-error-example").length) {
+
+    // If there is an error summary, set focus to the summary
+    if ($(".error-summary").length) {
+      $(".error-summary").focus();
+      $(".error-summary a").click(function(e) {
+        e.preventDefault();
+        var href = $(this).attr("href");
+        $(href).focus();
+      });
+    }
+    // Otherwise, set focus to the field with the error
+    else {
+      $(".error input:first").focus();
+    }
+  }
+
+});
+

--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -31,7 +31,7 @@
 // Elements page styles
 // ==========================================================================
 
-// These are example styles, used only for the Elements page example boxes
+// These are example styles, used only for the Elements index page
 
 // Headings
 // Used with heading-large = 36px
@@ -40,8 +40,8 @@
   padding-top: em(45, 36);
 }
 
-// Text
-.tight {
+// Use for paragraphs before lists
+.lead-in {
   margin-bottom: 0;
 }
 

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -11,7 +11,7 @@ fieldset {
 }
 
 // Fix left hand gap in IE7 and below
-@include ie-lte(7){
+@include ie-lte(7) {
   legend {
     margin-left: -7px;
   }
@@ -92,7 +92,9 @@ legend {
   @extend %contain-floats;
   float: left;
   width: 100%;
+
   margin-bottom: 5px;
+
   @include media(tablet) {
     margin-top: 10px;
   }

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -13,6 +13,7 @@ fieldset {
 // Form group is used to wrap label and input pairs
 .form-group {
   @extend %contain-floats;
+  @include box-sizing(border-box);
   float: left;
   width: 100%;
   margin-bottom: $gutter-half;
@@ -30,6 +31,7 @@ fieldset {
   }
 }
 
+// Form group compound is used to reduce the space between label and input pairs
 .form-group-compound {
   margin-bottom: 10px;
 }
@@ -56,15 +58,24 @@ fieldset {
 
 .form-label {
   @include core-19;
-  margin-bottom: 5px;
 }
 
 .form-label-bold {
-  @include bold-24;
-  margin-bottom: 0;
+  @include bold-19;
+}
 
-  .form-hint {
-    @include core-19;
+legend {
+  .form-label,
+  .form-label-bold {
+    @include inline-block;
+    margin-bottom: 10px;
+  }
+}
+
+.error legend {
+  .form-label,
+  .form-label-bold {
+    margin-bottom: 0;
   }
 }
 
@@ -73,6 +84,11 @@ fieldset {
   @extend %contain-floats;
   float: left;
   width: 100%;
+  margin-bottom: 5px;
+
+  @include media(tablet) {
+    margin-top: 10px;
+  }
 }
 
 
@@ -80,13 +96,11 @@ fieldset {
 
 // Form hints & examples are light grey and sit above a form control
 .form-hint {
+  @include core-19;
   display: block;
   color: $secondary-text-colour;
+  font-weight: normal;
   margin-bottom: 5px;
-
-  @include media (tablet) {
-    margin-top: 8px;
-  }
 }
 
 // Form controls
@@ -97,7 +111,7 @@ fieldset {
   @include box-sizing(border-box);
   @include core-19;
   width: 100%;
-  
+
   padding: 4px;
   background-color: $white;
   border: 1px solid $border-colour;
@@ -154,7 +168,7 @@ fieldset {
 .form-checkbox {
   display: block;
   margin: $gutter-half 0;
-  
+
   input {
     vertical-align: middle;
     margin: -2px 5px 0 0;

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -10,6 +10,13 @@ fieldset {
   width: 100%;
 }
 
+// Fix left hand gap in IE7 and below
+@include ie-lte(7){
+  legend {
+    margin-left: -7px;
+  }
+}
+
 // Form group is used to wrap label and input pairs
 .form-group {
   @extend %contain-floats;
@@ -64,18 +71,19 @@ fieldset {
   @include bold-19;
 }
 
+// Add spacing under spans within labels
 legend {
   .form-label,
   .form-label-bold {
-    @include inline-block;
-    margin-bottom: 10px;
+    padding-bottom: 7px;
   }
 }
 
+// Remove spacing when error messages are shown
 .error legend {
   .form-label,
   .form-label-bold {
-    margin-bottom: 0;
+    padding-bottom: 0;
   }
 }
 
@@ -85,7 +93,6 @@ legend {
   float: left;
   width: 100%;
   margin-bottom: 5px;
-
   @include media(tablet) {
     margin-top: 10px;
   }

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -5,6 +5,7 @@
 @import "measurements";
 @import "conditionals";
 
+
 // By default, block labels stack vertically
 .block-label {
 
@@ -16,15 +17,12 @@
   background: $panel-colour;
   border: 1px solid $panel-colour;
   padding: (18px $gutter $gutter-half $gutter*1.5);
-  margin-top: 10px;
-  margin-bottom: 10px;
 
+  margin-bottom: 10px;
   cursor: pointer; // Encourage clicking on block labels
 
   @include media(tablet) {
     float: left;
-    margin-top: 5px;
-    margin-bottom: 5px;
     // width: 25%; - Test : check that text within labels will wrap
   }
 
@@ -40,6 +38,10 @@
   &:hover {
     border-color: $black;
   }
+}
+
+.block-label:last-child {
+  margin-bottom: 0;
 }
 
 // To stack horizontally, use .inline on parent, to sit block labels next to each other

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -1,50 +1,107 @@
-// Validation summary box
+// Form validation
+// ==========================================================================
 
-@import "colours";
-@import "measurements";
-@import "conditionals";
-@import "typography";
+// Update the error colour in the govuk frontend toolkit
+$error-colour: #b10e1e;
 
-.validation-summary {
-  border: 3px solid $error-colour;
-  padding: $gutter-half $gutter;
-  margin-bottom: $gutter;
+// Using the classname .error as it's shorter than .validation and easier to type!
+.error {
+
+  // Ensure the .error class is applied to .form-group, otherwide box-sizing(border-box) will need to be used
+  // @include box-sizing(border-box);
+  margin-right: 15px;
+
+  // Error messages should be red and bold
+  .error-message {
+    color: $error-colour;
+    font-weight: bold;
+  }
+
+  // Form inputs should have a red border
+  .form-control {
+    border: 4px solid $error-colour;
+  }
+
+  .form-hint {
+    margin-bottom: 0;
+  }
+
+}
+
+.error,
+.error-summary {
+
+  // Add a red border to the left of the field
+  border-left: 4px solid $error-colour;
+  padding-left: 10px;
+
+  @include media(tablet) {
+    border-left: 5px solid $error-colour;
+    padding-left: $gutter-half;
+  }
+}
+
+.error-message {
+  @include core-19;
+
+  display: block;
+  clear: both;
+
+  margin: 0;
+  padding: 5px 0 10px 0;
+}
+
+// Summary of multiple error messages
+.error-summary {
+
+  // Error summary has a border on all sides
+  border: 4px solid $error-colour;
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  padding: $gutter-half 10px;
+
+  @include media(tablet) {
+    border: 5px solid $error-colour;
+
+    margin-top: $gutter;
+    margin-bottom: $gutter;
+
+    padding: 20px $gutter-half $gutter-half $gutter-half;
+  }
 
   @include ie-lte(6) {
     zoom: 1;
   }
 
-  ul {
-    margin-top: 10px;
+  // Use the GOV.UK outline focus style
+  &:focus {
+    outline: 3px solid $focus-colour;
   }
-  
-  li,
-  p {
-    @include core-16;
+
+  .error-summary-heading {
+    margin-top: 0;
   }
 
   p {
-    margin-top: $gutter-half;
-    margin-bottom: 5px;
+    margin-bottom: 10px;
   }
-  
-  a {
-    color: $error-colour;
-    
-    @include ie-lte(6) {
-      color: $error-colour !important;
+
+  .error-summary-list {
+    padding-left: 0;
+
+    li {
+
+      @include media(tablet) {
+        margin-bottom: 5px;
+      }
+    }
+
+    a {
+      color: $error-colour;
+      font-weight: bold;
+      text-decoration: underline;
     }
   }
-  
-  .heading-small {
-    margin-top: $gutter-half;
-  }
-
-}
-
-// Validation message
-.validation-message {
-  @include core-16;
-  display: block;
-  color: $error-colour;
 }

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -48,7 +48,7 @@ $error-colour: #b10e1e;
   clear: both;
 
   margin: 0;
-  padding: 5px 0 10px 0;
+  padding: 5px 0 7px 0;
 }
 
 // Summary of multiple error messages

--- a/routes.js
+++ b/routes.js
@@ -26,6 +26,38 @@ module.exports = {
       res.render('examples/forms', {'assetPath' : assetPath });
     });
 
+    app.get('/examples/form-validation-single-question-radio', function (req, res) {
+      res.render('examples/form-validation-single-question-radio', {'assetPath' : assetPath});
+    });
+
+    app.post('/examples/form-validation-single-question-radio', function (req, res) {
+      var personal_details = req.body.personal_details;
+      var error = false;
+      if (!personal_details) {
+        error = true;
+      } else {
+        error = false;
+      }
+      res.render('examples/form-validation-single-question-radio', {'assetPath' : assetPath, 'personal_details': personal_details, 'error': error});
+    });
+
+    app.get('/examples/form-validation-multiple-questions', function (req, res) {
+      res.render('examples/form-validation-multiple-questions', {'assetPath' : assetPath });
+    });
+
+    app.post('/examples/form-validation-multiple-questions', function(req, res) {
+      var fullName = req.body.fullName;
+      var niNo = req.body.niNo;
+      var error = false;
+      if (!fullName || !niNo) {
+        error = true;
+      }
+      else {
+        error = false;
+      }
+      res.render('examples/form-validation-multiple-questions', {'assetPath' : assetPath, 'fullName': fullName, 'niNo': niNo, 'error': error});
+    });
+
     // GOV.UK elements test pages
 
     // Progressive disclosure pattern

--- a/views/examples/form-validation-multiple-questions.html
+++ b/views/examples/form-validation-multiple-questions.html
@@ -1,0 +1,99 @@
+{{<govuk_template}}
+
+{{$cookieMessage}}
+  {{>cookie_message}}
+{{/cookieMessage}}
+
+{{$head}}
+  {{>head}}
+  <style>
+  .list-bullet .panel-indent {
+    display: block;
+    margin-top: 5px;
+    margin-bottom: 15px;
+    background: #F5F2F0;
+    padding-right: 15px;
+  }
+
+  .implementation-advice {
+    border-top: 1px solid #bfc1c3;
+    padding-top: 1.25em;
+  }
+
+  .lead-in {
+    margin-bottom: 0;
+  }
+</style>
+{{/head}}
+
+{{$propositionHeader}}
+  {{>propositional_navigation}}
+{{/propositionHeader}}
+
+{{$headerClass}}with-proposition{{/headerClass}}
+
+{{$content}}
+<main class="js-error-example" id="content" role="main">
+
+  <a href="/" class="example-back-link">Back to GOV.UK elements</a>
+
+  <form method="post" action="/examples/form-validation-multiple-questions">
+    {{> form_error_multiple }}
+  </form>
+
+  <h2 class="heading-medium implementation-advice">Implementation advice</h2>
+  <p class="lead-in">When an error occurs:</p>
+  <ul class="list-bullet text">
+    <li>
+      add a 5px red left border to the field with the error
+    </li>
+    <li>
+      show an error summary at the top of the page
+    </li>
+    <li>
+      move keyboard focus to the start of the summary
+      <span class="panel-indent">
+        to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
+      </span>
+    </li>
+    <li>
+      indicate to screenreaders that the summary represents a collection of information
+      <span class="panel-indent">
+        add the ARIA <code>role="group"</code> to the containing <code>div</code>
+      </span>
+    </li>
+    <li>
+      use a heading at the top of the summary
+    </li>
+    <li>
+      associate the heading with the summary box
+      <span class="panel-indent">
+        use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
+      </span>
+    </li>
+    <li>
+      link from the error list in the summary to the fields with errors
+    </li>
+    <li>
+      show an error message before each field with an error
+    </li>
+    <li>
+      associate each error message with the corresponding field
+      <span class="panel-indent">
+         add an ID to each error message and associate this with the field using <code>aria-describedby</code>
+      </span>
+    </li>
+  </ul>
+
+  <p class="text">
+    Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
+  </p>
+
+</main>
+{{/content}}
+
+{{$bodyEnd}}
+  {{>scripts}}
+{{/bodyEnd}}
+
+{{/govuk_template}}

--- a/views/examples/form-validation-single-question-radio.html
+++ b/views/examples/form-validation-single-question-radio.html
@@ -1,0 +1,105 @@
+{{<govuk_template}}
+
+{{$cookieMessage}}
+  {{>cookie_message}}
+{{/cookieMessage}}
+
+{{$head}}
+  {{>head}}
+  <style>
+  .list-bullet .panel-indent {
+    display: block;
+    margin-top: 5px;
+    margin-bottom: 15px;
+    background: #F5F2F0;
+    padding-right: 15px;
+  }
+
+  .implementation-advice {
+    border-top: 1px solid #bfc1c3;
+    padding-top: 1.25em;
+  }
+
+  .lead-in {
+    margin-bottom: 0;
+  }
+  </style>
+{{/head}}
+
+{{$propositionHeader}}
+  {{>propositional_navigation}}
+{{/propositionHeader}}
+
+{{$headerClass}}with-proposition{{/headerClass}}
+
+{{$content}}
+<main class="js-error-example" id="content" role="main">
+
+  <a href="/" class="example-back-link">Back to GOV.UK elements</a>
+
+  <form method="post" action="/examples/form-validation-single-question-radio">
+    {{> form_error_radio }}
+  </form>
+
+  <h2 class="heading-medium implementation-advice">Implementation advice</h2>
+  <p class="lead-in">When an error occurs:</p>
+  <ul class="list-bullet text">
+    <li>
+      add a 5px red left border to the field with the error
+    </li>
+    <li>
+      the error message be red and bold and appear after the question
+    </li>
+    <li>
+      the error message must sit inside the <code>&lt;legend&gt;</code>
+    </li>
+    <li>
+      show an error summary at the top of the page
+    </li>
+    <li>
+      move keyboard focus to the start of the summary
+      <span class="panel-indent">
+        to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
+      </span>
+    </li>
+    <li>
+      indicate to screenreaders that the summary represents a collection of information
+      <span class="panel-indent">
+        add the ARIA <code>role="group"</code> to the containing <code>div</code>
+      </span>
+    </li>
+    <li>
+      use a heading at the top of the summary
+    </li>
+    <li>
+      associate the heading with the summary box
+      <span class="panel-indent">
+        use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
+      </span>
+    </li>
+    <li>
+      link from the error list in the summary to the fields with errors
+    </li>
+    <li>
+      show an error message before each field with an error
+    </li>
+    <li>
+      associate each error message with the corresponding field
+      <span class="panel-indent">
+         add an ID to each error message and associate this with the field using <code>aria-describedby</code>
+      </span>
+    </li>
+  </ul>
+
+  <p class="text">
+    Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
+  </p>
+
+</main>
+{{/content}}
+
+{{$bodyEnd}}
+  {{>scripts}}
+{{/bodyEnd}}
+
+{{/govuk_template}}

--- a/views/index.html
+++ b/views/index.html
@@ -974,20 +974,83 @@
   <div id="guide-errors">
 
     <h2 class="heading-large heading-with-border">8. Errors and validation</h2>
+
+    <h3 class="heading-medium">Minimise the number of errors on a page</h3>
+
     <p class="text">
-       Summarise validation errors in a box at the top of your page.
-       Use jump links in the summary box to reach the errors in the form.
-    </p>
-    <p class="text">
-       Ensure error messages make sense when read by screen readers.
+      Recovering from errors can be hard for users, especially if a page contains multiple errors.
+      Avoid this by splitting long forms across multiple pages, with each page asking a single question.
     </p>
 
-    <h3 class="heading-medium" id="error-form-validation">Form validation</h3>
+    <h3 class="heading-medium">
+      Summarise errors at the top of the page
+    </h3>
+
+    <p class="text lead-in">
+      You must:
+    </p>
+
+    <ul class="text list-bullet">
+      <li>show an error summary at the top of the page</li>
+      <li>include a heading to alert the user to the error</li>
+      <li>link to each of the problematic questions</li>
+    </ul>
+
+    <div class="example example-error">
+      {{> form_error_radio_show_errors }}
+    </div>
+
+    <h4 class="text heading-small panel-indent">
+      The error summary must appear at the top of the page, so it is visible when the page is refreshed and is immediately read out by assistive technology.
+    </h4>
+
+    <div class="text">
+
+      <h3 class="heading-medium">Highlight errors in forms</h3>
+
+      <p class="lead-in">
+        For each error:
+      </p>
+
+      <ul class="list-bullet">
+        <li>write a message that helps the user to understand why the error occurred and what to do about it</li>
+        <li>put the message in the <code>&lt;label&gt;</code> or <code>&lt;legend&gt;</code> for the question,
+        after the question text, in red</li>
+        <li>use a red border to visually connect the message and the question it belongs to</li>
+        <li>if the error relates to specific text fields within the question, give these a red border as well</li>
+      </ul>
+
+    </div>
+
+    <p class="text">
+      For red, use the <code>$error-colour</code> Sass variable &ndash; find this in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_colours.scss">colours.scss</a> file
+    </p>
+
+    <div class="example example-error">
+      {{> form_error_multiple_show_errors }}
+    </div>
+
+    <p class="text">
+      If users are regularly making multiple errors on a page this indicates that your page has either too many questions, or that the question needs to be rewritten in plain English.
+    </p>
+
+    <p class="text">
+      Simplify the page by rewriting and where possible, removing questions or splitting questions across multiple pages.
+    </p>
+
+    <h3 class="heading-medium" id="error-message-examples">Implementation examples</h3>
+
     <ul class="list-bullet text">
-      <li>use a red border on the box to visually connect the errors and messages in the form</li>
-      <li>apply the same colour to the area of the form where an error has occurred</li>
-      <li>error copy should be specific to the question and validation should identify all errors</li>
-      <li>errors should not cause pre-filled fields to clear</li>
+      <li>
+        <a href="{{ site.baseurl}}/examples/form-validation-single-question-radio">
+          Example with one question, a group of radio buttons
+        </a>
+      </li>
+      <li>
+        <a href="{{ site.baseurl}}/examples/form-validation-multiple-questions">
+          Example with multiple questions
+        </a>
+      </li>
     </ul>
 
     <p>
@@ -1004,7 +1067,7 @@
       You have to use an alpha banner if your thing is in alpha, and a beta banner if it’s in beta.
     </p>
 
-    <h3 class="heading-medium" id="error-form-validation">Things on the service.gov.uk subdomain</h3>
+    <h3 class="heading-medium" id="guide-alpha-beta-subdomain">Things on the service.gov.uk subdomain</h3>
     <p class="text">
       If your service is in beta or alpha, you must show the relevant banner in the header.
       It should sit directly underneath the black GOV.UK header and colour bar.
@@ -1018,7 +1081,7 @@
       {{> phase_banner_beta }}
     </div>
 
-    <h3 class="heading-medium" id="error-form-validation">Things on GOV.UK</h3>
+    <h3 class="heading-medium" id="guide-alpha-beta-govuk">Things on GOV.UK</h3>
     <p class="text">
       If your GOV.UK content is in beta or alpha, show the relevant banner below the page title, but above the body content. You can see what they should look like in <a href="https://designnotes.blog.gov.uk/2014/03/26/betas-on-gov-uk/">this blog post</a>.
     </p>

--- a/views/snippets.html
+++ b/views/snippets.html
@@ -33,7 +33,7 @@
   <li><a href="#guide-data">Data</a></li>
   <li><a href="#guide-forms">Forms</a></li>
   <li><a href="#guide-buttons">Buttons</a></li>
-  <li>Errors and validation</li>
+  <li><a href="#guide-errors">Errors and validation</a></li>
   <li><a href="#guide-alpha-beta">Alpha and beta banners</a></li>
 </ol>
 
@@ -307,12 +307,26 @@
 </pre>
 
 <!-- 8. Errors and validation -->
-<!-- TODO :
+
 <h2 class="heading-medium" id="guide-errors">8. Errors and validation</h2>
 
-<pre><code class="language-markup">
-</code></pre>
--->
+<div class="example">
+  {{> form_error_radio_show_errors }}
+</div>
+<pre>
+<code class="language-markup">
+  {{> form_error_radio_show_errors }}
+</code>
+</pre>
+
+<div class="example">
+  {{> form_error_multiple_show_errors }}
+</div>
+<pre>
+<code class="language-markup">
+  {{> form_error_multiple_show_errors }}
+</code>
+</pre>
 
 <!-- 9. Alpha beta banners -->
 

--- a/views/snippets/form_date.html
+++ b/views/snippets/form_date.html
@@ -1,7 +1,10 @@
 <div class="form-group">
   <fieldset>
-    <legend class="form-label-bold">Date of birth</legend>
-
+    <legend>
+      <span class="form-label-bold">
+        Date of birth
+      </span>
+    </legend>
     <div class="form-date">
 
       <p class="form-hint">For example, 31 3 1980</p>

--- a/views/snippets/form_error_multiple.html
+++ b/views/snippets/form_error_multiple.html
@@ -11,10 +11,10 @@
 
   <ul class="error-summary-list">
     {{^fullName}}
-    <li><a href="#error-full-name">Descriptive link to the question with an error</a></li>
+    <li><a href="#example-full-name">Descriptive link to the question with an error</a></li>
     {{/fullName}}
     {{^niNo}}
-    <li><a href="#error-ni-number">Descriptive link to the question with an error</a></li>
+    <li><a href="#example-ni-number">Descriptive link to the question with an error</a></li>
     {{/niNo}}
   </ul>
 
@@ -44,7 +44,7 @@
 
 <div class="form-group {{#error}}{{^niNo}}error{{/niNo}}{{/error}}">
 
-  <label for="example-ni-number" {{#error}}{{^fullName}}id="error-full-name"{{/fullName}}{{/error}}>
+  <label for="example-ni-number" {{#error}}{{^niNo}}id="error-full-name"{{/niNo}}{{/error}}>
 
     <span class="form-label-bold">National Insurance number</span>
     <span class="form-hint">

--- a/views/snippets/form_error_multiple.html
+++ b/views/snippets/form_error_multiple.html
@@ -26,25 +26,44 @@
 </h1>
 
 <div class="form-group {{#error}}{{^fullName}}error{{/fullName}}{{/error}}">
-  <label for="full-name">
+
+  <label for="example-full-name" {{#error}}{{^fullName}}id="error-full-name"{{/fullName}}{{/error}}>
+
     <span class="form-label-bold">Full name</span>
     <span class="form-hint">As shown on your birth certificate or passport</span>
-    {{#error}}{{^fullName}}<span class="error-message">Error message about full name goes here</span>{{/fullName}}{{/error}}
+    {{#error}}
+      {{^fullName}}
+      <span class="error-message" id="error-message-full-name">Error message about full name goes here</span>
+      {{/fullName}}
+    {{/error}}
+
   </label>
-  <input class="form-control" id="full-name" type="text" name="fullName" value="{{fullName}}" {{#error}}{{^fullName}}aria-describedby="error-full-name"{{/fullName}}{{/error}}>
+
+  <input class="form-control" id="example-full-name" type="text" name="fullName" value="{{fullName}}" {{#error}}{{^fullName}}aria-describedby="error-message-full-name"{{/fullName}}{{/error}}>
 </div>
 
 <div class="form-group {{#error}}{{^niNo}}error{{/niNo}}{{/error}}">
-  <label class="form-label" for="ni-number">
+
+  <label for="example-ni-number" {{#error}}{{^fullName}}id="error-full-name"{{/fullName}}{{/error}}>
+
     <span class="form-label-bold">National Insurance number</span>
     <span class="form-hint">
       It's on your National Insurance card, benefit letter, payslip or P60.
       <br>
       For example, 'VO 12 34 56 D'.
     </span>
-    {{#error}}{{^niNo}}<span class="error-message">Error message about National Insurance number goes here</span>{{/niNo}}{{/error}}
+    {{#error}}
+      {{^niNo}}
+      <span class="error-message" id="error-message-ni-number">
+        Error message about National Insurance number goes here
+      </span>
+      {{/niNo}}
+    {{/error}}
+
   </label>
-  <input class="form-control" id="ni-number" type="text" name="niNo" value="{{niNo}}" {{#error}}{{^niNo}}aria-describedby="error-ni-number"{{/niNo}}{{/error}}>
+
+  <input class="form-control" id="example-ni-number" type="text" name="niNo" value="{{niNo}}" {{#error}}{{^niNo}}aria-describedby="error-message-ni-number"{{/niNo}}{{/error}}>
+
 </div>
 
 <input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_multiple.html
+++ b/views/snippets/form_error_multiple.html
@@ -1,0 +1,50 @@
+{{#error}}
+<div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
+
+  <h1 class="heading-medium error-summary-heading" id="error-summary-heading">
+    Message to alert the user to a problem goes here
+  </h1>
+
+  <p>
+    Optional description of the error(s) and how to correct them
+  </p>
+
+  <ul class="error-summary-list">
+    {{^fullName}}
+    <li><a href="#error-full-name">Descriptive link to the question with an error</a></li>
+    {{/fullName}}
+    {{^niNo}}
+    <li><a href="#error-ni-number">Descriptive link to the question with an error</a></li>
+    {{/niNo}}
+  </ul>
+
+</div>
+{{/error}}
+
+<h1 class="heading-large">
+  Your personal details
+</h1>
+
+<div class="form-group {{#error}}{{^fullName}}error{{/fullName}}{{/error}}">
+  <label for="full-name">
+    <span class="form-label-bold">Full name</span>
+    <span class="form-hint">As shown on your birth certificate or passport</span>
+    {{#error}}{{^fullName}}<span class="error-message">Error message about full name goes here</span>{{/fullName}}{{/error}}
+  </label>
+  <input class="form-control" id="full-name" type="text" name="fullName" value="{{fullName}}" {{#error}}{{^fullName}}aria-describedby="error-full-name"{{/fullName}}{{/error}}>
+</div>
+
+<div class="form-group {{#error}}{{^niNo}}error{{/niNo}}{{/error}}">
+  <label class="form-label" for="ni-number">
+    <span class="form-label-bold">National Insurance number</span>
+    <span class="form-hint">
+      It's on your National Insurance card, benefit letter, payslip or P60.
+      <br>
+      For example, 'VO 12 34 56 D'.
+    </span>
+    {{#error}}{{^niNo}}<span class="error-message">Error message about National Insurance number goes here</span>{{/niNo}}{{/error}}
+  </label>
+  <input class="form-control" id="ni-number" type="text" name="niNo" value="{{niNo}}" {{#error}}{{^niNo}}aria-describedby="error-ni-number"{{/niNo}}{{/error}}>
+</div>
+
+<input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_multiple_show_errors.html
+++ b/views/snippets/form_error_multiple_show_errors.html
@@ -1,0 +1,59 @@
+<div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-2" tabindex="-1">
+
+  <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-2">
+    Message to alert the user to a problem goes here
+  </h1>
+
+  <p>
+    Optional description of the error(s) and how to correct them
+  </p>
+
+  <ul class="error-summary-list">
+    {{^fullName}}
+    <li><a href="#error-full-name">Descriptive link to the question with an error</a></li>
+    {{/fullName}}
+    {{^niNo}}
+    <li><a href="#error-ni-number">Descriptive link to the question with an error</a></li>
+    {{/niNo}}
+  </ul>
+
+</div>
+
+<h1 class="heading-large form-title">
+  Your details
+</h1>
+
+<div class="form-group error">
+
+  <label class="form-label-bold" for="error-example-full-name">
+
+    Full name
+
+    <span class="form-hint">As shown on your birth certificate or passport</span>
+    <span class="error-message" id="error-full-name">Error message about full name goes here</span>
+
+  </label>
+
+  <input class="form-control" id="error-example-full-name" type="text" name="fullName" value="" aria-describedby="error-full-name">
+</div>
+
+<div class="form-group error">
+
+  <label class="form-label-bold" for="error-example-ni-number">
+
+    National Insurance number
+
+    <span class="form-hint">
+      It's on your National Insurance card, benefit letter, payslip or P60.
+      <br>
+      For example, 'VO 12 34 56 D'.
+    </span>
+
+    <span class="error-message" id="error-ni-number">Error message about National Insurance number goes here</span>
+
+  </label>
+
+  <input class="form-control" id="error-example-ni-number" type="text" name="niNo" value="" aria-describedby="error-ni-number">
+</div>
+
+<input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_multiple_show_errors.html
+++ b/views/snippets/form_error_multiple_show_errors.html
@@ -9,18 +9,14 @@
   </p>
 
   <ul class="error-summary-list">
-    {{^fullName}}
-    <li><a href="#error-full-name">Descriptive link to the question with an error</a></li>
-    {{/fullName}}
-    {{^niNo}}
-    <li><a href="#error-ni-number">Descriptive link to the question with an error</a></li>
-    {{/niNo}}
+    <li><a href="#example-full-name">Descriptive link to the question with an error</a></li>
+    <li><a href="#example-ni-number">Descriptive link to the question with an error</a></li>
   </ul>
 
 </div>
 
 <h1 class="heading-large">
-  Your details
+  Your personal details
 </h1>
 
 <div class="form-group error">

--- a/views/snippets/form_error_multiple_show_errors.html
+++ b/views/snippets/form_error_multiple_show_errors.html
@@ -19,41 +19,41 @@
 
 </div>
 
-<h1 class="heading-large form-title">
+<h1 class="heading-large">
   Your details
 </h1>
 
 <div class="form-group error">
 
-  <label class="form-label-bold" for="error-example-full-name">
+  <label for="example-full-name" id="error-full-name">
 
-    Full name
-
+    <span class="form-label-bold">Full name</span>
     <span class="form-hint">As shown on your birth certificate or passport</span>
-    <span class="error-message" id="error-full-name">Error message about full name goes here</span>
+    <span class="error-message" id="error-message-full-name">Error message about full name goes here</span>
 
   </label>
 
-  <input class="form-control" id="error-example-full-name" type="text" name="fullName" value="" aria-describedby="error-full-name">
+  <input class="form-control" id="example-full-name" type="text" name="fullName" value="" aria-describedby="error-message-full-name">
 </div>
 
 <div class="form-group error">
 
-  <label class="form-label-bold" for="error-example-ni-number">
+  <label for="example-ni-number" id="error-ni-number">
 
-    National Insurance number
-
+    <span class="form-label-bold">National Insurance number</span>
     <span class="form-hint">
       It's on your National Insurance card, benefit letter, payslip or P60.
       <br>
       For example, 'VO 12 34 56 D'.
     </span>
-
-    <span class="error-message" id="error-ni-number">Error message about National Insurance number goes here</span>
+    <span class="error-message" id="error-message-ni-number">
+      Error message about National Insurance number goes here
+    </span>
 
   </label>
 
-  <input class="form-control" id="error-example-ni-number" type="text" name="niNo" value="" aria-describedby="error-ni-number">
+  <input class="form-control" id="example-ni-number" type="text" name="niNo" value="" aria-describedby="error-message-ni-number">
+
 </div>
 
 <input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_radio.html
+++ b/views/snippets/form_error_radio.html
@@ -33,7 +33,6 @@
       <span class="form-label-bold">
         Are your personal details correct and up-to-date?
       </span>
-
       {{#error}}
         <span class="error-message">
           Error message about personal details goes here

--- a/views/snippets/form_error_radio.html
+++ b/views/snippets/form_error_radio.html
@@ -29,14 +29,17 @@
   <fieldset>
 
     <legend {{#error}}id="error-personal-details"{{/error}}>
+
       <span class="form-label-bold">
         Are your personal details correct and up-to-date?
       </span>
+
       {{#error}}
         <span class="error-message">
           Error message about personal details goes here
         </span>
       {{/error}}
+
     </legend>
 
     <label class="block-label" for="personal_details_yes">

--- a/views/snippets/form_error_radio.html
+++ b/views/snippets/form_error_radio.html
@@ -1,0 +1,55 @@
+{{#error}}
+<div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
+
+  <h1 class="heading-medium error-summary-heading" id="error-summary-heading">
+    Message to alert the user to a problem goes here
+  </h1>
+
+  <p>
+    Optional description of the error(s) and how to correct them
+  </p>
+
+  <ul class="error-summary-list">
+    <li><a href="#error-personal-details">Descriptive link to the question with an error</a></li>
+  </ul>
+
+</div>
+{{/error}}
+
+<h1 class="heading-large">
+  Check your personal details
+</h1>
+
+<p class="lede">
+  Look at your name, signature and other details.
+</p>
+
+
+<div class="form-group {{#error}}error{{/error}}">
+  <fieldset>
+
+    <legend {{#error}}id="error-personal-details"{{/error}}>
+      <span class="form-label-bold">
+        Are your personal details correct and up-to-date?
+      </span>
+      {{#error}}
+        <span class="error-message">
+          Error message about personal details goes here
+        </span>
+      {{/error}}
+    </legend>
+
+    <label class="block-label" for="personal_details_yes">
+      <input id="personal_details_yes" type="radio" name="personal_details" value="Yes">
+      <span></span> Yes, my personal details are correct
+    </label>
+
+    <label class="block-label" for="personal_details_no">
+      <input id="personal_details_no" type="radio" name="personal_details" value="No">
+      <span></span> No, some details are wrong or have changed
+    </label>
+
+  </fieldset>
+</div>
+
+<input class="button" type="submit" value="Continue">

--- a/views/snippets/form_error_radio.html
+++ b/views/snippets/form_error_radio.html
@@ -10,7 +10,7 @@
   </p>
 
   <ul class="error-summary-list">
-    <li><a href="#error-personal-details">Descriptive link to the question with an error</a></li>
+    <li><a href="#example-personal-details">Descriptive link to the question with an error</a></li>
   </ul>
 
 </div>
@@ -28,7 +28,7 @@
 <div class="form-group {{#error}}error{{/error}}">
   <fieldset>
 
-    <legend {{#error}}id="error-personal-details"{{/error}}>
+    <legend {{#error}}id="example-personal-details"{{/error}}>
 
       <span class="form-label-bold">
         Are your personal details correct and up-to-date?

--- a/views/snippets/form_error_radio_show_errors.html
+++ b/views/snippets/form_error_radio_show_errors.html
@@ -9,7 +9,7 @@
   </p>
 
   <ul class="error-summary-list">
-    <li><a href="#error-personal-details">Descriptive link to the question with an error</a></li>
+    <li><a href="#example-personal-details">Descriptive link to the question with an error</a></li>
   </ul>
 
 </div>
@@ -26,7 +26,7 @@
   <div class="form-group error">
     <fieldset>
 
-      <legend id="error-personal-details">
+      <legend id="example-personal-details">
 
         <span class="form-label-bold">
           Are your personal details correct and up-to-date?

--- a/views/snippets/form_error_radio_show_errors.html
+++ b/views/snippets/form_error_radio_show_errors.html
@@ -26,7 +26,7 @@
   <div class="form-group error">
     <fieldset>
 
-      <legend class="form-label-bold" id="error-personal-details">
+      <legend id="error-personal-details">
 
         <span class="form-label-bold">
           Are your personal details correct and up-to-date?
@@ -34,6 +34,7 @@
         <span class="error-message">
           Error message about personal details goes here
         </span>
+
       </legend>
 
       <label class="block-label" for="personal_details_yes">

--- a/views/snippets/form_error_radio_show_errors.html
+++ b/views/snippets/form_error_radio_show_errors.html
@@ -1,0 +1,49 @@
+<div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+
+  <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+    Message to alert the user to a problem goes here
+  </h1>
+
+  <p>
+    Optional description of the error(s) and how to correct them
+  </p>
+
+  <ul class="error-summary-list">
+    <li><a href="#error-personal-details">Descriptive link to the question with an error</a></li>
+  </ul>
+
+</div>
+
+<h1 class="heading-large">
+  Check your personal details
+</h1>
+<p>
+  Look at your name, signature and other details.
+</p>
+
+<form>
+  <div class="form-group error">
+    <fieldset>
+
+      <legend class="form-label-bold" id="error-personal-details">
+        Are your personal details correct and up-to-date?
+        <span class="error-message">
+          Error message about personal details goes here
+        </span>
+      </legend>
+
+      <label class="block-label" for="personal_details_yes">
+        <input id="personal_details_yes" type="radio" name="personal_details" value="Yes">
+        <span></span> Yes, my personal details are correct
+      </label>
+
+      <label class="block-label" for="personal_details_no">
+        <input id="personal_details_no" type="radio" name="personal_details" value="No">
+        <span></span> No, some details are wrong or have changed
+      </label>
+
+    </fieldset>
+  </div>
+
+  <input class="button" type="submit" value="Continue">
+</form>

--- a/views/snippets/form_error_radio_show_errors.html
+++ b/views/snippets/form_error_radio_show_errors.html
@@ -17,6 +17,7 @@
 <h1 class="heading-large">
   Check your personal details
 </h1>
+
 <p>
   Look at your name, signature and other details.
 </p>
@@ -26,7 +27,10 @@
     <fieldset>
 
       <legend class="form-label-bold" id="error-personal-details">
-        Are your personal details correct and up-to-date?
+
+        <span class="form-label-bold">
+          Are your personal details correct and up-to-date?
+        </span>
         <span class="error-message">
           Error message about personal details goes here
         </span>
@@ -46,4 +50,5 @@
   </div>
 
   <input class="button" type="submit" value="Continue">
+
 </form>

--- a/views/snippets/form_inset_checkboxes.html
+++ b/views/snippets/form_inset_checkboxes.html
@@ -1,5 +1,9 @@
 <fieldset>
-  <legend class="form-label-bold">What is your nationality?</legend>
+  <legend>
+    <span class="form-label-bold">
+      What is your nationality?
+    </span>
+  </legend>
   <p>
     Select all options that are relevant to you.
   </p>

--- a/views/snippets/form_inset_radios.html
+++ b/views/snippets/form_inset_radios.html
@@ -1,5 +1,9 @@
 <fieldset class="inline">
-  <legend class="form-label">Do you know their National Insurance number?</legend>
+  <legend>
+    <span class="form-label">
+      Do you know their National Insurance number?
+    </span>
+  </legend>
   <div class="form-group form-group-compound">
     <label class="block-label" data-target="example-ni-no" for="radio-indent-1">
       <input id="radio-indent-1" type="radio" name="radio-indent-group" value="Yes">

--- a/views/snippets/form_inset_radios.html
+++ b/views/snippets/form_inset_radios.html
@@ -1,7 +1,7 @@
 <fieldset class="inline">
   <legend class="form-label">Do you know their National Insurance number?</legend>
   <div class="form-group form-group-compound">
-    <label class="block-label" data-target="example-ni-number" for="radio-indent-1">
+    <label class="block-label" data-target="example-ni-no" for="radio-indent-1">
       <input id="radio-indent-1" type="radio" name="radio-indent-group" value="Yes">
       Yes
     </label>
@@ -10,7 +10,7 @@
       No
     </label>
   </div>
-  <div class="panel-indent js-hidden" id="example-ni-number">
+  <div class="panel-indent js-hidden" id="example-ni-no">
     <label class="form-label" for="national-insurance">National Insurance number</label>
     <input class="form-control" type="text" id="national-insurance">
   </div>


### PR DESCRIPTION
There has been rather a lot of back-and-forth in the previous PR while this was tested further.
This is a new clean branch with the proposed changes to the errors and validation section.

It can be previewed here: https://govuk-elements-test.herokuapp.com/

Our current thinking about validation messages is:
- encourage the use of error summary boxes, as close to the top of the main content as possible
- provide a link to correct each error within the summary box
- error text must sit within either the label or legend for the question it relates to, to ensure it is read out by Assistive Technology

There are two example pages, one which shows how to display errors for a single question - a group of radio buttons and another which shows how to display errors for multiple questions. They have additional implementation advice underneath each example.

In both cases a summary box has been used and the wording is generic, to discourage these examples being copied verbatim. The words used as error messages in the examples show how the messages should differ, however, the exact wording used for error messages is outside the scope of this pull request.

![gov uk elements - errors](https://cloud.githubusercontent.com/assets/417754/7637584/e6ef24e0-fa66-11e4-8d6e-c83350bb5beb.png)

![gov uk the best place to find government services and information - example 1](https://cloud.githubusercontent.com/assets/417754/7637537/93f5dc16-fa66-11e4-8702-221e78637a68.png)
![gov uk the best place to find government services and information - example 3](https://cloud.githubusercontent.com/assets/417754/7637543/9abc5386-fa66-11e4-80bf-1345539500ad.png)