### PR TITLE
Move govuk frontend toolkit dependencies

### DIFF
--- a/public/sass/elements/_buttons.scss
+++ b/public/sass/elements/_buttons.scss
@@ -1,9 +1,5 @@
 // Buttons
 // ==========================================================================
-// GOV.UK front end toolkit dependencies
-@import "design-patterns/buttons";
-@import "measurements";
-@import "typography";
 
 .button {
   @include button ($button-colour);

--- a/public/sass/elements/_details.scss
+++ b/public/sass/elements/_details.scss
@@ -1,7 +1,5 @@
 // Details
 // ==========================================================================
-// GOV.UK front end toolkit dependencies
-@import "colours";
 
 details {
   display: block;

--- a/public/sass/elements/_elements-typography.scss
+++ b/public/sass/elements/_elements-typography.scss
@@ -1,10 +1,6 @@
 // Typography
 // ==========================================================================
 
-// GOV.UK front end toolkit dependencies
-@import "typography";
-@import "colours";
-
 // Increase the base font size to 19px for the main content area
 // Using the core-19 mixin from the govuk_toolkit _typography.scss file
 

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -3,28 +3,14 @@
 
 // Contents:
 //
-// 1. GOV.UK front end toolkit dependencies
-// 2. Helpers
-// 3. Form wrappers
-// 4. Form labels
-// 5. Form hints
-// 6. Form controls
-// 7. Form control widths
+// 1. Helpers
+// 2. Form wrappers
+// 3. Form labels
+// 4. Form hints
+// 5. Form controls
+// 6. Form control widths
 
-// 8. Errors and validation styles
-// 9. Form design patterns
-//     - Date of birth
-//     - "Chunky" radio buttons and checkboxes
-
-
-// 1. GOV.UK front end toolkit dependencies
-// ==========================================================================
-
-@import "helpers";
-@import "colours";
-
-
-// 2. Helpers
+// 1. Helpers
 // ==========================================================================
 
 // Fieldset is used to group more than one .form-group
@@ -46,7 +32,7 @@ textarea{
 }
 
 
-// 3. Form wrappers
+// 2. Form wrappers
 // ==========================================================================
 
 // Form group is used to wrap label and input pairs
@@ -79,7 +65,7 @@ textarea{
 }
 
 
-// 4. Form labels
+// 3. Form labels
 // ==========================================================================
 
 // Form labels, or for legends styled to look like labels
@@ -130,7 +116,7 @@ legend {
   }
 }
 
-// 5. Form hints
+// 4. Form hints
 // ==========================================================================
 
 // Form hints and example text are light grey and sit above a form control
@@ -143,7 +129,7 @@ legend {
 }
 
 
-// 6. Form controls
+// 5. Form controls
 // ==========================================================================
 
 // By default, form controls are 50% width for desktop,
@@ -188,7 +174,7 @@ legend {
 }
 
 
-// 7. Form control widths
+// 6. Form control widths
 // ==========================================================================
 
 // TODO: Update these
@@ -237,20 +223,3 @@ legend {
     width: 12.5%;
   }
 }
-
-
-// 8. Errors and validation styles
-// ==========================================================================
-@import "forms/form-validation";
-
-
-// 9. Form design patterns
-//    - Date of birth
-//    - "Chunky" radio buttons and checkboxes
-// ==========================================================================
-
-// Date of birth
-@import "forms/form-date";
-
-// "Chunky" radios and checkboxes
-@import "forms/form-block-labels";

--- a/public/sass/elements/_helpers.scss
+++ b/public/sass/elements/_helpers.scss
@@ -1,12 +1,5 @@
 // Helpers
 // ==========================================================================
-// GOV.UK front end toolkit dependencies
-@import "colours";
-@import "shims";
-@import "measurements";
-@import "typography";
-@import "css3";
-@import "url-helpers";
 
 // Path to assets for use with file-url() is not already defined
 @if ($path == false) {

--- a/public/sass/elements/_icons.scss
+++ b/public/sass/elements/_icons.scss
@@ -1,6 +1,4 @@
 // GOV.UK icons
-// GOV.UK front end toolkit dependencies
-@import "device-pixels";
 
 .icon {
   background-position: 0 0;
@@ -26,7 +24,7 @@
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-file-download-2x.png");
     background-size: 100%;
-  } 
+  }
 }
 
 .icon-important {
@@ -150,7 +148,7 @@
   width: 23px;
   height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-5.png");
-  
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-5-2x.png");
     background-size: 100%;

--- a/public/sass/elements/_layout.scss
+++ b/public/sass/elements/_layout.scss
@@ -1,14 +1,6 @@
 // Layout
 // ==========================================================================
 
-// GOV.UK front end toolkit dependencies
-@import "measurements";
-@import "conditionals";
-@import "grid_layout";
-@import "helpers";
-@import "design-patterns/alpha-beta";
-
-
 // Content
 // ==========================================================================
 
@@ -17,7 +9,7 @@
   @extend %site-width-container;
   @extend %contain-floats;
   padding-bottom: $gutter;
-  
+
   @include media(desktop) {
     padding-bottom: $gutter*3;
   }

--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -1,8 +1,5 @@
 // Panels
 // ==========================================================================
-// GOV.UK front end toolkit dependencies
-@import "helpers";
-
 
 // Indented panels with a grey left hand border
 .panel-indent {

--- a/public/sass/elements/_tables.scss
+++ b/public/sass/elements/_tables.scss
@@ -1,9 +1,5 @@
 // Tables
 // ==========================================================================
-// GOV.UK front end toolkit dependencies
-@import "typography";
-@import "colours";
-
 
 table {
   border-collapse: collapse;
@@ -25,7 +21,7 @@ table {
     // Right align headings for numeric content
     &.numeric {
       text-align: right;
-    } 
+    }
   }
 
   // Use tabular numbers for numeric table cells

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -1,11 +1,6 @@
 // Large hit area
 // Radio buttons & checkboxes
 
-@import "colours";
-@import "measurements";
-@import "conditionals";
-
-
 // By default, block labels stack vertically
 .block-label {
 

--- a/public/sass/main.scss
+++ b/public/sass/main.scss
@@ -1,3 +1,19 @@
+// GOV.UK front end toolkit
+// Sass mixins and variables
+// https://github.com/alphagov/govuk_frontend_toolkit/tree/master/stylesheets
+
+@import "colours";
+@import "conditionals";
+@import "device-pixels";
+// @import "font_stack";
+@import "grid_layout";
+@import "measurements";
+@import "shims";
+@import "typography";
+@import "url-helpers";
+@import "design-patterns/alpha-beta";
+@import "design-patterns/buttons";
+
 // GOV.UK elements
 @import "elements/helpers";
 @import "elements/reset";

--- a/public/sass/main.scss
+++ b/public/sass/main.scss
@@ -1,44 +1,20 @@
-// Helpers
+// GOV.UK elements
 @import "elements/helpers";
-
-// Reset
 @import "elements/reset";
-
-// Typography
 @import "elements/elements-typography";
-
-// Layout
 @import "elements/layout";
 
-// Breadcrumb
-@import "elements/breadcrumb";
-
-// Modules
-// ==========================================================================
-
-// Forms
 @import "elements/forms";
+@import "elements/forms/form-block-labels";
+@import "elements/forms/form-date";
+@import "elements/forms/form-validation";
 
-// Tables
 @import "elements/tables";
-
-// Buttons
-@import "elements/buttons";
-
-// Details
-@import "elements/details";
-
-// Lists
 @import "elements/lists";
-
-// Panels
+@import "elements/details";
 @import "elements/panels";
-
-// Icons
+@import "elements/buttons";
 @import "elements/icons";
 
-// Components
-// ==========================================================================
-// .govuk-prefixed styles
-
 @import "elements/components";
+@import "elements/breadcrumb";


### PR DESCRIPTION
The aim of this PR is to put all the Sass import statements in once place, with the Sass variables and mixins from the govuk front end toolkit first.

It also moves any Sass imports within partials to the top level - so the main.scss file shows all files imported - this removes the imports from the bottom of forms, for block labels, date of birth and validation.