### PR TITLE
Remove Firefox "fix" for arrow edges

### DIFF
--- a/public/sass/elements/_elements-typography.scss
+++ b/public/sass/elements/_elements-typography.scss
@@ -215,14 +215,6 @@ p {
     margin-top: -6px;
   }
 
-  // Improve arrow shape in Firefox
-  @-moz-document url-prefix() {
-    &::before {
-      border-top: 5px dotted rgba(255, 0, 0, 0);
-      border-bottom: 5px dotted rgba(255, 0, 0, 0);
-    }
-  }
-
   // Fallback
   // IE8 doesn't support rgba and only supports the single colon syntax for :before
   // IE7 doesn't support pseudo-elements, let's fallback to an image instead.


### PR DESCRIPTION
This was an attempt to smooth the edges of the left pointing triangle
in Firefox, as they appeared jagged.

Unfortunately, this caused the following Sass compilation error in the Rails govuk prototype template: 

Base-level rules cannot contain the
parent-selector-referencing character '&'.

Since this “fix” is no longer required, removing these rules fixes this.

Screenshots of Firefox and Safari, to compare:

![firefox-nofix](https://cloud.githubusercontent.com/assets/417754/11277712/90775566-8edf-11e5-93c9-89228ca7cdd1.png)

![safari](https://cloud.githubusercontent.com/assets/417754/11277770/cd94e116-8edf-11e5-8142-2526a54e2485.png)



