### PR TITLE
Change to 'button-start' class name

### DIFF
--- a/public/sass/elements/_buttons.scss
+++ b/public/sass/elements/_buttons.scss
@@ -36,6 +36,7 @@
 }
 
 // Start now buttons
+.button-start,
 .button-get-started {
   @include bold-24;
   background-image: file-url("icons/icon-pointer.png");


### PR DESCRIPTION
The current class name is `button-get-started` which can be confusing and hard to remember if you don't have that text on the button.

The example says 'Start now' - I propose just having `button-start` so it's agnostic to what text is on the button.

Continue to support `button-get-started` as an alias for now, so it doesn't break people's code