### PR TITLE
Add fixed character width form controls

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -160,6 +160,24 @@ legend {
   width: 12.5%;
 }
 
+// Fixed character width form controls
+.form-control-1-char    { width: 1.5em }
+.form-control-2-chars   { width: 2.4em }
+.form-control-3-chars   { width: 3.3em }
+.form-control-4-chars   { width: 4.2em }
+.form-control-5-chars   { width: 5.1em }
+.form-control-6-chars   { width: 6em }
+.form-control-7-chars   { width: 7em }
+.form-control-8-chars   { width: 8em }
+.form-control-9-chars   { width: 9em }
+.form-control-10-chars  { width: 10em }
+.form-control-11-chars  { width: 11em }
+.form-control-12-chars  { width: 12em }
+.form-control-13-chars  { width: 13em }
+.form-control-14-chars  { width: 14em }
+.form-control-15-chars  { width: 15em }
+.form-control-16-chars  { width: 16em }
+
 
 // Radio buttons
 .form-radio {


### PR DESCRIPTION
For short form fields where the maximum number of characters is known it can be more useful to have fixed widths. These styles allow for that.

Note: the widths may need tweaking and there's probably a neater way of specifying these styles in sass.