### PR TITLE
Only set $path if not already set

### DIFF
--- a/public/sass/elements/_helpers.scss
+++ b/public/sass/elements/_helpers.scss
@@ -7,8 +7,10 @@
 @import "typography";
 @import "css3";
 
-// Path to assets for use with file-url()
-$path: "/public/images/";
+// Path to assets for use with file-url() is not already defined
+@if ($path == false) {
+    $path: "/public/images/";
+}
 
 // Return ems from a pixel value
 // This assumes a base of 19px


### PR DESCRIPTION
Some users of the GOV UK Elements sass have their own existing file structure for image assets. When the $path was added it created urls starting with /public/images but it would be more flexible to allow other users to set their own value. By making the assignment optional, if a developer has defined $path in their top level file it will use that instead. Alternatively move the $path assignment out of the helper and up to the main.scss file
