### PR TITLE
Add list class for lists

### DIFF
--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -39,11 +39,6 @@
   margin-bottom: 0;
 }
 
-// Lists
-.list-bullet {
-  margin-bottom: ($gutter*1.5);
-}
-
 
 // Example boxes
 // ==========================================================================

--- a/public/sass/elements/_lists.scss
+++ b/public/sass/elements/_lists.scss
@@ -1,10 +1,16 @@
 // Lists
 // ==========================================================================
 
-ul,
-ol {
+.list {
   list-style-type: none;
   padding: 0;
+
+  margin-top: 5px;
+  margin-bottom: 20px;
+}
+
+.list li {
+  margin-bottom: 5px;
 }
 
 // Bulleted lists
@@ -17,20 +23,8 @@ ol {
 .list-number {
   list-style-type: decimal;
   padding-left: 20px;
-  
+
   @include ie-lte(7) {
     padding-left: 28px;
   }
 }
-
-.list-bullet,
-.list-number {
-  margin-top: 5px;
-  margin-bottom: 20px;
-}
-
-.list-bullet li,
-.list-number li {
-  margin-bottom: 5px;
-}
-

--- a/public/sass/elements/_lists.scss
+++ b/public/sass/elements/_lists.scss
@@ -6,7 +6,10 @@
   padding: 0;
 
   margin-top: 5px;
-  margin-bottom: 20px;
+  margin-bottom: $gutter-half;
+  @include media(tablet) {
+    margin-bottom: $gutter;
+  }
 }
 
 .list li {

--- a/public/sass/elements/_lists.scss
+++ b/public/sass/elements/_lists.scss
@@ -28,3 +28,12 @@
     padding-left: 28px;
   }
 }
+
+// Lists of links
+.list-links {
+  @include core-16;
+}
+
+.list-links li {
+  margin-bottom: 10px;
+}

--- a/views/examples/example_form_validation_multiple_questions.html
+++ b/views/examples/example_form_validation_multiple_questions.html
@@ -13,7 +13,7 @@
 
   <h2 class="heading-medium implementation-advice">Implementation advice</h2>
   <p class="lead-in">When an error occurs:</p>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>
       add a 5px red left border to the field with the error
     </li>

--- a/views/examples/example_form_validation_single_question_radio.html
+++ b/views/examples/example_form_validation_single_question_radio.html
@@ -13,7 +13,7 @@
 
   <h2 class="heading-medium implementation-advice">Implementation advice</h2>
   <p class="lead-in">When an error occurs:</p>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>
       add a 5px red left border to the field with the error
     </li>

--- a/views/examples/example_typography.html
+++ b/views/examples/example_typography.html
@@ -39,14 +39,14 @@
 
     <p>Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.</p>
 
-    <ul class="list-bullet">
+    <ul class="list list-bullet">
       <li>here is a bulleted list</li>
       <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
       <li>vestibulum id ligula porta felis euismod semper</li>
       <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
     </ul>
 
-    <ol class="list-number">
+    <ol class="list list-number">
       <li>here is a numbered list</li>
       <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
       <li>vestibulum id ligula porta felis euismod semper</li>

--- a/views/guide_colour.html
+++ b/views/guide_colour.html
@@ -229,7 +229,7 @@
   </div>
 
   <h3 class="heading-medium" id="colour-extended-palette">Extended palette</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>used for graphs and supporting material</li>
     <li>for tints of the extended palette use 50% or 25%</li>
     <li>for departmental colours

--- a/views/guide_data.html
+++ b/views/guide_data.html
@@ -68,7 +68,7 @@
 </p>
 
   <h3 class="heading-medium" id="data-visualisation">Data visualisation</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>data is recommended as an alternative to using images</li>
     <li>for screen readers, ensure the data value appears first so it makes sense when read aloud</li>
   </ul>
@@ -116,7 +116,7 @@
   </div>
 
   <h3 class="heading-medium" id="examples">Examples</h3>
-  <ul class="list-bullet">
+  <ul class="list list-bullet">
     <li>
       <a href="https://www.gov.uk/pay-leave-for-parents/y/yes/2013-1-2/employee/employee/yes/yes/122.00-week/yes/yes/yes/122.00-week/yes" rel="external">
         see an example of table usage on GOV.UK

--- a/views/guide_errors.html
+++ b/views/guide_errors.html
@@ -75,7 +75,7 @@
     For each error:
   </p>
 
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>write a message that helps the user to understand why the error occurred and what to do about it</li>
     <li>put the message in the <code class="code">&lt;label&gt;</code> or <code class="code">&lt;legend&gt;</code> for the question,
     after the question text, in red</li>
@@ -98,7 +98,7 @@
 </pre>
 
   <h3 class="heading-medium" id="examples">Examples</h3>
-  <ul class="list-bullet">
+  <ul class="list list-bullet">
     <li>
       <a href="{{ site.baseurl}}/errors/example-form-validation-single-question-radio">
         form validation - single question

--- a/views/guide_form_elements.html
+++ b/views/guide_form_elements.html
@@ -99,7 +99,7 @@
   </div>
 
   <h3 class="heading-medium"  id="form-hint-text">Hint text</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>don't use placeholder text in form fields, as this will disappear once content is entered into the form field</li>
     <li>use hint text for supporting contextual help, this will always be shown</li>
     <li>hint text should sit above a form field</li>
@@ -148,7 +148,7 @@
   </p>
 
   <h3 class="heading-medium" id="form-radio-buttons">Radio buttons</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>use these to let users choose a single option from a list</li>
     <li>for more than two options, radio buttons should be stacked</li>
     <li>radio buttons with large hit areas are easier to select with a mouse or touch devices</li>
@@ -181,7 +181,7 @@
 </pre>
 
   <h3 class="heading-medium" id="form-checkboxes">Checkboxes</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>use these to select either on/off toggles or multiple selections</li>
     <li>make it clear with words when users can select one or multiple options</li>
   </ul>
@@ -200,7 +200,7 @@
 </pre>
 
   <h4 class="heading-small">Inline checkboxes</h4>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>large hit areas aren't always appropriate</li>
     <li>only pre-select options if there's a strong, user-centred reason to</li>
   </ul>
@@ -226,7 +226,7 @@
   <h3 class="heading-medium" id="form-toggle-content">
     Conditionally revealing content
   </h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>reveal additional questions, depending on the context</li>
     <li>insets are used to emphasise this supporting information</li>
   </ul>
@@ -274,7 +274,7 @@
 </pre>
 
   <h3 class="heading-medium" id="examples">Examples</h3>
-  <ul class="list-bullet">
+  <ul class="list list-bullet">
     <li><a href="{{site.baseurl}}/form-elements/example-form-elements/">form elements</a></li>
     <li><a href="{{site.baseurl}}/form-elements/example-date/">date pattern</a></li>
     <li><a href="{{site.baseurl}}/form-elements/example-radios-checkboxes/">radio buttons and checkboxes</a></li>

--- a/views/guide_icons_images.html
+++ b/views/guide_icons_images.html
@@ -30,7 +30,7 @@
   </div>
 
   <h3 class="heading-medium" id="icons">Icons</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>
       if icons are needed ensure they are clear, simple and accompanied by relevant text
     </li>

--- a/views/guide_layout.html
+++ b/views/guide_layout.html
@@ -57,7 +57,7 @@
   </div>
 
   <h3 class="heading-medium" id="layout-spacing">Spacing</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>spacing between elements is usually 5px, 10px, 15px or multiples of 15px</li>
     <li>gutters are 15px for smaller screens and 30px for larger screens</li>
   </ul>
@@ -67,7 +67,7 @@
   </div>
 
   <h3 class="heading-medium" id="layout-grid-unit-proportions">Grid unit proportions</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>introduce columns as the content requires it – base column ratios on halves, thirds or quarters of the page width</li>
     <li>for screen breakpoints use media queries &ndash; find these in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_conditionals.scss">_conditionals.scss</a> file</li>
   </ul>
@@ -128,7 +128,7 @@
 </pre>
 
   <h3 class="heading-medium" id="examples">Examples</h3>
-  <ul class="list-bullet">
+  <ul class="list list-bullet">
     <li>
       <a href="{{ site.baseurl}}/layout/example-grid-layout/">
         an example grid layout page

--- a/views/guide_typography.html
+++ b/views/guide_typography.html
@@ -133,7 +133,7 @@
 
   <h3 class="heading-medium" id="typography-lists">Lists</h3>
   <p class="text">
-    List items start with a lowercase letter and have no full stop at the end.
+    List items start with a lowercase letter (unless it's a list of links) and have no full stop at the end.
   </p>
 
 <div class="example">

--- a/views/guide_typography.html
+++ b/views/guide_typography.html
@@ -51,7 +51,7 @@
     Headings
   </h3>
 
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>use GDS Transport Website Bold</li>
     <li>use sentence case for headings</li>
     <li>use headings consistently to create a clear hierarchy</li>
@@ -71,7 +71,7 @@
     Lead paragraph
   </h3>
 
-  <ul class="list-bullet">
+  <ul class="list list-bullet">
     <li>use 24px for a lead paragraph</li>
     <li>there should only be one lead paragraph per page</li>
   </ul>
@@ -92,7 +92,7 @@
     Body copy
   </h3>
 
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>use GDS Transport Website Light</li>
     <li>avoid using bold and italics</li>
     <li>use 19px for body copy &ndash; 16px for smaller screens</li>
@@ -113,7 +113,7 @@
 </pre>
 
   <h3 class="heading-medium" id="typography-links">Links</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>links within body copy should be blue and underlined</li>
     <li>links without surrounding text should not have a full stop at the end</li>
     <li>link colours can be found in the <a href="{{site.baseurl}}/colour">colour palette</a></li>
@@ -184,7 +184,7 @@
 
 
   <h3 class="heading-medium" id="examples">Examples</h3>
-  <ul class="list-bullet">
+  <ul class="list list-bullet">
     <li>
       <a href="{{ site.baseurl}}/typography/example-typography/">
         an example typography page

--- a/views/snippets/typography_lists.html
+++ b/views/snippets/typography_lists.html
@@ -1,11 +1,11 @@
-<ul class="list-bullet">
+<ul class="list list-bullet">
   <li>here is a bulleted list</li>
   <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
   <li>vestibulum id ligula porta felis euismod semper</li>
   <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
 </ul>
 
-<ol class="list-number">
+<ol class="list list-number">
   <li>here is a numbered list</li>
   <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
   <li>vestibulum id ligula porta felis euismod semper</li>

--- a/views/snippets/typography_lists.html
+++ b/views/snippets/typography_lists.html
@@ -11,3 +11,9 @@
   <li>vestibulum id ligula porta felis euismod semper</li>
   <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
 </ol>
+
+<ul class="list list-links">
+  <li><a href="#">Here is a plain list</a></li>
+  <li><a href="#">It's good for lists of links</a></li>
+  <li><a href="#">Especially at smaller font sizes</a></li>
+</ul>


### PR DESCRIPTION
Don't apply list styles to unordered and ordered list elements
There will be cases where the styles set for ul and ol have to be
overridden. 

Instead, use a class of .list to apply these styles.

