### PR TITLE
Update cookie message to match govuk template default

### DIFF
--- a/lib/template-config.js
+++ b/lib/template-config.js
@@ -4,7 +4,7 @@ module.exports = {
   bodyClasses: "{{$bodyClasses}}{{/bodyClasses}}",
   bodyEnd: "{{$bodyEnd}}{{/bodyEnd}}",
   content: "{{$content}}{{/content}}",
-  cookieMessage: "{{$cookieMessage}}{{/cookieMessage}}",
+  cookieMessage: "{{$cookieMessage}}<p>GOV.UK uses cookies to make the site simpler. <a href='https://www.gov.uk/help/cookies'>Find out more about cookies</a></p>{{/cookieMessage}}",
   crownCopyrightMessage: "{{$crownCopyrightMessage}}© Crown copyright{{/crownCopyrightMessage}}",
   footerSupportLinks: "{{$footerSupportLinks}}{{/footerSupportLinks}}",
   footerTop: "{{$footerTop}}{{/footerTop}}",

--- a/views/includes/cookie_message.html
+++ b/views/includes/cookie_message.html
@@ -1,3 +1,0 @@
-<p>
-  GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>
-</p>

--- a/views/layout.html
+++ b/views/layout.html
@@ -1,9 +1,5 @@
 {{<govuk_template}}
 
-{{$cookieMessage}}
-  {{>cookie_message}}
-{{/cookieMessage}}
-
 {{$head}}
   {{>elements_head}}
   {{>elements_tracking}}

--- a/views/layout_example.html
+++ b/views/layout_example.html
@@ -1,9 +1,5 @@
 {{<govuk_template}}
 
-{{$cookieMessage}}
-  {{>cookie_message}}
-{{/cookieMessage}}
-
 {{$head}}
   {{>head}}
   <style>


### PR DESCRIPTION
- Use the [same cookie message as govuk_template](https://github.com/alphagov/govuk_template/blob/master/source/views/layouts/govuk_template.html.erb#L73)
- Move the default message to `lib/config.js`, this matches the [govuk_prototype_kit](https://github.com/alphagov/govuk_prototype_kit/pull/92)
- Remove cookie message include as this is no longer required

Screenshot below:

![gov uk elements - cookie message](https://cloud.githubusercontent.com/assets/417754/11494961/24cfc856-97ff-11e5-9e5d-e8bdb9d5e743.png)
