### PR TITLE
Remove links from below the submit button

### DIFF
--- a/views/examples/example_forms.html
+++ b/views/examples/example_forms.html
@@ -37,13 +37,9 @@
     <!-- Date of birth -->
     {{> form_date }}
 
-    <!-- Primary buttons, secondary links -->
+    <!-- Primary button -->
     <div class="form-group">
       <input type="submit" class="button" value="Continue">
-      <ul>
-        <li><a href="#">Skip this section for now</a></li>
-        <li><a href="/">Back</a></li>
-      </ul>
     </div>
 
   </form>


### PR DESCRIPTION
I think we should remove these from the example, as we're pretty much decided that the 'Back' link goes at the top of the page. And 'Skip' links aren't very commonly used.