### PR TITLE
[WIP] Propose gutter multiples for fixed widths

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -149,6 +149,43 @@ legend {
 // 6. Form controls
 // ==========================================================================
 
+// NEW form control widths
+// These make use of the gutter multiplier function
+// to give multiples of either 30px ($gutter) or 15px ($gutter-half)
+
+@function gutter-multiplier($gutter, $multiplier) {
+  @return $gutter * $multiplier
+}
+
+// Usage:
+// .my-form-control-width {
+//    width: gutter-multiplier($gutter, 2);
+// }
+
+// TODO: Decide on naming convention for gutter-based widths
+.form-control-1 {
+  width: gutter-multiplier($gutter, 1);
+}
+
+.form-control-2 {
+  width: gutter-multiplier($gutter, 2);
+}
+
+.form-control-4 {
+  width: gutter-multiplier($gutter, 4);
+}
+
+.form-control-8 {
+  width: gutter-multiplier($gutter, 8);
+}
+
+.form-control-16 {
+  width: gutter-multiplier($gutter, 16);
+}
+
+// OLD form control percentage widths
+// Use the fixed widths above in future
+
 // By default, form controls are 50% width for desktop,
 // and 100% width for mobile
 .form-control {


### PR DESCRIPTION
** Please note: These changes aren’t ready to merge and are here to get feedback on how this should work ** 

These changes also include the form reorganisation changes from #85. Ignore those as they will be removed once #85 has been merged.

[Take a look at this commit](https://github.com/alphagov/govuk_elements/commit/e4544a0938264f6e8c49fa3ad60e6ef49c492b3f) which takes @edwardhorsford's suggestion to used fixed widths based off multiples of the gutter.

Not yet considered in this PR:
- These will need to be declared in media queries for tablet and up.
- How to remove the existing 50% width for tablet and up without causing a breaking change