### PR TITLE
Increase the width of the border and make the border color darker for form controls

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -163,7 +163,7 @@ legend {
 
   padding: 4px;
   background-color: $white;
-  border: 1px solid $border-colour;
+  border: 2px solid $grey-1;
 
   // TODO: Remove 50% width set for tablet and up
   // !! BREAKING CHANGE !!


### PR DESCRIPTION
Increase this to 2px and change the colour from a light grey
($border-colour) to a darker grey ($grey-1).

The current border style:
![form elements before gov uk elements](https://cloud.githubusercontent.com/assets/417754/10302231/3d1c16a4-6c02-11e5-9bdc-b40f970de3b3.png)


With a darker colour and thicker border:
![form controls gov uk elements](https://cloud.githubusercontent.com/assets/417754/10302222/289ab7c6-6c02-11e5-87fd-249246eb86a8.png)
