### PR TITLE
Make buttons full width for smaller screens

### DIFF
--- a/public/sass/elements/_buttons.scss
+++ b/public/sass/elements/_buttons.scss
@@ -7,9 +7,13 @@
 
 .button {
   @include button ($button-colour);
+  @include box-sizing (border-box);
   margin: 0 $gutter-half $gutter-half 0;
   padding: em(10) em(15) em(5) em(15);
   vertical-align: top;
+  @include media (mobile) {
+    width: 100%;
+  }
 }
 
 // Fix unwanted button padding in Firefox

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -194,14 +194,6 @@ legend {
   }
 }
 
-// Buttons
-// Ensure buttons are full-width for smaller screens
-form .button {
-  @include media(mobile) {
-    width: 100%;
-  }
-}
-
 
 // 7. Form control widths
 // ==========================================================================


### PR DESCRIPTION
These changes match those [already made to the GOV.UK prototype kit]( https://github.com/alphagov/govuk_prototype_kit/commit/da465756c1ed08e2c25735924ee2317abc508b0a).

