### PR TITLE
Add pattern example confirmation

### DIFF
--- a/public/sass/elements/_boxes.scss
+++ b/public/sass/elements/_boxes.scss
@@ -1,0 +1,7 @@
+.box-highlighted {
+  margin: 1em 0 1em 0;
+  padding: 2em 0 1em 0;
+  color: $white;
+  background: $turquoise;
+  text-align: center;
+}

--- a/public/sass/main.scss
+++ b/public/sass/main.scss
@@ -34,6 +34,9 @@
 // Panels
 @import "elements/panels";
 
+// Boxes
+@import "elements/boxes";
+
 // Icons
 @import "elements/icons";
 

--- a/routes.js
+++ b/routes.js
@@ -204,5 +204,19 @@ module.exports = {
       res.render('guide_alpha_beta', {'assetPath' : assetPath, 'page_name' : page_name });
     });
 
+    // Patterns
+    app.get('/patterns', function (req, res) {
+      var page_name = "Patterns";
+      res.render('patterns', {'assetPath' : assetPath, 'page_name' : page_name });
+    });
+
+    // Pattern page: Confirmation page
+    app.get('/patterns/confirmation-page', function (req, res) {
+      var section = "patterns";
+      var section_name = "Patterns";
+      var page_name = "Confirmation page";
+      res.render('patterns/pattern_confirmation_page', {'assetPath' : assetPath, 'section': section, 'section_name' : section_name, 'page_name' : page_name });
+    });
+
   }
 };

--- a/views/index.html
+++ b/views/index.html
@@ -106,6 +106,15 @@
 
   <div class="grid-row divider">
     <div class="column-two-thirds">
+      <h2 class="heading-medium"><a href="/patterns/">Patterns</a></h2>
+      <p class="lead-in">
+        Pattern pages, created using GOV.UK elements
+      </p>
+    </div>
+  </div>
+
+  <div class="grid-row divider">
+    <div class="column-two-thirds">
 
       <h3 class="heading-small">Looking for the styles?</h3>
       <p>

--- a/views/patterns.html
+++ b/views/patterns.html
@@ -1,0 +1,63 @@
+{{<layout}}
+
+{{$pageTitle}}Patterns — GOV.UK elements{{/pageTitle}}
+
+{{$content}}
+
+<main class="elements-index" id="content" role="main">
+
+  {{>phase_banner}}
+  {{>breadcrumb}}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h1 class="heading-xlarge">
+        <span class="heading-secondary">GOV.UK elements</span>
+        Patterns
+      </h1>
+
+      <p class="lede">
+        Pattern pages using GOV.UK elements.
+      </p>
+
+      <div class="divider">
+        <h2 class="heading-small">Confirmation pages</h2>
+        <p>
+          All new and redesigned services should provide <a href="{{ site.baseurl}}/patterns/confirmation-page/">transaction end pages</a>.
+        </p>
+
+        <details>
+          <summary>
+            <span class="summary">Find out more about confirmation pages</span>
+          </summary>
+          <div class="panel-indent">
+            <p class="lead-in">Transaction end pages: </p>
+            <ul class="list-bullet">
+              <li>tell the user that their transaction has finished OR</li>
+              <li>tell the user what they have to do next (if they're not finished)</li>
+              <li>prompt the user to give feedback on the service – to measure user satisfaction</li>
+              <li>count completed transactions – to measure completion rate</li>
+            </ul>
+            <p>
+              Transaction end pages are hosted by the service.
+            </p>
+            <p>
+              Discuss <a href="https://designpatterns.hackpad.com/Transaction-end-pages-xkOPGx6R1iM" rel="external">transaction end pages on the Design Patterns Hackpad</a>.
+            </p>
+          </div>
+        </details>
+
+      </div>
+
+    </div>
+  </div>
+
+</main><!-- / #content -->
+{{/content}}
+
+{{$bodyEnd}}
+  {{>scripts}}
+{{/bodyEnd}}
+
+{{/layout}}

--- a/views/patterns/pattern_confirmation_page.html
+++ b/views/patterns/pattern_confirmation_page.html
@@ -1,0 +1,49 @@
+{{<layout_example}}
+
+{{$pageTitle}}Pattern: Confirmation page — Patterns — GOV.UK elements{{/pageTitle}}
+
+{{$content}}
+<main id="content" role="main">
+
+  {{>breadcrumb}}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+        <h1 class="heading-xlarge">
+          Example service name
+        </h1>
+
+        <div class="box-highlighted">
+          <h2 class="bold-large">
+            Application complete
+          </h2>
+          <p>
+            Your reference number is </br>
+            <strong class="heading-medium">HDJ2123F</strong>
+          </p>
+        </div>
+
+        <p>
+          We have sent you a confirmation email.
+        </p>
+
+        <h2 class="heading-medium">
+          What happens next?
+        </h2>
+        <p>
+          We've sent your application to Hackney Electoral Register Office.
+        </p>
+        <p>
+          They will contact you either to confirm your registration, or to ask for more information.
+        </p>
+
+      </div>
+    </div>
+
+    </div>
+
+</main><!-- /#content -->
+{{/content}}
+
+{{/layout_example}}


### PR DESCRIPTION
This pull request adds a new section to GOV.UK elements - Patterns. 

This shows how to use GOV.UK elements to create pattern pages.

This adds an example - the transaction end page, or confirmation page,
has guidance taken from the Hackpad and a link to the Hackpad.

Here is a screenshot of the patterns page:

![patterns gov uk elements](https://cloud.githubusercontent.com/assets/417754/10641243/470ca7ea-7810-11e5-8c03-7682d536371e.png)


Here is a screenshot of the confimation page:

![pattern confirmation page patterns gov uk elements](https://cloud.githubusercontent.com/assets/417754/10641168/f70741ce-780f-11e5-8cce-56ef130fe4d0.png)

This relates to this PR on the GOV.UK prototype kit, to add common patterns for prototyping: https://github.com/alphagov/govuk_prototype_kit/pull/35


cc. @timpaul @ @joelanman @rivalee. 