### PR TITLE
Show icons in the govuk frontend toolkit

### DIFF
--- a/public/sass/elements/_icons.scss
+++ b/public/sass/elements/_icons.scss
@@ -42,7 +42,7 @@
 }
 
 .icon-important {
-  @include icon(icon-important, 34, 34);
+  @include icon(icon-important, 35, 35);
 }
 
 .icon-information {

--- a/public/sass/elements/_icons.scss
+++ b/public/sass/elements/_icons.scss
@@ -72,3 +72,31 @@
     @include icon(icon-step-#{$i}, 23, 23, icon-steps);
   }
 }
+
+// Propose replacing step icons with circles
+.circle {
+  display: inline-block;
+  @include border-radius(100%);
+
+  background: $black;
+  color: $white;
+
+  font-family: $NTA-Light-Tabular;
+  font-size: 12px;
+  font-weight: bold;
+  text-align: center;
+}
+
+// All step circles are 24px x 24px
+.circle-step {
+  min-width: 24px;
+  min-height: 24px;
+  line-height: 24px;
+}
+
+.circle-step-large {
+  font-size: 19px;
+  min-width: 38px;
+  min-height: 38px;
+  line-height: 38px;
+}

--- a/public/sass/elements/_icons.scss
+++ b/public/sass/elements/_icons.scss
@@ -76,7 +76,7 @@
 // Propose replacing step icons with circles
 .circle {
   display: inline-block;
-  @include border-radius(100%);
+  @include border-radius(50%);
 
   background: $black;
   color: $white;

--- a/public/sass/elements/_icons.scss
+++ b/public/sass/elements/_icons.scss
@@ -1,246 +1,74 @@
-// GOV.UK icons
+// Icons
+// ==========================================================================
+
+// Icon mixin
+@mixin icon($icon-name, $icon-width, $icon-height, $icon-sub-folder:false) {
+
+  width: #{$icon-width}px;
+  height: #{$icon-height}px;
+
+  @if $icon-sub-folder {
+    background-image: file-url("icons/#{$icon-sub-folder}/#{$icon-name}.png");
+
+    @include device-pixel-ratio() {
+      background-image: file-url("icons/#{$icon-sub-folder}/#{$icon-name}-2x.png");
+      background-size: 100%;
+    }
+
+  } @else {
+    background-image: file-url("icons/#{$icon-name}.png");
+
+    @include device-pixel-ratio() {
+      background-image: file-url("icons/#{$icon-name}-2x.png");
+      background-size: 100%;
+    }
+  }
+}
 
 .icon {
-  display: block;
+  display: inline-block;
+
   background-position: 0 0;
   background-repeat: no-repeat;
-  overflow: hidden;
 }
 
+// GOV.UK front end toolkit icons
 .icon-calendar {
-  width: 27px;
-  height: 27px;
-  background-image: file-url("icons/icon-calendar.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-calendar-2x.png");
-    background-size: 100%;
-  }
+  @include icon(icon-calendar, 27, 27);
 }
 
-.icon-download {
-  width: 30px;
-  height: 39px;
-  background-image: file-url("icons/icon-file-download.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-file-download-2x.png");
-    background-size: 100%;
-  }
+.icon-file-download {
+  @include icon(icon-file-download, 30, 39);
 }
 
 .icon-important {
-  width: 35px;
-  height: 35px;
-  background-image: file-url("icons/icon-important.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-important-2x.png");
-    background-size: 100%;
-  }
+  @include icon(icon-important, 34, 34);
 }
 
 .icon-information {
-  width: 27px;
-  height: 27px;
-  background-image: file-url("icons/icon-information.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-information-2x.png");
-    background-size: 100%;
-  }
+  @include icon(icon-information, 27, 27);
 }
 
 .icon-locator {
-  width: 26px;
-  height: 36px;
-  background-image: file-url("icons/icon-locator.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-locator-2x.png");
-    background-size: 100%;
-  }
+  @include icon(icon-locator, 26, 36);
 }
 
-.icon-search {
-  width: 30px;
-  height: 22px;
-  background-color: $black;
-  background-image: file-url("icons/icon-search.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-search-2x.png");
-    background-size: 100%;
-  }
-}
-
-// GOV.UK arrow icons
 .icon-pointer {
-  width: 30px;
-  height: 19px;
-  background-color: $black;
-  background-image: file-url("icons/icon-pointer.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-pointer-2x.png");
-    background-size: 100%;
-  }
+  @include icon(icon-pointer, 30, 19);
 }
 
 .icon-pointer-black {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-pointer-black.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-pointer-black-2x.png");
-    background-size: 100%;
-  }
+  @include icon(icon-pointer-black, 23, 23);
 }
 
-// GOV.UK external link icons
-// TODO (Are these provided by the template?)
+.icon-search {
+  @include icon(icon-search, 30, 22);
+}
+
 
 // GOV.UK step icons
-.icon-step-1 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-1.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-1-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-2 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-2.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-2-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-3 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-3.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-3-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-4 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-4.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-4-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-5 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-5.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-5-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-6 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-6.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-6-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-7 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-7.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-7-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-8 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-8.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-8-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-9 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-9.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-9-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-10 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-10.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-10-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-11 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-11.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-11-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-12 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-12.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-12-2x.png");
-    background-size: 100%;
-  }
-}
-
-.icon-step-13 {
-  width: 23px;
-  height: 23px;
-  background-image: file-url("icons/icon-steps/icon-step-13.png");
-
-  @include device-pixel-ratio() {
-    background-image: file-url("icons/icon-steps/icon-step-13-2x.png");
-    background-size: 100%;
+@for $i from 1 through 14 {
+  .icon-step-#{$i} {
+    @include icon(icon-step-#{$i}, 23, 23, icon-steps);
   }
 }

--- a/routes.js
+++ b/routes.js
@@ -73,6 +73,14 @@ module.exports = {
       res.render('guide_icons_images', {'assetPath' : assetPath, 'page_name' : page_name });
     });
 
+    // Example page: Icons
+    app.get('/icons-images/example-icons', function (req, res) {
+      var section = "Icons and images";
+      var section_name = "Icons";
+      var page_name = "Example: Icons";
+      res.render('examples/example_icons', {'assetPath' : assetPath, 'section': section, 'section_name' : section_name, 'page_name' : page_name });
+    });
+
     // Data
     app.get('/data', function (req, res) {
       var page_name = "Data";

--- a/views/examples/example_icons.html
+++ b/views/examples/example_icons.html
@@ -80,15 +80,15 @@
       <h2 class="heading-medium">White or semi-transparent icons</h2>
       <ul class="example-icon-list example-icon-list-background">
         <li>
-          <i class="icon-pointer"></i>
+          <i class="icon icon-pointer"></i>
           <p>icon-pointer.png</p>
         </li>
         <li>
-          <i class="icon-pointer-black"></i>
+          <i class="icon icon-pointer-black"></i>
           <p>icon-pointer-black.png</p>
         </li>
         <li>
-          <i class="icon-search"></i>
+          <i class="icon icon-search"></i>
           <p>icon-search.png</p>
         </li>
       </ul>

--- a/views/examples/example_icons.html
+++ b/views/examples/example_icons.html
@@ -89,7 +89,7 @@
         </li>
         <li>
           <i class="icon-search"></i>
-          <p>icon-search.pngs</p>
+          <p>icon-search.png</p>
         </li>
       </ul>
     </div>

--- a/views/examples/example_icons.html
+++ b/views/examples/example_icons.html
@@ -1,0 +1,102 @@
+{{<layout_example}}
+
+{{$pageTitle}}Example: Icons — Icons and images — GOV.UK elements{{/pageTitle}}
+
+{{$content}}
+<main id="content" role="main">
+
+  {{>breadcrumb}}
+
+  <style>
+  .example-icon-list p { font-size: 16px; }
+  .example-icon-list-background { background-color: #d3d3d3; padding: 15px; }
+  </style>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h1 class="heading-xlarge">
+        <span class="heading-secondary">Icons and images</span>
+        Example: Icons
+      </h1>
+
+      <p class="text">
+        This test page shows the icons which are included in the govuk frontend toolkit.
+      </p>
+
+    </div>
+  </div>
+
+  <div class="grid-row">
+
+    <div class="column-third">
+      <h2 class="heading-medium">Step icons</h2>
+      <ol class="example-icon-list">
+        <li><i class="icon icon-step-1"></i> <p>icon-step-1.png</p></li>
+        <li><i class="icon icon-step-2"></i> <p>icon-step-2.png</p></li>
+        <li><i class="icon icon-step-3"></i> <p>icon-step-3.png</p></li>
+        <li><i class="icon icon-step-4"></i> <p>icon-step-4.png</p></li>
+        <li><i class="icon icon-step-5"></i> <p>icon-step-5.png</p></li>
+        <li><i class="icon icon-step-6"></i> <p>icon-step-6.png</p></li>
+        <li><i class="icon icon-step-7"></i> <p>icon-step-7.png</p></li>
+        <li><i class="icon icon-step-8"></i> <p>icon-step-8.png</p></li>
+        <li><i class="icon icon-step-9"></i> <p>icon-step-9.png</p></li>
+        <li><i class="icon icon-step-10"></i> <p>icon-step-10.png</p></li>
+        <li><i class="icon icon-step-11"></i> <p>icon-step-11.png</p></li>
+        <li><i class="icon icon-step-12"></i> <p>icon-step-12.png</p></li>
+        <li><i class="icon icon-step-13"></i> <p>icon-step-13.png</p></li>
+        <li><i class="icon icon-step-14"></i> <p>icon-step-14.png</p></li>
+      </ol>
+    </div>
+
+    <div class="column-third">
+      <h2 class="heading-medium">Icons</h2>
+      <ul class="example-icon-list">
+        <li>
+          <i class="icon icon-calendar"></i>
+          <p>icon-calendar.png</p>
+        </li>
+        <li>
+          <i class="icon icon-file-download"></i>
+          <p>icon-file-download.png</p>
+        </li>
+        <li>
+          <i class="icon icon-important"></i>
+          <p>icon-important.png</p>
+        </li>
+        <li>
+          <i class="icon icon-information"></i>
+          <p>icon-information.png</p>
+        </li>
+        <li>
+          <i class="icon icon-locator"></i>
+          <p>icon-locator.png</p>
+        </li>
+      </ul>
+
+    </div>
+
+    <div class="column-third">
+      <h2 class="heading-medium">White or semi-transparent icons</h2>
+      <ul class="example-icon-list example-icon-list-background">
+        <li>
+          <i class="icon-pointer"></i>
+          <p>icon-pointer.png</p>
+        </li>
+        <li>
+          <i class="icon-pointer-black"></i>
+          <p>icon-pointer-black.png</p>
+        </li>
+        <li>
+          <i class="icon-search"></i>
+          <p>icon-search.pngs</p>
+        </li>
+      </ul>
+    </div>
+
+  </div>
+
+</main><!-- /#content-->
+{{/content}}
+
+{{/layout_example}}

--- a/views/examples/example_icons.html
+++ b/views/examples/example_icons.html
@@ -8,7 +8,8 @@
   {{>breadcrumb}}
 
   <style>
-  .example-icon-list p { font-size: 16px; }
+  .example-icon-list p { display: inline-block; font-size: 16px; padding-left: 1em; vertical-align: middle; margin-bottom: 0;}
+  .example-icon-list li { margin-bottom: 15px;}
   .example-icon-list-background { background-color: #d3d3d3; padding: 15px; }
   </style>
 
@@ -46,6 +47,26 @@
         <li><i class="icon icon-step-12"></i> <p>icon-step-12.png</p></li>
         <li><i class="icon icon-step-13"></i> <p>icon-step-13.png</p></li>
         <li><i class="icon icon-step-14"></i> <p>icon-step-14.png</p></li>
+      </ol>
+    </div>
+
+    <div class="column-third">
+      <h2 class="heading-medium">Step circles</h2>
+      <ol class="example-icon-list">
+        <li> <span class="circle circle-step">1</span>  <span class="circle circle-step-large">1</span>  </li>
+        <li> <span class="circle circle-step">2</span>  <span class="circle circle-step-large">2</span>  </li>
+        <li> <span class="circle circle-step">3</span>  <span class="circle circle-step-large">3</span>  </li>
+        <li> <span class="circle circle-step">4</span>  <span class="circle circle-step-large">4</span>  </li>
+        <li> <span class="circle circle-step">5</span>  <span class="circle circle-step-large">5</span>  </li>
+        <li> <span class="circle circle-step">6</span>  <span class="circle circle-step-large">6</span>  </li>
+        <li> <span class="circle circle-step">7</span>  <span class="circle circle-step-large">7</span>  </li>
+        <li> <span class="circle circle-step">8</span>  <span class="circle circle-step-large">8</span>  </li>
+        <li> <span class="circle circle-step">9</span>  <span class="circle circle-step-large">9</span>  </li>
+        <li> <span class="circle circle-step">10</span> <span class="circle circle-step-large">10</span> </li>
+        <li> <span class="circle circle-step">11</span> <span class="circle circle-step-large">11</span> </li>
+        <li> <span class="circle circle-step">12</span> <span class="circle circle-step-large">12</span> </li>
+        <li> <span class="circle circle-step">13</span> <span class="circle circle-step-large">13</span> </li>
+        <li> <span class="circle circle-step">14</span> <span class="circle circle-step-large">14</span> </li>
       </ol>
     </div>
 

--- a/views/guide_icons_images.html
+++ b/views/guide_icons_images.html
@@ -76,6 +76,11 @@
     </div>
   </div>
 
+  <h3 class="heading-medium" id="examples">Examples</h3>
+  <ul>
+    <li><a href="{{site.baseurl}}/icons-images/example-icons/">Example page: Icons in the GOV.UK frontend toolkit</a></li>
+  </ul>
+
 </main><!-- / #content -->
 {{/content}}
 


### PR DESCRIPTION
- Create an example page and link to it from the Icons and images section.

- Create a mixin to generate the rules for each icon, to avoid repetition. 
The mixin requires the icon name, width and height and optional subfolder - for the step icons.
(The subfolder option can be removed once the step icons are rebuilt using only CSS)

- Use a base class and modifier class for each icon

Here is a screenshot of the Icons example page:

![govuk frontend toolkkit icons](https://cloud.githubusercontent.com/assets/417754/11427297/c2078a54-9459-11e5-8084-c161ac7e1afe.png)

cc. @fofr, @robinwhittleton.