### PR TITLE
Update guidance on page width and line length

### DIFF
--- a/views/guide_layout.html
+++ b/views/guide_layout.html
@@ -34,9 +34,17 @@
   </div>
 
   <h3 class="heading-medium" id="page-width">Page width</h3>
-  <p>
-    The default maximum page width is 1020px, but go wider if the content requires it.
-  </p>
+  <div class="text">
+    <p>
+      The default maximum page width is 1020px, but go wider if the content requires it.
+    </p>
+    <p>
+      <a href="#layout-grid-unit-proportions">Use a grid</a> to lay out your content. To prevent long lines of text, content should sit in a column which is two-thirds of the page width.
+    </p>
+    <p>
+      Long lines reduce legibility, so all lines of text should be no longer than 70 to 80 characters.
+    </p>
+  </div>
 
   <h3 class="heading-medium" id="screen-size">Screen size</h3>
   <div class="text">


### PR DESCRIPTION
Recommend using a grid split in a 2/3, 1/3 page layout 
- to prevent overly long lines of text.

This applies to all content, not just body text. 
Add this guidance to the layout section.

cc. @edwardhorsford, @timpaul.