### PR TITLE
Update the README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,11 @@
-# Guidelines
+# Contribution Guidelines
 
-In the spirit of open source, we welcome contributions. These can be as trivial as fixing typos or grammatical errors, to suggesting new areas of guidance in the style guide.
+We welcome patches to GOV.UK elements, as long as you follow these
+guidelines:
 
-We will review your submission and may suggest amendments via the comments system. However, we are not obliged to accept all contributions and will maintain editorial control.
+## Indentation and whitespace
 
-## Process
-Submissions should be made as pull requests. Each piece will be reviewed by a content specialist, who will make sure it stays true to the GOV.UK style as well as the spirit of the manual.
-
-Once a change has been submitted it will stay open as a pull request for a few days so that teams throughout GDS and beyond get a chance to review and comment.
-
-Remember to:
-
-* [write helpful commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
-* [check the GDS style guide](https://www.gov.uk/design-principles/style-guide) for tips on how to write to our standard
-* [check the service manual](https://www.gov.uk/service-manual/design-and-content) for tips on how to create content
+2-space, soft-tabs only. No trailing whitespace.
 
 ## Versioning
 
@@ -25,3 +17,21 @@ their own. This alerts team members to the new version and allows for
 last-minute scrutiny before the new version is released. Also, by raising a
 separate pull request, we avoid version number conflicts between feature
 branches.
+
+## Commit hygiene
+
+Please see our [git style guide](https://github.com/alphagov/styleguides/blob/master/git.md)
+which describes how we prefer git history and commit messages to read.
+
+## Code
+
+The code in GOV.UK elements is built on top of the [GOV.UK template](https://github.com/alphagov/govuk_template)
+and the [GOV.UK front end toolkit](https://github.com/alphagov/govuk_frontend_toolkit).
+
+If you find an issue with GOV.UK elements, please raise an issue via this repository.
+
+If you want to suggest changes or raise bugs on code from the toolkit, please do so through its repository, not this one.
+
+## Design
+
+There is a Hackpad for [Design Patterns for GOV.UK services](https://designpatterns.hackpad.com/).

--- a/README.md
+++ b/README.md
@@ -1,80 +1,126 @@
 GOV.UK elements
 ===============
 
-### What is it?
+## What is it?
 
-GOV.UK Elements is two things:
+GOV.UK elements is two things:
 
 1. an online design guide, explaining how to make your service look consistent with the rest of GOV.UK
 2. an example of how to use the code in the [GOV.UK template](https://github.com/alphagov/govuk_template) and the [GOV.UK front end toolkit](https://github.com/alphagov/govuk_frontend_toolkit)
 
-The guide can be seen at: http://govuk-elements.herokuapp.com/.
+The guide can be seen here: http://govuk-elements.herokuapp.com/.
 
-### How can it be used?
+## How can it be used?
 
-GOV.UK Elements is still in alpha so the CSS might change but you're welcome to use whatever form of it you feel fits your project. Please use [GitHub's watch feature](https://help.github.com/articles/watching-repositories) to keep an eye on what may change.
+It can be used as a base of front end code.
 
-It can be used as a sensible base of front end code. Choose the Sass files you need to build on top of those provided by the front end toolkit. For example, add grids, typography and additional modules as you need them.
+GOV.UK elements has the [GOV.UK front end toolkit](https://github.com/alphagov/govuk_frontend_toolkit) as a dependency.
+The toolkit provides Sass variables and mixins, in order to use these - they must be imported before any of the elements Sass files.
 
-As you get a better understanding of the user needs for your project you should be iterating this code so it best fits the resulting requirements.
+Take a look at `/public/sass/main.scss` to see how the GOV.UK front end toolkit's Sass files are imported.
 
-### How are people building with GOV.UK Elements?
 
-Here are examples of service-specific pattern libraries using GOV.UK Elements.
+    // Sass mixins and variables
+    // https://github.com/alphagov/govuk_frontend_toolkit/tree/master/stylesheets
 
-* [Rural Payments style guide](http://rural-payments-styleguide.herokuapp.com) | [Source Code](https://github.com/Defra/rural-payments-styleguide/)
-* [Land Registry style guide](http://styleguide.landregistryconcept.co.uk/)
-* [Digital Marketplace front end toolkit](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/)
+    @import "colours";
+    @import "conditionals";
+    @import "device-pixels";
+    // @import "font_stack";
+    @import "grid_layout";
+    @import "measurements";
+    @import "shims";
+    @import "typography";
+    @import "url-helpers";
+    @import "design-patterns/alpha-beta";
+    @import "design-patterns/buttons";
 
-###  How to we want people to contribute and improve elements.
+Note that `_font_stack.scss` is not imported here, as this is used by the [GOV.UK template](https://github.com/alphagov/govuk_template), to set the font stack.
 
-#### Design
+Choose the Sass files you need to build on top of those provided by the front end toolkit.
+For example, add typography, layout (for grid layout) and additional modules as you need them.
 
-There is a Hackpad for feeding back on the design patterns contained in elements:
+Take a look at `/public/sass/main.scss` to see how the Sass files within `/public/sass/elements` are imported.
 
-https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2
 
-#### Code
+    // GOV.UK elements
+    @import "elements/helpers";
+    @import "elements/reset";
+    @import "elements/elements-typography";
+    @import "elements/layout";
 
-The code in GOV.UK Elements is built on top of the [GOV.UK front end toolkit](https://github.com/alphagov/govuk_frontend_toolkit).
+    @import "elements/forms";
+    @import "elements/forms/form-block-labels";
+    @import "elements/forms/form-date";
+    @import "elements/forms/form-validation";
 
-If you want to suggest changes or raise bugs on code from the toolkit, please do so through its repository, not this one.
+    @import "elements/tables";
+    @import "elements/lists";
+    @import "elements/details";
+    @import "elements/panels";
+    @import "elements/buttons";
+    @import "elements/icons";
 
-GOV.UK Elements code in use across live projects but not already in the toolkit should eventually be added to it. All contributions towards this goal are welcome and should be in the form of pull requests on the toolkit repository.
+    @import "elements/components";
+    @import "elements/breadcrumb";
 
-Examples of pull requests already raised to this end:
 
-- https://github.com/alphagov/govuk_frontend_toolkit/pull/100
-- https://github.com/alphagov/govuk_frontend_toolkit/pull/121
+Ignore the `/public/sass/elements-page.scss` files, these exist to style the page furniture of GOV.UK elements (for example, the HTML example boxes and colour swatches).
 
-### Navigating this repository
-
-#### To view the Sass files:
-
-You can find the Sass files here:
-
-```
-/public/sass/
-```
-
-```
-/public/sass/main.scss
-```
-
-The main.scss file shows how to import the Elements Sass files.
-
-#### To view this site locally:
+## Running this site locally
 
 If you would like to clone the repository and run it locally,
 you will need [Node.js](http://nodejs.org/) (at least version v0.10.0).
 
 * clone this repository
 * install the required node modules
-```
-npm install --production
-```
+
+    npm install
+
+
 * run the app
-```
-foreman start -p 3000
-```
+
+    node start.js
+
+
 * go to [localhost:3000](http://localhost:3000) in your browser.
+
+### Running wraith to compare changes
+
+GOV.UK elements uses Wraith so that regressions can be easily spotted.
+Runs against all the main elements pages and some of the examples.
+
+#### Usage
+
+On master run:
+
+    wraith history config.yaml
+
+
+On local branch run
+
+    wraith latest config.yaml
+
+
+##  How to we want people to contribute and improve elements.
+
+### Code
+
+The code in GOV.UK elements is built on top of the [GOV.UK template](https://github.com/alphagov/govuk_template)
+and the [GOV.UK front end toolkit](https://github.com/alphagov/govuk_frontend_toolkit).
+
+If you find an issue with GOV.UK elements, please raise an issue via this repository.
+
+If you want to suggest changes or raise bugs on code from the toolkit, please do so through its repository, not this one.
+
+### Design
+
+There is a Hackpad for [Design Patterns for GOV.UK services](https://designpatterns.hackpad.com/).
+
+## How are people building with GOV.UK elements?
+
+Here are examples of service-specific pattern libraries using GOV.UK elements.
+
+* [Rural Payments style guide](http://rural-payments-styleguide.herokuapp.com) | [Source Code](https://github.com/Defra/rural-payments-styleguide/)
+* [Land Registry style guide](http://styleguide.landregistryconcept.co.uk/)
+* [Digital Marketplace front end toolkit](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/)

--- a/README.md
+++ b/README.md
@@ -85,19 +85,27 @@ you will need [Node.js](http://nodejs.org/) (at least version v0.10.0).
 
 * go to [localhost:3000](http://localhost:3000) in your browser.
 
-### Running wraith to compare changes
+## Running Wraith to compare changes
 
 GOV.UK elements uses Wraith so that regressions can be easily spotted.
 Runs against all the main elements pages and some of the examples.
 
+### Install Wraith and its dependencies
+
+    gem install wraith
+    brew install phantomjs
+    brew install imagemagick
+
 #### Usage
 
+Take a baseline of the current version.
 On master run:
 
     wraith history config.yaml
 
 
-On local branch run
+Switch to your feature branch and make changes.
+On feature branch run:
 
     wraith latest config.yaml
 

--- a/README.md
+++ b/README.md
@@ -72,23 +72,28 @@ Ignore the `/public/sass/elements-page.scss` files, these exist to style the pag
 If you would like to clone the repository and run it locally,
 you will need [Node.js](http://nodejs.org/) (at least version v0.10.0).
 
-* clone this repository
-* install the required node modules
+Clone this repository
+
+    git clone git@github.com:alphagov/govuk_elements.git
+
+
+Install the required node modules
 
     npm install
 
 
-* run the app
+Run the app
 
     node start.js
 
 
-* go to [localhost:3000](http://localhost:3000) in your browser.
+Go to [localhost:3000](http://localhost:3000) in your browser.
 
 ## Running Wraith to compare changes
 
 GOV.UK elements uses Wraith so that regressions can be easily spotted.
-Runs against all the main elements pages and some of the examples.
+
+This needs to be run from the Wraith directory `/tests/wraith` and some dependencies need to be installed on the local machine first.
 
 ### Install Wraith and its dependencies
 
@@ -96,7 +101,7 @@ Runs against all the main elements pages and some of the examples.
     brew install phantomjs
     brew install imagemagick
 
-#### Usage
+### Usage
 
 Take a baseline of the current version.
 On master run:
@@ -109,21 +114,6 @@ On feature branch run:
 
     wraith latest config.yaml
 
-
-##  How to we want people to contribute and improve elements.
-
-### Code
-
-The code in GOV.UK elements is built on top of the [GOV.UK template](https://github.com/alphagov/govuk_template)
-and the [GOV.UK front end toolkit](https://github.com/alphagov/govuk_frontend_toolkit).
-
-If you find an issue with GOV.UK elements, please raise an issue via this repository.
-
-If you want to suggest changes or raise bugs on code from the toolkit, please do so through its repository, not this one.
-
-### Design
-
-There is a Hackpad for [Design Patterns for GOV.UK services](https://designpatterns.hackpad.com/).
 
 ## How are people building with GOV.UK elements?
 


### PR DESCRIPTION
- Add details about the Sass dependency on the GOV.UK front end toolkit
- Show how the Sass files within /public/sass/elements are imported
- Explain which files are used only to style the page furniture
- Add an example for running Wraith
- Request that issues are raised with this repository

cc. @fofr, @robinwhittleton.