### PR TITLE
Form control test page

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -165,10 +165,6 @@ legend {
   background-color: $white;
   border: 1px solid $border-colour;
 
-  // Disable webkit appearance and remove rounded corners
-  -webkit-appearance: none;
-  border-radius: 0;
-
   // TODO: Remove 50% width set for tablet and up
   // !! BREAKING CHANGE !!
   @include media(tablet) {

--- a/routes.js
+++ b/routes.js
@@ -75,5 +75,10 @@ module.exports = {
       res.render('patterns/radios_checkboxes', {'assetPath' : assetPath });
     });
 
+    // Form element test page
+    app.get('/test/form-elements', function (req, res) {
+      res.render('test/form_elements', {'assetPath' : assetPath });
+    });
+
   }
 };

--- a/views/test/form_elements.html
+++ b/views/test/form_elements.html
@@ -1,0 +1,101 @@
+{{<govuk_template}}
+
+{{$cookieMessage}}
+  {{>cookie_message}}
+{{/cookieMessage}}
+
+{{$head}}
+  {{>head}}
+{{/head}}
+
+{{$propositionHeader}}
+  {{>propositional_navigation}}
+{{/propositionHeader}}
+
+{{$headerClass}}with-proposition{{/headerClass}}
+
+{{$content}}
+<main id="content" role="main">
+
+  <a href="/" class="link-back">Back to GOV.UK elements</a>
+
+  <form action="/" method="post" class="form">
+
+    <h1 class="heading-large">
+      Form elements test page
+    </h1>
+
+    <!-- Input type="text" -->
+    <div class="form-group">
+      <label class="form-label" for="input-text">Single line text fields</label>
+      <input class="form-control" id="input-text" type="text">
+    </div>
+
+    <!-- Textarea -->
+    <div class="form-group">
+      <label class="form-label" for="textarea">Multi-line text fields</label>
+      <textarea class="form-control" id="textarea" cols="30" rows="10"></textarea>
+    </div>
+
+    <!-- Select box -->
+    <div class="form-group">
+      <label class="form-label" for="select-box">Drop down content</label>
+      <select class="form-control" id="select-box">
+        <option>Banana</option>
+        <option>Cherry</option>
+        <option>Lemon</option>
+      </select>
+    </div>
+
+    <!-- Check box -->
+    <div class="form-group">
+      <label class="form-checkbox" for="checkbox-telephone-number" >
+        <input id="checkbox-telephone-number" type="checkbox" value="checkbox-telephone-number">
+        Native check box
+      </label>
+    </div>
+
+    <!-- Chunky check box -->
+
+    <div class="form-group">
+      <label class="block-label" for="checkbox-1">
+        <input id="checkbox-1" type="checkbox" value="waste-animal">
+        Checkbox
+      </label>
+      <label class="block-label" for="checkbox-2">
+        <input id="checkbox-2" type="checkbox" value="waste-mines">
+        Checkbox
+      </label>
+      <label class="block-label" for="checkbox-3">
+        <input id="checkbox-3" type="checkbox" value="farm-agricultural">
+        Checkbox
+      </label>
+    </div>
+
+    <!-- Radio button -->
+
+    <div class="form-group">
+      <label class="block-label" for="radio-1">
+        <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">
+        Radio
+      </label>
+      <label class="block-label" for="radio-2">
+        <input id="radio-2" type="radio" name="radio-group" value="Isle of Man or the Channel Islands">
+        Radio
+      </label>
+      <label class="block-label" for="radio-3">
+        <input id="radio-3" type="radio" name="radio-group" value="I am a British citizen living abroad">
+        Radio
+      </label>
+    </div>
+
+  </form>
+
+</main><!-- / #content -->
+{{/content}}
+
+{{$bodyEnd}}
+  {{>scripts}}
+{{/bodyEnd}}
+
+{{/govuk_template}}


### PR DESCRIPTION
This PR creates a new test page for form elements and shows the difference when `-webkit-appearance: none` is removed from `.form-control`. 

Screenshots:

Before:

![dd-before](https://cloud.githubusercontent.com/assets/417754/9499999/c22b6b90-4c1a-11e5-871d-0829c4a3c51f.png)

After:

![dd-after](https://cloud.githubusercontent.com/assets/417754/9500004/ca01ac80-4c1a-11e5-8e56-abf68e11878d.png)

