### PR TITLE
Remove button margins

### DIFF
--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -345,12 +345,7 @@ $palette: (
 // 7. Buttons
 // ==========================================================================
 
-// Increase spacing under buttons in example boxes
-.example-button .button {
-  margin-bottom: 15px;
-}
-
-// Remove top margin from "Creating buttons" example
+// Remove top margin from headings in the "Creating buttons" example
 .example-button .heading-small {
   margin-top: 0;
 }
@@ -358,11 +353,6 @@ $palette: (
 // Make swatch wrapper full width for "Creating buttons" example
 .example-button .swatch-wrapper {
   width: 100%;
-}
-
-// Remove bottom padding to keep "Creating buttons" example
-.example-button ul {
-  padding-bottom: 0;
 }
 
 

--- a/public/sass/elements/_buttons.scss
+++ b/public/sass/elements/_buttons.scss
@@ -4,7 +4,6 @@
 .button {
   @include button ($button-colour);
   @include box-sizing (border-box);
-  margin: 0 $gutter-half $gutter-half 0;
   padding: em(10) em(15) em(5) em(15);
   vertical-align: top;
   @include media (mobile) {


### PR DESCRIPTION
Spacing for form elements is made consistent using the .form-group
clearing wrapper, remove the top and right margins, currently added to all buttons.

Also remove overrides for spacing underneath buttons within example boxes.

cc. @tyom, @robinwhittleton.