### PR TITLE
Fixes for the details summary polyfill

### DIFF
--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -175,8 +175,8 @@
     // Also update the arrow position
     function statechange(summary) {
 
-      var expanded = summary.__details.__summary.getAttribute('aria-expanded') == 'true';
-      var hidden = summary.__details.__content.getAttribute('aria-hidden') == 'true';
+      var expanded = summary.__details.__summary.getAttribute('aria-expanded') === 'true';
+      var hidden = summary.__details.__content.getAttribute('aria-hidden') === 'true';
 
       summary.__details.__summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'));
       summary.__details.__content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'));

--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -9,6 +9,8 @@
 (function () {
   'use strict';
 
+  var NATIVE_DETAILS = typeof document.createElement('details').open === 'boolean';
+
   // Add event construct for modern browsers or IE
   // which fires the callback with a pre-converted target reference
   function addEvent(node, type, callback) {
@@ -82,9 +84,6 @@
     for (i; i < n; i++) {
       var details = list[i];
 
-      // Detect native implementations
-      details.__native = typeof(details.open) == 'boolean';
-
       // Save shortcuts to the inner summary and content elements
       details.__summary = details.getElementsByTagName('summary').item(0);
       details.__content = details.getElementsByTagName('div').item(0);
@@ -104,12 +103,11 @@
       // Add aria-controls
       details.__summary.setAttribute('aria-controls', details.__content.id);
 
-      // Set tabindex so the summary is keyboard accessible
-      // details.__summary.setAttribute('tabindex', 0);
+      // Set tabIndex so the summary is keyboard accessible for non-native elements
       // http://www.saliences.com/browserBugs/tabIndex.html
-      details.__summary.tabIndex = 0;
-
-      // Detect initial open/closed state
+      if (!NATIVE_DETAILS) {
+        details.__summary.tabIndex = 0;
+      }
 
       // Detect initial open state
       var openAttr = details.getAttribute('open') !== null;
@@ -119,7 +117,9 @@
       } else {
         details.__summary.setAttribute('aria-expanded', 'false');
         details.__content.setAttribute('aria-hidden', 'true');
-        details.__content.style.display = 'none';
+        if (!NATIVE_DETAILS) {
+          details.__content.style.display = 'none';
+        }
       }
 
       // Create a circular reference from the summary back to its
@@ -128,7 +128,7 @@
 
       // If this is not a native implementation, create an arrow
       // inside the summary
-      if (!details.__native) {
+      if (!NATIVE_DETAILS) {
 
         var twisty = document.createElement('i');
 
@@ -155,7 +155,9 @@
 
       summary.__details.__summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'));
       summary.__details.__content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'));
-      summary.__details.__content.style.display = (expanded ? 'none' : '');
+      if (!NATIVE_DETAILS) {
+        summary.__details.__content.style.display = (expanded ? 'none' : '');
+      }
 
       if (summary.__twisty) {
         summary.__twisty.firstChild.nodeValue = (expanded ? '\u25ba' : '\u25bc');

--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -155,8 +155,16 @@
 
       summary.__details.__summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'));
       summary.__details.__content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'));
+
       if (!NATIVE_DETAILS) {
         summary.__details.__content.style.display = (expanded ? 'none' : '');
+
+        var hasOpenAttr = summary.__details.getAttribute('open') !== null;
+        if (!hasOpenAttr) {
+          summary.__details.setAttribute('open', 'open');
+        } else {
+          summary.__details.removeAttribute('open');
+        }
       }
 
       if (summary.__twisty) {

--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -111,40 +111,15 @@
 
       // Detect initial open/closed state
 
-      // Native support - has 'open' attribute
-      if (details.open === true) {
+      // Detect initial open state
+      var openAttr = details.getAttribute('open') !== null;
+      if (openAttr === true) {
         details.__summary.setAttribute('aria-expanded', 'true');
         details.__content.setAttribute('aria-hidden', 'false');
-        details.__content.style.display = 'block';
-      }
-
-      // Native support - doesn't have 'open' attribute
-      if (details.open === false) {
+      } else {
         details.__summary.setAttribute('aria-expanded', 'false');
         details.__content.setAttribute('aria-hidden', 'true');
         details.__content.style.display = 'none';
-      }
-
-      // If this is not a native implementation
-      if (!details.__native) {
-
-        // Add an arrow
-        var twisty = document.createElement('i');
-
-        // Check for the 'open' attribute
-        // If open exists, but isn't supported it won't have a value
-        if (details.getAttribute('open') === "") {
-          details.__summary.setAttribute('aria-expanded', 'true');
-          details.__content.setAttribute('aria-hidden', 'false');
-        }
-
-        // If open doesn't exist - it will be null or undefined
-        if (details.getAttribute('open') == null || details.getAttribute('open') == "undefined" ) {
-          details.__summary.setAttribute('aria-expanded', 'false');
-          details.__content.setAttribute('aria-hidden', 'true');
-          details.__content.style.display = 'none';
-        }
-
       }
 
       // Create a circular reference from the summary back to its
@@ -157,7 +132,7 @@
 
         var twisty = document.createElement('i');
 
-        if (details.getAttribute('open') === "") {
+        if (openAttr === true) {
           twisty.className = 'arrow arrow-open';
           twisty.appendChild(document.createTextNode('\u25bc'));
         } else {
@@ -180,7 +155,7 @@
 
       summary.__details.__summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'));
       summary.__details.__content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'));
-      summary.__details.__content.style.display = (expanded ? 'none' : 'block');
+      summary.__details.__content.style.display = (expanded ? 'none' : '');
 
       if (summary.__twisty) {
         summary.__twisty.firstChild.nodeValue = (expanded ? '\u25ba' : '\u25bc');

--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -79,7 +79,7 @@
 
     // else iterate through them to apply their initial state
     var n = list.length, i = 0;
-    for (n; i < n; i++) {
+    for (i; i < n; i++) {
       var details = list[i];
 
       // Detect native implementations

--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -7,6 +7,7 @@
 // http://www.sitepoint.com/fixing-the-details-element/
 
 (function () {
+  'use strict';
 
   // Add event construct for modern browsers or IE
   // which fires the callback with a pre-converted target reference

--- a/public/javascripts/vendor/details.polyfill.js
+++ b/public/javascripts/vendor/details.polyfill.js
@@ -27,7 +27,7 @@
   function addClickEvent(node, callback) {
     // Prevent space(32) from scrolling the page
     addEvent(node, 'keypress', function (e, target) {
-      if (target.nodeName === "SUMMARY") {
+      if (target.nodeName === 'SUMMARY') {
         if (e.keyCode === 32) {
           if (e.preventDefault) {
             e.preventDefault();

--- a/views/patterns/details_summary.html
+++ b/views/patterns/details_summary.html
@@ -44,6 +44,30 @@
     </div>
   </details>
 
+  <details open>
+    <summary>
+      <span class="summary">Where to find your driving licence number</span>
+    </summary>
+    <div class="panel-indent">
+      <p>
+        Your driving licence number can be found in section 5<br>
+        of your driving licence photocard.
+      </p>
+    </div>
+  </details>
+
+  <details open="open">
+    <summary>
+      <span class="summary">Where to find your driving licence number</span>
+    </summary>
+    <div class="panel-indent">
+      <p>
+        Your driving licence number can be found in section 5<br>
+        of your driving licence photocard.
+      </p>
+    </div>
+  </details>
+
 </main><!-- /#content -->
 {{/content}}
 


### PR DESCRIPTION
This includes the fixes made by @gavboulton in #95 and also removes the `open` attribute for non-native details when the widget is closed and sets it when the widget is re-opened.

It also adds two more details elements to the test page, with both `<details open>` and `<details open="open">` to ensure the polyfill is setting and removing the open attribute as the widget is opened and closed.

http://www.w3.org/html/wg/drafts/html/master/semantics.html#the-details-element
http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#boolean-attribute

cc @tombye.