### PR TITLE
[WIP] Improve contrast for form elements

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -125,16 +125,18 @@ legend {
   }
 }
 
-// Used for paragraphs in-between form elements
+// Used for the 'or' in between block label options
 .form-block {
   @extend %contain-floats;
   float: left;
   width: 100%;
 
+  margin-top: -5px;
   margin-bottom: 5px;
 
   @include media(tablet) {
-    margin-top: 10px;
+    margin-top: 0;
+    margin-bottom: 10px;
   }
 }
 

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -163,7 +163,7 @@ legend {
 
   padding: 4px;
   background-color: $white;
-  border: 1px solid $border-colour;
+  border: 2px solid $black;
 
   // TODO: Remove 50% width set for tablet and up
   // !! BREAKING CHANGE !!

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -141,11 +141,11 @@ legend {
 // 5. Form hints
 // ==========================================================================
 
-// Form hints and example text are light grey and sit above a form control
+// Form hints and example text sit within form labels, above a form control
 .form-hint {
   @include core-19;
   display: block;
-  color: $secondary-text-colour;
+  color: $text-colour;
   font-weight: normal;
   margin-bottom: 5px;
 }

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -15,7 +15,7 @@
   position: relative;
 
   background: $panel-colour;
-  border: 1px solid $panel-colour;
+  border: 2px solid $panel-colour;
   padding: (18px $gutter $gutter-half $gutter*1.8);
 
   margin-bottom: 10px;


### PR DESCRIPTION
Make hint text the same colour as the label text (using $text-colour).

Increase the width of the border for form controls to 2px.

Increase the width of the border for the selected state of block labels to 2px.

Screenshots to follow.