### PR TITLE
Fix panel spacing

### DIFF
--- a/public/sass/elements/_details.scss
+++ b/public/sass/elements/_details.scss
@@ -21,20 +21,16 @@ details {
       outline: 3px solid $focus-colour;
     }
   }
-  
+
   // Underline only summary text (not the arrow)
   .summary {
     text-decoration: underline;
   }
-  
+
   // Match fallback arrow spacing with -webkit default
   .arrow {
     margin-right: .35em;
     font-style: normal;
   }
-  
-  // Remove top margin from bordered panel
-  .panel-indent {
-    margin-top: 0;
-  }
+
 }

--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -8,21 +8,21 @@
 .panel-indent {
   @extend %contain-floats;
   clear: both;
-  border-left: 4px solid $border-colour;
+  border-left: 10px solid $border-colour;
 
-  padding: 10px 0 10px $gutter-half;
-  margin: ($gutter $gutter-half $gutter*1.5 0);
+  padding: em(15,19);
+  margin-bottom: em(15,19);
 
   legend {
     margin-top: 0;
   }
-  
+
   // Remove bottom margin on last paragraph
   p:only-child,
   p:last-child {
     margin-bottom: 0;
   }
-  
+
   .form-group:last-child {
     margin-bottom: 0;
   }

--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -27,3 +27,9 @@
     margin-bottom: 0;
   }
 }
+
+// Indented panels within forms
+form .panel-indent {
+  border-left-width: 5px;
+  padding-bottom: 0;
+}

--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -8,7 +8,7 @@
 .panel-indent {
   @extend %contain-floats;
   clear: both;
-  border-left: 10px solid $border-colour;
+  border-left: 5px solid $border-colour;
 
   padding: em(15,19);
   margin-bottom: em(15,19);
@@ -28,8 +28,11 @@
   }
 }
 
-// Indented panels within forms
-form .panel-indent {
-  border-left-width: 5px;
+.panel-indent-info {
+  border-left-width: 10px;
+}
+
+// Indented panels within form groups
+.form-group .panel-indent {
   padding-bottom: 0;
 }

--- a/views/snippets/form_inset_checkboxes.html
+++ b/views/snippets/form_inset_checkboxes.html
@@ -7,7 +7,7 @@
   <p>
     Select all options that are relevant to you.
   </p>
-  <div class="form-group form-group-compound">
+  <div class="form-group">
     <label class="block-label" for="nationalities-british">
       <input id="nationalities-british" name="nationalities" type="checkbox" value="British">
       British (including English, Scottish, Welsh and Northern Irish)
@@ -20,9 +20,9 @@
       <input id="nationalities-other" name="nationalities" type="checkbox" value="Citizen of a different country">
       Citizen of a different country
     </label>
-  </div>
-  <div class="panel-indent js-hidden" id="example-different-country">
-    <label class="form-label" for="nationalities-other-country">Country name</label>
-    <input class="form-control" type="text" id="nationalities-other-country" name="nationalities-other-country">
+    <div class="panel-indent js-hidden" id="example-different-country">
+      <label class="form-label" for="nationalities-other-country">Country name</label>
+      <input class="form-control" type="text" id="nationalities-other-country" name="nationalities-other-country">
+    </div>
   </div>
 </fieldset>

--- a/views/snippets/form_inset_radios.html
+++ b/views/snippets/form_inset_radios.html
@@ -4,7 +4,7 @@
       Do you know their National Insurance number?
     </span>
   </legend>
-  <div class="form-group form-group-compound">
+  <div class="form-group">
     <label class="block-label" data-target="example-ni-no" for="radio-indent-1">
       <input id="radio-indent-1" type="radio" name="radio-indent-group" value="Yes">
       Yes
@@ -13,9 +13,10 @@
       <input id="radio-indent-2" type="radio" name="radio-indent-group" value="No">
       No
     </label>
-  </div>
-  <div class="panel-indent js-hidden" id="example-ni-no">
-    <label class="form-label" for="national-insurance">National Insurance number</label>
-    <input class="form-control" name="national-insurance" type="text" id="national-insurance">
+
+    <div class="panel-indent js-hidden" id="example-ni-no">
+      <label class="form-label" for="national-insurance">National Insurance number</label>
+      <input class="form-control" name="national-insurance" type="text" id="national-insurance">
+    </div>
   </div>
 </fieldset>

--- a/views/snippets/typography_inset_text.html
+++ b/views/snippets/typography_inset_text.html
@@ -1,4 +1,4 @@
-<div class="panel-indent">
+<div class="panel-indent panel-indent-info">
   <p>
     It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.
   </p>


### PR DESCRIPTION
**Increase the border width for indented 'info' panels**

These are used to highlight supporting information on GOV.UK and have a 10px left hand border.

![info-panel](https://cloud.githubusercontent.com/assets/417754/10304073/b9919b7a-6c0f-11e5-89b7-7fe06e54e59b.png)

The current style for indented panels of text:

![typography gov uk elements](https://cloud.githubusercontent.com/assets/417754/10304093/db7fd81e-6c0f-11e5-8c1c-c44fd2230306.png)

Proposed change to match GOV.UK:

![typography inset text - gov uk elements](https://cloud.githubusercontent.com/assets/417754/10304098/e03a4c18-6c0f-11e5-8930-20982e6b759c.png)

**Fix the spacing of toggled content within forms** 

Before:

![radio-before](https://cloud.githubusercontent.com/assets/417754/10304137/341f6278-6c10-11e5-8aef-708e426dda11.png)

![checkbox-before](https://cloud.githubusercontent.com/assets/417754/10304143/391b4a76-6c10-11e5-98d6-20ab8b2adf9a.png)

After:

![form elements after - gov uk elements](https://cloud.githubusercontent.com/assets/417754/10304063/ad96ca02-6c0f-11e5-9c3d-d87e5ec5d7e2.png)

![form elements after - checkboxes - gov uk elements](https://cloud.githubusercontent.com/assets/417754/10304056/a3bfcf2e-6c0f-11e5-96fc-8e6a698c9b07.png)

Also, increase the width of the indented panel for toggled content in forms to 5px. All units used elsewhere are multiples of 5px.