### PR TITLE
Add plain list style

### DIFF
--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -40,7 +40,8 @@
 }
 
 // Lists
-.list-bullet {
+.list-bullet,
+.list-number {
   margin-bottom: ($gutter*1.5);
 }
 

--- a/public/sass/elements/_lists.scss
+++ b/public/sass/elements/_lists.scss
@@ -23,12 +23,14 @@ ol {
   }
 }
 
+.list,
 .list-bullet,
 .list-number {
   margin-top: 5px;
   margin-bottom: 20px;
 }
 
+.list li,
 .list-bullet li,
 .list-number li {
   margin-bottom: 5px;

--- a/views/guide_typography.html
+++ b/views/guide_typography.html
@@ -133,7 +133,7 @@
 
   <h3 class="heading-medium" id="typography-lists">Lists</h3>
   <p class="text">
-    List items start with a lowercase letter and have no full stop at the end.
+    List items start with a lowercase letter (unless it's a list of links) and have no full stop at the end.
   </p>
 
 <div class="example">

--- a/views/snippets/typography_lists.html
+++ b/views/snippets/typography_lists.html
@@ -11,3 +11,10 @@
   <li>vestibulum id ligula porta felis euismod semper</li>
   <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
 </ol>
+
+<ul class="list font-xsmall">
+  <li><a href="#">Here is a plain list</a></li>
+  <li><a href="#">It's good for lists of links</a></li>
+  <li><a href="#">Especially at smaller font sizes</a></li>
+  <li><a href="#">Integer posuere erat a ante venenatis dapibus posuere velit aliquet</a></li>
+</ul>


### PR DESCRIPTION
I've added a plain '.list' style and example. This is primarily for lists of links where we want the extra margins but we don't want bullets (for example, lists of related links in the right hand column).