### PR TITLE
Add attributes to snippets

### DIFF
--- a/views/snippets/buttons_button.html
+++ b/views/snippets/buttons_button.html
@@ -1,1 +1,1 @@
-<button class="button" type="submit">Save and continue</button>
+<input class="button" type="submit" value="Save and continue">

--- a/views/snippets/buttons_button.html
+++ b/views/snippets/buttons_button.html
@@ -1,1 +1,1 @@
-<button class="button">Save and continue</button>
+<button class="button" type="submit">Save and continue</button>

--- a/views/snippets/buttons_button_disabled.html
+++ b/views/snippets/buttons_button_disabled.html
@@ -1,1 +1,1 @@
-<button class="button" disabled="disabled">Save and continue</button>
+<input class="button" type="submit" value="Save and continue" disabled="disabled">

--- a/views/snippets/form_checkbox_native.html
+++ b/views/snippets/form_checkbox_native.html
@@ -1,6 +1,6 @@
 <label class="form-label" for="telephone-number">Enter your telephone number</label>
 <input class="form-control" id="telephone-number" name="telephone-number" type="text">
 <label class="form-checkbox" for="checkbox-telephone-number">
-  <input id="checkbox-telephone-number" name="checkbox-telephone-number" type="checkbox" value="checkbox-telephone-number">
+  <input id="checkbox-telephone-number" name="contact-by-text-phone" type="checkbox" value="true">
   I need to be contacted using a text phone
 </label>

--- a/views/snippets/form_checkbox_native.html
+++ b/views/snippets/form_checkbox_native.html
@@ -1,6 +1,6 @@
 <label class="form-label" for="telephone-number">Enter your telephone number</label>
-<input class="form-control" id="telephone-number" type="text">
-<label class="form-checkbox" for="checkbox-telephone-number" >
-  <input id="checkbox-telephone-number" type="checkbox" value="checkbox-telephone-number">
+<input class="form-control" id="telephone-number" name="telephone-number" type="text">
+<label class="form-checkbox" for="checkbox-telephone-number">
+  <input id="checkbox-telephone-number" name="checkbox-telephone-number" type="checkbox" value="checkbox-telephone-number">
   I need to be contacted using a text phone
 </label>

--- a/views/snippets/form_checkboxes.html
+++ b/views/snippets/form_checkboxes.html
@@ -1,16 +1,16 @@
 <fieldset>
   <legend class="form-label-bold">Which types of waste do you transport regularly?</legend>
   <p>Select all that apply</p>
-  <label class="block-label" for="checkbox-1">
-    <input id="checkbox-1" name="checkbox[]" type="checkbox" value="waste-animal">
+  <label class="block-label" for="waste-type-1">
+    <input id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal">
     Waste from animal carcasses
   </label>
-  <label class="block-label" for="checkbox-2">
-    <input id="checkbox-2" name="checkbox[]" type="checkbox" value="waste-mines">
+  <label class="block-label" for="waste-type-2">
+    <input id="waste-type-2" name="waste-types" type="checkbox" value="waste-mines">
     Waste from mines or quarries
   </label>
-  <label class="block-label" for="checkbox-3">
-    <input id="checkbox-3" name="checkbox[]" type="checkbox" value="farm-agricultural">
+  <label class="block-label" for="waste-type-3">
+    <input id="waste-type-3" name="waste-types" type="checkbox" value="waste-farm-agricultural">
     Farm or agricultural waste
   </label>
 </fieldset>

--- a/views/snippets/form_checkboxes.html
+++ b/views/snippets/form_checkboxes.html
@@ -2,15 +2,15 @@
   <legend class="form-label-bold">Which types of waste do you transport regularly?</legend>
   <p>Select all that apply</p>
   <label class="block-label" for="checkbox-1">
-    <input id="checkbox-1" type="checkbox" value="waste-animal">
+    <input id="checkbox-1" name="checkbox[]" type="checkbox" value="waste-animal">
     Waste from animal carcasses
   </label>
   <label class="block-label" for="checkbox-2">
-    <input id="checkbox-2" type="checkbox" value="waste-mines">
+    <input id="checkbox-2" name="checkbox[]" type="checkbox" value="waste-mines">
     Waste from mines or quarries
   </label>
   <label class="block-label" for="checkbox-3">
-    <input id="checkbox-3" type="checkbox" value="farm-agricultural">
+    <input id="checkbox-3" name="checkbox[]" type="checkbox" value="farm-agricultural">
     Farm or agricultural waste
   </label>
 </fieldset>

--- a/views/snippets/form_date.html
+++ b/views/snippets/form_date.html
@@ -11,17 +11,17 @@
 
       <div class="form-group form-group-day">
         <label for="dob-day">Day</label>
-        <input class="form-control" id="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+        <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
       </div>
 
       <div class="form-group form-group-month">
         <label for="dob-month">Month</label>
-        <input class="form-control" id="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+        <input class="form-control" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
       </div>
 
       <div class="form-group form-group-year">
         <label for="dob-year">Year</label>
-        <input class="form-control" id="dob-year" type="number" pattern="[0-9]*" min="0" max="2014">
+        <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2014">
       </div>
     </div>
 

--- a/views/snippets/form_inset_checkboxes.html
+++ b/views/snippets/form_inset_checkboxes.html
@@ -8,21 +8,21 @@
     Select all options that are relevant to you.
   </p>
   <div class="form-group form-group-compound">
-    <label class="block-label" for="nationality-british">
-      <input id="nationality-british" name="nationality" type="checkbox" value="British">
+    <label class="block-label" for="nationalities-british">
+      <input id="nationalities-british" name="nationalities" type="checkbox" value="British">
       British (including English, Scottish, Welsh and Northern Irish)
     </label>
-    <label class="block-label" for="nationality-irish">
-      <input id="nationality-irish" name="nationality" type="checkbox" value="Irish">
+    <label class="block-label" for="nationalities-irish">
+      <input id="nationalities-irish" name="nationalities" type="checkbox" value="Irish">
       Irish
     </label>
-    <label class="block-label" for="nationality-other" data-target="example-different-country">
-      <input id="nationality-other" name="nationality" type="checkbox" value="Citizen of a different country">
+    <label class="block-label" for="nationalities-other" data-target="example-different-country">
+      <input id="nationalities-other" name="nationalities" type="checkbox" value="Citizen of a different country">
       Citizen of a different country
     </label>
   </div>
   <div class="panel-indent js-hidden" id="example-different-country">
-    <label class="form-label" for="nationality-other-country">Country name</label>
-    <input class="form-control" type="text" id="nationality-other-country" name="nationality-other-country">
+    <label class="form-label" for="nationalities-other-country">Country name</label>
+    <input class="form-control" type="text" id="nationalities-other-country" name="nationalities-other-country">
   </div>
 </fieldset>

--- a/views/snippets/form_inset_checkboxes.html
+++ b/views/snippets/form_inset_checkboxes.html
@@ -9,20 +9,20 @@
   </p>
   <div class="form-group form-group-compound">
     <label class="block-label" for="nationality-british">
-      <input id="nationality-british" type="checkbox" value="British">
+      <input id="nationality-british" name="nationality[]" type="checkbox" value="British">
       British (including English, Scottish, Welsh and Northern Irish)
     </label>
     <label class="block-label" for="nationality-irish">
-      <input id="nationality-irish" type="checkbox" value="Irish">
+      <input id="nationality-irish" name="nationality[]" type="checkbox" value="Irish">
       Irish
     </label>
     <label class="block-label" for="nationality-other" data-target="example-different-country">
-      <input id="nationality-other" type="checkbox" value="Citizen of a different country">
+      <input id="nationality-other" name="nationality[]" type="checkbox" value="Citizen of a different country">
       Citizen of a different country
     </label>
   </div>
   <div class="panel-indent js-hidden" id="example-different-country">
     <label class="form-label" for="nationality-other-country">Country name</label>
-    <input class="form-control" type="text" id="nationality-other-country">
+    <input class="form-control" type="text" id="nationality-other-country" name="nationality-other-country">
   </div>
 </fieldset>

--- a/views/snippets/form_inset_checkboxes.html
+++ b/views/snippets/form_inset_checkboxes.html
@@ -9,15 +9,15 @@
   </p>
   <div class="form-group form-group-compound">
     <label class="block-label" for="nationality-british">
-      <input id="nationality-british" name="nationality[]" type="checkbox" value="British">
+      <input id="nationality-british" name="nationality" type="checkbox" value="British">
       British (including English, Scottish, Welsh and Northern Irish)
     </label>
     <label class="block-label" for="nationality-irish">
-      <input id="nationality-irish" name="nationality[]" type="checkbox" value="Irish">
+      <input id="nationality-irish" name="nationality" type="checkbox" value="Irish">
       Irish
     </label>
     <label class="block-label" for="nationality-other" data-target="example-different-country">
-      <input id="nationality-other" name="nationality[]" type="checkbox" value="Citizen of a different country">
+      <input id="nationality-other" name="nationality" type="checkbox" value="Citizen of a different country">
       Citizen of a different country
     </label>
   </div>

--- a/views/snippets/form_inset_radios.html
+++ b/views/snippets/form_inset_radios.html
@@ -16,6 +16,6 @@
   </div>
   <div class="panel-indent js-hidden" id="example-ni-no">
     <label class="form-label" for="national-insurance">National Insurance number</label>
-    <input class="form-control" type="text" id="national-insurance">
+    <input class="form-control" name="national-insurance" type="text" id="national-insurance">
   </div>
 </fieldset>

--- a/views/snippets/form_spacing.html
+++ b/views/snippets/form_spacing.html
@@ -1,9 +1,9 @@
 <!-- Use .form-group to create spacing when wrapping label and input pairs -->
 <div class="form-group">
   <label class="form-label" for="first-name-2">First name</label>
-  <input class="form-control" id="first-name-2" type="text">
+  <input class="form-control" id="first-name-2" name="first-name-2" type="text">
 </div>
 <div class="form-group">
   <label class="form-label" for="last-name-2">Last name</label>
-  <input class="form-control" id="last-name-2" type="text">
+  <input class="form-control" id="last-name-2" name="last-name-2" type="text">
 </div>


### PR DESCRIPTION
In order for the inputs to function in code, they must have the `name` attribute. I've added this so that people copying the snippets don't have to add any extra code.

For inputs in a series (checkboxes) I've used the `variable[]` naming convention from PHP, but I don't know if that works in Node/Express.