### PR TITLE
Remove top-margin from 1st element in indented panel

### DIFF
--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -16,6 +16,11 @@
   legend {
     margin-top: 0;
   }
+
+  // Remove top margin on first element
+  & > * {
+    margin-top: 0;
+  }
   
   // Remove bottom margin on last paragraph
   p:only-child,


### PR DESCRIPTION
If your indented panel start with a heading (or another element with a top-margin) you end up with unwanted whitespace. This fixes that.