### PR TITLE
Add box styles for transaction end pages

### DIFF
--- a/public/sass/elements/_boxes.scss
+++ b/public/sass/elements/_boxes.scss
@@ -1,0 +1,7 @@
+.box-highlighted {
+  margin: 1em 0 1em 0;
+  padding: 2em 0 1em 0;
+  color: $white;
+  background: $turquoise;
+  text-align: center;
+}

--- a/public/sass/main.scss
+++ b/public/sass/main.scss
@@ -34,6 +34,9 @@
 // Panels
 @import "elements/panels";
 
+// Boxes
+@import "elements/boxes";
+
 // Icons
 @import "elements/icons";
 

--- a/views/guide_colour.html
+++ b/views/guide_colour.html
@@ -368,6 +368,47 @@
     </a>
   </p>
 
+  <h3 class="heading-medium" id="examples">Examples</h3>
+  <h4 class="heading-small">Transaction end page</h4>
+
+  <div class="example">
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+        <h1 class="heading-xlarge">
+          Example service name
+        </h1>
+
+        <div class="box-highlighted">
+          <h2 class="bold-large">
+            Application complete
+          </h2>
+          <p>
+            Your reference number is </br>
+            <strong class="heading-medium">HDJ2123F</strong>
+          </p>
+        </div>
+
+        <p>
+          We have sent you a confirmation email.
+        </p>
+
+        <h2 class="heading-medium">
+          What happens next?
+        </h2>
+        <p>
+          We've sent your application to Hackney Electoral Register Office.
+        </p>
+        <p>
+          They will contact you either to confirm your registration, or to ask for more information.
+        </p>
+
+      </div>
+    </div>
+
+  </div>
+
 </main><!-- / #content -->
 {{/content}}
 


### PR DESCRIPTION
Add styles for `.box-highlight`, a turquoise box used for transaction end pages.

Show an example at the bottom of the "Colour" section.

![colour gov uk elements](https://cloud.githubusercontent.com/assets/417754/10642071/09c59fb4-7814-11e5-92da-ceb60b808335.png)

@timpaul, @rivalee, @joelanman.