### PR TITLE
Add swatches for discovery and live colours

### DIFF
--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -207,6 +207,14 @@ $palette: (
   background-color: $beta-colour;
 }
 
+.swatch-discovery {
+  background-color: $discovery-colour;
+}
+
+.swatch-live {
+  background-color: $live-colour;
+}
+
 .swatch-error {
   background-color: $error-colour;
 }

--- a/views/index.html
+++ b/views/index.html
@@ -355,6 +355,24 @@
       </div>
       <div class="swatch-wrapper">
 
+        <div class="swatch swatch-discovery"></div>
+        <ul>
+          <li><b>#912b88</b></li>
+          <li>$discovery-colour</li>
+        </ul>
+
+      </div>
+      <div class="swatch-wrapper">
+
+        <div class="swatch swatch-live"></div>
+        <ul>
+          <li><b>#85994b</b></li>
+          <li>$live-colour</li>
+        </ul>
+
+      </div>
+      <div class="swatch-wrapper">
+
         <div class="swatch swatch-error"></div>
         <ul>
           <li><b>#af1324</b></li>


### PR DESCRIPTION
- Add .swatch-colourname classes for discovery and live
- Add discovery and live colour swatches to index page

Check against govuk front end toolkit:

$discovery-colour: $fuschia: #912b88;
$live-colour : $grass-green: #85994b;

This reflects the changes made by @edwardhorsford in the [govuk front end toolkit 3.5.1](https://github.com/alphagov/govuk_frontend_toolkit_npm/commit/0d86d11004afad88a612d2a63f329a53cd46278c).

Screenshot below.

![gov uk elements - colour palette](https://cloud.githubusercontent.com/assets/417754/7679078/5fa0bd8a-fd51-11e4-8709-b7a6eab4d529.png)
