### PR TITLE
Add a colour swatch for $govuk-blue

### DIFF
--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -177,7 +177,8 @@ $palette: (
   ("green", $green),
   ("grass-green", $grass-green),
   ("turquoise", $turquoise),
-  ("light-blue", $light-blue)
+  ("light-blue", $light-blue),
+  ("govuk-blue", $govuk-blue)
 );
 
 @mixin color-swatches {

--- a/views/guide_colour.html
+++ b/views/guide_colour.html
@@ -358,6 +358,15 @@
         <li><b>#2b8cc4</b></li>
         <li>$light-blue</li>
       </ul>
+
+      <h4 class="heading-small">GOV.UK blue</h4>
+
+      <div class="swatch swatch-govuk-blue"></div>
+      <ul>
+        <li><b>#005ea5</b></li>
+        <li>$govuk-blue</li>
+      </ul>
+
     </div>
 
   </div>


### PR DESCRIPTION
The Sass variable $govuk-blue exists in the frontend toolkit, for
#005ea5.

Add this swatch to the colour palette.

![colour gov uk elements](https://cloud.githubusercontent.com/assets/417754/11344495/88bc04ac-9209-11e5-993c-8dd9d68d7e6d.png)
