### PR TITLE
Create an example page to show icons in the front end toolkit

### DIFF
--- a/public/sass/elements/_icons.scss
+++ b/public/sass/elements/_icons.scss
@@ -40,7 +40,7 @@
 }
 
 .icon-important {
-  @include icon(icon-important, 34, 34);
+  @include icon(icon-important, 35, 35);
 }
 
 .icon-information {

--- a/public/sass/elements/_icons.scss
+++ b/public/sass/elements/_icons.scss
@@ -13,6 +13,7 @@
 
   @if $icon-sub-folder {
     background-image: file-url("icons/#{$icon-sub-folder}/#{$icon-name}.png");
+
     @include device-pixel-ratio() {
       background-image: file-url("icons/#{$icon-sub-folder}/#{$icon-name}-2x.png");
       background-size: 100%;
@@ -20,6 +21,7 @@
 
   } @else {
     background-image: file-url("icons/#{$icon-name}.png");
+
     @include device-pixel-ratio() {
       background-image: file-url("icons/#{$icon-name}-2x.png");
       background-size: 100%;
@@ -54,7 +56,7 @@
 }
 
 .icon-pointer-black {
- @include icon(icon-pointer-black, 23, 23);
+  @include icon(icon-pointer-black, 23, 23);
 }
 
 .icon-search {

--- a/public/sass/elements/_icons.scss
+++ b/public/sass/elements/_icons.scss
@@ -1,244 +1,70 @@
-// GOV.UK icons
+// Icons
+// ==========================================================================
 
-.icon {
+// Icon mixin
+@mixin icon($icon-name, $icon-width, $icon-height, $icon-sub-folder:false) {
+  display: inline-block;
+
+  width: #{$icon-width}px;
+  height: #{$icon-height}px;
+
   background-position: 0 0;
   background-repeat: no-repeat;
+
+  @if $icon-sub-folder {
+    background-image: file-url("icons/#{$icon-sub-folder}/#{$icon-name}.png");
+    @include device-pixel-ratio() {
+      background-image: file-url("icons/#{$icon-sub-folder}/#{$icon-name}-2x.png");
+      background-size: 100%;
+    }
+
+  } @else {
+    background-image: file-url("icons/#{$icon-name}.png");
+    @include device-pixel-ratio() {
+      background-image: file-url("icons/#{$icon-name}-2x.png");
+      background-size: 100%;
+    }
+  }
 }
 
+
+// GOV.UK front end toolkit icons
 .icon-calendar {
-  width: 27px;
-  height: 27px;
-  background-image: file-url("icons/icon-calendar.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-calendar-2x.png");
-    background-size: 100%;
-  }
+  @include icon(icon-calendar, 27, 27);
 }
 
-.icon-download {
-  width: 30px;
-  height: 39px;
-  background-image: file-url("icons/icon-file-download.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-file-download-2x.png");
-    background-size: 100%;
-  }
+.icon-file-download {
+  @include icon(icon-file-download, 30, 39);
 }
 
 .icon-important {
-  width: 34px;
-  height: 34px;
-  background-image: file-url("icons/icon-important.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-important-2x.png");
-    background-size: 100%;
-  }
+  @include icon(icon-important, 34, 34);
 }
 
 .icon-information {
-  width: 27px;
-  height: 27px;
-  background-image: file-url("icons/icon-information.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-information-2x.png");
-    background-size: 100%;
-  }
+  @include icon(icon-information, 27, 27);
 }
 
 .icon-locator {
-  width: 26px;
-  height: 36px;
-  background-image: file-url("icons/icon-locator.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-locator-2x.png");
-    background-size: 100%;
-  }
+  @include icon(icon-locator, 26, 36);
 }
 
-.icon-search {
-  width: 30px;
-  height: 22px;
-  background-color: $black;
-  background-image: file-url("icons/icon-search.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-search-2x.png");
-    background-size: 100%;
-  }
-}
-
-// GOV.UK arrow icons
 .icon-pointer {
-  width: 30px;
-  height: 19px;
-  background-color: $black;
-  background-image: file-url("icons/icon-pointer.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-pointer-2x.png");
-    background-size: 100%;
-  }
+  @include icon(icon-pointer, 30, 19);
 }
 
 .icon-pointer-black {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-pointer-black.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-pointer-black-2x.png");
-    background-size: 100%;
-  }
+ @include icon(icon-pointer-black, 23, 23);
 }
 
-// GOV.UK external link icons
-// TODO (Are these provided by the template?)
+.icon-search {
+  @include icon(icon-search, 30, 22);
+}
+
 
 // GOV.UK step icons
-.icon-step-1 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-1.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-1-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-2 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-2.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-2-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-3 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-3.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-3-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-4 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-4.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-4-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-5 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-5.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-5-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-6 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-6.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-6-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-7 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-7.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-7-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-8 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-8.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-8-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-9 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-9.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-9-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-10 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-10.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-10-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-11 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-11.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-11-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-12 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-12.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-12-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-13 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-13.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-13-2x.png");
-    background-size: 100%;
+@for $i from 1 through 14 {
+  .icon-step-#{$i} {
+    @include icon(icon-step-#{$i}, 23, 23, icon-steps);
   }
 }

--- a/routes.js
+++ b/routes.js
@@ -73,6 +73,14 @@ module.exports = {
       res.render('guide_icons_images', {'assetPath' : assetPath, 'page_name' : page_name });
     });
 
+    // Example page: Icons
+    app.get('/icons-images/example-icons', function (req, res) {
+      var section = "Icons and images";
+      var section_name = "Icons";
+      var page_name = "Example: Icons";
+      res.render('examples/example_icons', {'assetPath' : assetPath, 'section': section, 'section_name' : section_name, 'page_name' : page_name });
+    });
+
     // Data
     app.get('/data', function (req, res) {
       var page_name = "Data";

--- a/views/examples/example_icons.html
+++ b/views/examples/example_icons.html
@@ -1,0 +1,102 @@
+{{<layout_example}}
+
+{{$pageTitle}}Example: Icons — Icons and images — GOV.UK elements{{/pageTitle}}
+
+{{$content}}
+<main id="content" role="main">
+
+  {{>breadcrumb}}
+
+  <style>
+  .example-icons p { font-size: 16px; }
+  .icon-background { background-color: #d3d3d3; padding: 15px; }
+  </style>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h1 class="heading-xlarge">
+        <span class="heading-secondary">Icons and images</span>
+        Example: Icons
+      </h1>
+
+      <p class="text">
+        This test page shows the icons which are included in the govuk frontend toolkit.
+      </p>
+
+    </div>
+  </div>
+
+  <div class="grid-row">
+
+    <div class="column-third">
+      <h2 class="heading-medium">Step icons</h2>
+      <ol class="example-icons">
+        <li><i class="icon-step-1"></i>  <p>icon-step-1.png</p></li>
+        <li><i class="icon-step-2"></i>  <p>icon-step-2.png</p></li>
+        <li><i class="icon-step-3"></i>  <p>icon-step-3.png</p></li>
+        <li><i class="icon-step-4"></i>  <p>icon-step-4.png</p></li>
+        <li><i class="icon-step-5"></i>  <p>icon-step-5.png</p></li>
+        <li><i class="icon-step-6"></i>  <p>icon-step-6.png</p></li>
+        <li><i class="icon-step-7"></i>  <p>icon-step-7.png</p></li>
+        <li><i class="icon-step-8"></i>  <p>icon-step-8.png</p></li>
+        <li><i class="icon-step-9"></i>  <p>icon-step-9.png</p></li>
+        <li><i class="icon-step-10"></i> <p>icon-step-10.png</p></li>
+        <li><i class="icon-step-11"></i> <p>icon-step-11.png</p></li>
+        <li><i class="icon-step-12"></i> <p>icon-step-12.png</p></li>
+        <li><i class="icon-step-13"></i> <p>icon-step-13.png</p></li>
+        <li><i class="icon-step-14"></i> <p>icon-step-14.png</p></li>
+      </ol>
+    </div>
+
+    <div class="column-third">
+      <h2 class="heading-medium">Icons</h2>
+      <ul class="example-icons">
+        <li>
+          <i class="icon-calendar"></i>
+          <p>icon-calendar.png</p>
+        </li>
+        <li>
+          <i class="icon-file-download"></i>
+          <p>icon-file-download.png</p>
+        </li>
+        <li>
+          <i class="icon-important"></i>
+          <p>icon-important.png</p>
+        </li>
+        <li>
+          <i class="icon-information"></i>
+          <p>icon-information.png</p>
+        </li>
+        <li>
+          <i class="icon-locator"></i>
+          <p>icon-locator.png</p>
+        </li>
+      </ul>
+
+    </div>
+
+    <div class="column-third">
+      <h2 class="heading-medium">White or semi-transparent icons</h2>
+      <ul class="icon-background example-icons">
+        <li>
+          <i class="icon-pointer"></i>
+          <p>icon-pointer.png</p>
+        </li>
+        <li>
+          <i class="icon-pointer-black"></i>
+          <p>icon-pointer-black.png</p>
+        </li>
+        <li>
+          <i class="icon-search"></i>
+          <p>icon-search.pngs</p>
+        </li>
+      </ul>
+    </div>
+
+  </div>
+
+</main><!-- /#content-->
+{{/content}}
+
+{{/layout_example}}

--- a/views/examples/example_icons.html
+++ b/views/examples/example_icons.html
@@ -89,7 +89,7 @@
         </li>
         <li>
           <i class="icon-search"></i>
-          <p>icon-search.pngs</p>
+          <p>icon-search.png</p>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
- Create an example page to show icons from the govuk front end toolkit
- Add a mixin to generate the common rules for each icon
- Use the mixin for the icons in the front end toolkit
- Generate classes for each of the 1 - 14 steps icons.

This PR shows the icons available in the front end toolkit and creating this new mixin aims to make it easier to update them in future (this mixin should move into the front-end toolkit).

Here's a screenshot of the example page:

![example icons icons and images gov uk elements](https://cloud.githubusercontent.com/assets/417754/11372161/dc60849c-92c3-11e5-9e53-4dd31999af48.png)

cc. @fofr, @robinwhittleton.


