### PR TITLE
Add govuk prefixed styles for box highlight

### DIFF
--- a/public/sass/elements/_components.scss
+++ b/public/sass/elements/_components.scss
@@ -1,0 +1,9 @@
+// Box with turquoise background and white text
+// Used for transaction end pages, and Bank Holidays
+.govuk-box-highlight {
+  margin: 1em 0 1em 0;
+  padding: 2em 0 1em 0;
+  color: $white;
+  background: $turquoise;
+  text-align: center;
+}

--- a/public/sass/main.scss
+++ b/public/sass/main.scss
@@ -37,3 +37,8 @@
 // Icons
 @import "elements/icons";
 
+// Components
+// ==========================================================================
+// .govuk-prefixed styles
+
+@import "elements/components";

--- a/views/guide_colour.html
+++ b/views/guide_colour.html
@@ -368,6 +368,47 @@
     </a>
   </p>
 
+  <h3 class="heading-medium" id="examples">Examples</h3>
+  <h4 class="heading-small">Transaction end page</h4>
+
+  <div class="example">
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+        <h1 class="heading-xlarge">
+          Example service name
+        </h1>
+
+        <div class="govuk-box-highlight">
+          <h2 class="bold-large">
+            Application complete
+          </h2>
+          <p>
+            Your reference number is </br>
+            <strong class="heading-medium">HDJ2123F</strong>
+          </p>
+        </div>
+
+        <p>
+          We have sent you a confirmation email.
+        </p>
+
+        <h2 class="heading-medium">
+          What happens next?
+        </h2>
+        <p>
+          We've sent your application to Hackney Electoral Register Office.
+        </p>
+        <p>
+          They will contact you either to confirm your registration, or to ask for more information.
+        </p>
+
+      </div>
+    </div>
+
+  </div>
+
 </main><!-- / #content -->
 {{/content}}
 


### PR DESCRIPTION
These box styles use a .govuk-prefix, in the same way as govuk
components. 

These styles will be moved either into the govuk-component
library, or to the front-end toolkit, but for now can sit here - to
identify common patterns between govuk pages (e.g. bank holidays) and
service pages - here the example is the transaction end page.

Screenshot below:
![transaction end pages](https://cloud.githubusercontent.com/assets/417754/10725403/c6894026-7bc3-11e5-8f03-189476c82d41.png)

