### PR TITLE
Use a common naming convention

### DIFF
--- a/public/sass/elements/_layout.scss
+++ b/public/sass/elements/_layout.scss
@@ -31,10 +31,10 @@
 // For two equal columns
 
 // <div class="grid-row">
-//   <div class="column-half">
+//   <div class="column-one-half">
 //
 //   </div>
-//   <div class="column-half">
+//   <div class="column-one-half">
 //
 //   </div>
 // </div>
@@ -46,11 +46,13 @@
 
 // Use .grid-column to create a grid column with 15px gutter
 // By default grid columns break to become full width at tablet size
-.column-quarter {
+.column-quarter,
+.column-one-quarter {
   @include grid-column(1/4);
 }
 
-.column-half {
+.column-half,
+.column-one-half {
   @include grid-column(1/2);
 }
 

--- a/public/sass/elements/_lists.scss
+++ b/public/sass/elements/_lists.scss
@@ -1,10 +1,15 @@
 // Lists
 // ==========================================================================
 
-ul,
-ol {
+.list {
   list-style-type: none;
   padding: 0;
+  margin-top: 5px;
+  margin-bottom: 20px;
+}
+
+.list li {
+  margin-bottom: 5px;
 }
 
 // Bulleted lists
@@ -17,20 +22,14 @@ ol {
 .list-number {
   list-style-type: decimal;
   padding-left: 20px;
-  
+
   @include ie-lte(7) {
     padding-left: 28px;
   }
 }
 
-.list-bullet,
-.list-number {
-  margin-top: 5px;
-  margin-bottom: 20px;
-}
-
-.list-bullet li,
-.list-number li {
-  margin-bottom: 5px;
+// Lists of related links
+.list-links li {
+  margin-bottom: 10px;
 }
 

--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -1,11 +1,11 @@
 // Panels
 // ==========================================================================
 
-// Indented panels with a grey left hand border
-.panel-indent {
+.panel {
   @extend %contain-floats;
   clear: both;
-  border-left: 5px solid $border-colour;
+  border-style: solid;
+  border-color: $border-colour;
 
   padding: em(15,19);
   margin-bottom: em(15,19);
@@ -18,14 +18,19 @@
   :last-child {
     margin-bottom: 0;
   }
-
 }
 
-.panel-indent-info {
+.panel-border-wide {
   border-left-width: 10px;
 }
 
-// Indented panels within form groups
-.form-group .panel-indent {
+// Used to show the left edge of "toggled" content
+.panel-border-narrow {
+  border-left-width: 5px;
+}
+
+// Panels within form groups
+// Remove the bottom padding as .form-group sets a bottom margin
+.form-group .panel-border-narrow {
   padding-bottom: 0;
 }

--- a/views/examples/example_details_summary.html
+++ b/views/examples/example_details_summary.html
@@ -41,7 +41,7 @@
         <summary>
           <span class="summary">Where to find your driving licence number</span>
         </summary>
-        <div class="panel-indent">
+        <div class="panel panel-border-narrow">
           <p>
             Your driving licence number can be found in section 5<br>
             of your driving licence photocard.
@@ -58,7 +58,7 @@
         <summary>
           <span class="summary">Where to find your driving licence number</span>
         </summary>
-        <div class="panel-indent">
+        <div class="panel panel-border-narrow">
           <p>
             Your driving licence number can be found in section 5<br>
             of your driving licence photocard.
@@ -75,7 +75,7 @@
         <summary>
           <span class="summary">Where to find your driving licence number</span>
         </summary>
-        <div class="panel-indent">
+        <div class="panel panel-border-narrow">
           <p>
             Your driving licence number can be found in section 5<br>
             of your driving licence photocard.

--- a/views/examples/example_form_validation_multiple_questions.html
+++ b/views/examples/example_form_validation_multiple_questions.html
@@ -22,13 +22,13 @@
     </li>
     <li>
       move keyboard focus to the start of the summary
-      <span class="panel-indent">
+      <span class="panel panel-border-narrow">
         to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
       </span>
     </li>
     <li>
       indicate to screenreaders that the summary represents a collection of information
-      <span class="panel-indent">
+      <span class="panel panel-border-narrow">
         add the ARIA <code>role="group"</code> to the containing <code>div</code>
       </span>
     </li>
@@ -37,7 +37,7 @@
     </li>
     <li>
       associate the heading with the summary box
-      <span class="panel-indent">
+      <span class="panel panel-border-narrow">
         use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
       </span>
     </li>
@@ -49,7 +49,7 @@
     </li>
     <li>
       associate each error message with the corresponding field
-      <span class="panel-indent">
+      <span class="panel panel-border-narrow">
          add an ID to each error message and associate this with the field using <code>aria-describedby</code>
       </span>
     </li>

--- a/views/examples/example_form_validation_multiple_questions.html
+++ b/views/examples/example_form_validation_multiple_questions.html
@@ -13,7 +13,7 @@
 
   <h2 class="heading-medium implementation-advice">Implementation advice</h2>
   <p class="lead-in">When an error occurs:</p>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>
       add a 5px red left border to the field with the error
     </li>

--- a/views/examples/example_form_validation_single_question_radio.html
+++ b/views/examples/example_form_validation_single_question_radio.html
@@ -28,13 +28,13 @@
     </li>
     <li>
       move keyboard focus to the start of the summary
-      <span class="panel-indent">
+      <span class="panel panel-border-narrow">
         to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
       </span>
     </li>
     <li>
       indicate to screenreaders that the summary represents a collection of information
-      <span class="panel-indent">
+      <span class="panel panel-border-narrow">
         add the ARIA <code>role="group"</code> to the containing <code>div</code>
       </span>
     </li>
@@ -43,7 +43,7 @@
     </li>
     <li>
       associate the heading with the summary box
-      <span class="panel-indent">
+      <span class="panel panel-border-narrow">
         use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
       </span>
     </li>
@@ -55,7 +55,7 @@
     </li>
     <li>
       associate each error message with the corresponding field
-      <span class="panel-indent">
+      <span class="panel panel-border-narrow">
          add an ID to each error message and associate this with the field using <code>aria-describedby</code>
       </span>
     </li>

--- a/views/examples/example_form_validation_single_question_radio.html
+++ b/views/examples/example_form_validation_single_question_radio.html
@@ -13,7 +13,7 @@
 
   <h2 class="heading-medium implementation-advice">Implementation advice</h2>
   <p class="lead-in">When an error occurs:</p>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>
       add a 5px red left border to the field with the error
     </li>

--- a/views/examples/example_grid_layout.html
+++ b/views/examples/example_grid_layout.html
@@ -28,7 +28,7 @@
         </p>
       </div>
     </div>
-    <div class="column-third">
+    <div class="column-one-third">
       <h2 class="bold-medium">One third</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
@@ -37,19 +37,19 @@
   </div>
 
   <div class="grid-row">
-    <div class="column-third">
+    <div class="column-one-third">
       <h2 class="bold-medium">One third</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="column-third">
+    <div class="column-one-third">
       <h2 class="bold-medium">One third</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="column-third">
+    <div class="column-one-third">
       <h2 class="bold-medium">One third</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
@@ -58,13 +58,13 @@
   </div>
 
   <div class="grid-row">
-    <div class="column-half">
+    <div class="column-one-half">
       <h2 class="bold-medium">One half</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="column-half">
+    <div class="column-one-half">
       <h2 class="bold-medium">One half</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
@@ -73,19 +73,19 @@
   </div>
 
   <div class="grid-row">
-    <div class="column-half">
+    <div class="column-one-half">
       <h2 class="bold-medium">One half</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="column-quarter">
+    <div class="column-one-quarter">
       <h2 class="bold-medium">One quarter</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="column-quarter">
+    <div class="column-one-quarter">
       <h2 class="bold-medium">One quarter</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
@@ -94,25 +94,25 @@
   </div>
 
   <div class="grid-row">
-    <div class="column-quarter">
+    <div class="column-one-quarter">
       <h2 class="bold-medium">One quarter</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="column-quarter">
+    <div class="column-one-quarter">
       <h2 class="bold-medium">One quarter</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="column-quarter">
+    <div class="column-one-quarter">
       <h2 class="bold-medium">One quarter</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="column-quarter">
+    <div class="column-one-quarter">
       <h2 class="bold-medium">One quarter</h2>
       <p>
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.

--- a/views/examples/example_radios_checkboxes.html
+++ b/views/examples/example_radios_checkboxes.html
@@ -52,7 +52,7 @@
               Citizen of another country
             </label>
 
-            <div class="panel-indent js-hidden" id="example_nationality_other">
+            <div class="panel panel-border-narrow js-hidden" id="example_nationality_other">
               <label for="nationality_other_countries" class="form-label">
                 Country name
               </label>
@@ -83,7 +83,7 @@
               Other address
             </label>
 
-            <div class="panel-indent js-hidden" id="example-other-address">
+            <div class="panel panel-border-narrow js-hidden" id="example-other-address">
 
               <h2 class="heading-medium">
                 Your other address

--- a/views/examples/example_typography.html
+++ b/views/examples/example_typography.html
@@ -39,19 +39,26 @@
 
     <p>Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.</p>
 
-    <ul class="list-bullet">
+    <ul class="list list-bullet">
       <li>here is a bulleted list</li>
       <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
       <li>vestibulum id ligula porta felis euismod semper</li>
       <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
     </ul>
 
-    <ol class="list-number">
+    <ol class="list list-number">
       <li>here is a numbered list</li>
       <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
       <li>vestibulum id ligula porta felis euismod semper</li>
       <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
     </ol>
+
+    <ul class="list list-links">
+      <li><a href="#">Related link</a></li>
+      <li><a href="#">Related link</a></li>
+      <li><a href="#">Related link</a></li>
+      <li><a href="#" class="bold-xsmall">More</a></li>
+    </ul>
 
     <p>Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.</p>
 

--- a/views/guide_buttons.html
+++ b/views/guide_buttons.html
@@ -102,12 +102,12 @@
 
   <div class="example example-button">
     <div class="grid-row">
-      <div class="column-third">
+      <div class="column-one-third">
 
         <button class="button">Save and continue</button>
 
       </div>
-      <div class="column-third">
+      <div class="column-one-third">
 
         <div class="swatch-wrapper">
           <h4 class="heading-small">Button</h4>
@@ -119,7 +119,7 @@
         </div>
 
       </div>
-      <div class="column-third">
+      <div class="column-one-third">
 
         <div class="swatch-wrapper">
           <h4 class="heading-small">Focus</h4>

--- a/views/guide_colour.html
+++ b/views/guide_colour.html
@@ -229,7 +229,7 @@
   </div>
 
   <h3 class="heading-medium" id="colour-extended-palette">Extended palette</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>used for graphs and supporting material</li>
     <li>for tints of the extended palette use 50% or 25%</li>
     <li>for departmental colours

--- a/views/guide_data.html
+++ b/views/guide_data.html
@@ -75,7 +75,7 @@
 
   <div class="example">
     <div class="grid-row">
-      <div class="column-half">
+      <div class="column-one-half">
 
         <div class="data">
           <h2 class="bold-xxlarge">24</h2>
@@ -83,7 +83,7 @@
         </div>
 
       </div>
-      <div class="column-half">
+      <div class="column-one-half">
 
         <div class="data">
           <h2 class="bold-xxlarge">80px</h2>
@@ -96,7 +96,7 @@
 
   <div class="example">
     <div class="grid-row">
-      <div class="column-half">
+      <div class="column-one-half">
 
         <div class="data">
           <h2 class="bold-xlarge">56/154</h2>
@@ -104,7 +104,7 @@
         </div>
 
       </div>
-      <div class="column-half">
+      <div class="column-one-half">
 
         <div class="data">
           <h2 class="bold-xlarge">48px</h2>

--- a/views/guide_data.html
+++ b/views/guide_data.html
@@ -31,7 +31,7 @@
   </div>
 
   <h3 class="heading-medium" id="data-table-numeric">Numeric tabular data</h3>
-  <ul class="text list-bullet">
+  <ul class="text list list-bullet">
     <li>when comparing rows of numbers, align numbers to the right in table cells</li>
     <li>use the GOV.UK frontend toolkit's <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/mixins.md#tabular-numbers" rel="external">tabular numbers</a> to allow numbers of the same width to be more easily compared</li>
   </ul>
@@ -68,7 +68,7 @@
 </p>
 
   <h3 class="heading-medium" id="data-visualisation">Data visualisation</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>data is recommended as an alternative to using images</li>
     <li>for screen readers, ensure the data value appears first so it makes sense when read aloud</li>
   </ul>
@@ -116,7 +116,7 @@
   </div>
 
   <h3 class="heading-medium" id="examples">Examples</h3>
-  <ul class="list-bullet">
+  <ul class="list list-bullet">
     <li>
       <a href="https://www.gov.uk/pay-leave-for-parents/y/yes/2013-1-2/employee/employee/yes/yes/122.00-week/yes/yes/yes/122.00-week/yes" rel="external">
         see an example of table usage on GOV.UK

--- a/views/guide_errors.html
+++ b/views/guide_errors.html
@@ -48,7 +48,7 @@
     You must:
   </p>
 
-  <ul class="text list-bullet">
+  <ul class="text list list-bullet">
     <li>show an error summary at the top of the page</li>
     <li>include a heading to alert the user to the error</li>
     <li>link to each of the problematic questions</li>
@@ -77,7 +77,7 @@
     For each error:
   </p>
 
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>write a message that helps the user to understand why the error occurred and what to do about it</li>
     <li>put the message in the <code class="code">&lt;label&gt;</code> or <code class="code">&lt;legend&gt;</code> for the question,
     after the question text, in red</li>
@@ -100,7 +100,7 @@
 </pre>
 
   <h3 class="heading-medium" id="examples">Examples</h3>
-  <ul class="list-bullet">
+  <ul class="list list-bullet">
     <li>
       <a href="{{ site.baseurl}}/errors/example-form-validation-single-question-radio">
         form validation - single question

--- a/views/guide_errors.html
+++ b/views/guide_errors.html
@@ -65,9 +65,11 @@
 </code>
 </pre>
 
-  <h3 class="heading-small panel-indent text">
-    The error summary must appear at the top of the page, so it is visible when the page is refreshed and is immediately read out by assistive technology.
-  </h3>
+  <div class="panel panel-border-narrow">
+    <h3 class="heading-small">
+      The error summary must appear at the top of the page, so it is visible when the page is refreshed and is immediately read out by assistive technology.
+    </h3>
+  </div>
 
   <h3 class="heading-medium" id="highlight-errors">Highlight errors in forms</h3>
 

--- a/views/guide_form_elements.html
+++ b/views/guide_form_elements.html
@@ -40,14 +40,14 @@
 
 
   <h3 class="heading-medium" id="form-optional-fields">Optional and mandatory fields</h3>
-  <ul class="text list-bullet">
+  <ul class="text list list-bullet">
     <li>only ask for the information you absolutely need</li>
     <li>if you do ask for optional information, mark the labels of optional fields with '(optional)'</li>
     <li>don't mark mandatory fields with asterisks</li>
   </ul>
 
   <h3 class="heading-medium" id="form-labels">Labels</h3>
-  <ul class="text list-bullet">
+  <ul class="text list list-bullet">
     <li>all form fields should be given labels</li>
     <li>don't hide labels, unless the surrounding context makes them unnecessary</li>
     <li>labels should be aligned above their fields</li>
@@ -99,7 +99,7 @@
   </div>
 
   <h3 class="heading-medium"  id="form-hint-text">Hint text</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>don't use placeholder text in form fields, as this will disappear once content is entered into the form field</li>
     <li>use hint text for supporting contextual help, this will always be shown</li>
     <li>hint text should sit above a form field</li>
@@ -148,7 +148,7 @@
   </p>
 
   <h3 class="heading-medium" id="form-radio-buttons">Radio buttons</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>use these to let users choose a single option from a list</li>
     <li>for more than two options, radio buttons should be stacked</li>
     <li>radio buttons with large hit areas are easier to select with a mouse or touch devices</li>
@@ -181,7 +181,7 @@
 </pre>
 
   <h3 class="heading-medium" id="form-checkboxes">Checkboxes</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>use these to select either on/off toggles or multiple selections</li>
     <li>make it clear with words when users can select one or multiple options</li>
   </ul>
@@ -200,7 +200,7 @@
 </pre>
 
   <h4 class="heading-small">Inline checkboxes</h4>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>large hit areas aren't always appropriate</li>
     <li>only pre-select options if there's a strong, user-centred reason to</li>
   </ul>
@@ -226,7 +226,7 @@
   <h3 class="heading-medium" id="form-toggle-content">
     Conditionally revealing content
   </h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>reveal additional questions, depending on the context</li>
     <li>insets are used to emphasise this supporting information</li>
   </ul>
@@ -274,7 +274,7 @@
 </pre>
 
   <h3 class="heading-medium" id="examples">Examples</h3>
-  <ul class="list-bullet">
+  <ul class="list list-bullet">
     <li><a href="{{site.baseurl}}/form-elements/example-form-elements/">form elements</a></li>
     <li><a href="{{site.baseurl}}/form-elements/example-date/">date pattern</a></li>
     <li><a href="{{site.baseurl}}/form-elements/example-radios-checkboxes/">radio buttons and checkboxes</a></li>

--- a/views/guide_icons_images.html
+++ b/views/guide_icons_images.html
@@ -50,10 +50,10 @@
 
   <div class="example example-images">
     <div class="grid-row">
-      <div class="column-half">
+      <div class="column-one-half">
         <img src="/public/images/examples/3by2.jpg" alt="3:2">
       </div>
-      <div class="column-half">
+      <div class="column-one-half">
         <img src="/public/images/examples/pm.jpg" alt="">
       </div>
     </div>

--- a/views/guide_icons_images.html
+++ b/views/guide_icons_images.html
@@ -30,7 +30,7 @@
   </div>
 
   <h3 class="heading-medium" id="icons">Icons</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>
       if icons are needed ensure they are clear, simple and accompanied by relevant text
     </li>

--- a/views/guide_layout.html
+++ b/views/guide_layout.html
@@ -57,7 +57,7 @@
   </div>
 
   <h3 class="heading-medium" id="layout-spacing">Spacing</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>spacing between elements is usually 5px, 10px, 15px or multiples of 15px</li>
     <li>gutters are 15px for smaller screens and 30px for larger screens</li>
   </ul>
@@ -67,7 +67,7 @@
   </div>
 
   <h3 class="heading-medium" id="layout-grid-unit-proportions">Grid unit proportions</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>introduce columns as the content requires it – base column ratios on halves, thirds or quarters of the page width</li>
     <li>for screen breakpoints use media queries &ndash; find these in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_conditionals.scss">_conditionals.scss</a> file</li>
   </ul>
@@ -128,7 +128,7 @@
 </pre>
 
   <h3 class="heading-medium" id="examples">Examples</h3>
-  <ul class="list-bullet">
+  <ul class="list list-bullet">
     <li>
       <a href="{{ site.baseurl}}/layout/example-grid-layout/">
         an example grid layout page

--- a/views/guide_typography.html
+++ b/views/guide_typography.html
@@ -51,7 +51,7 @@
     Headings
   </h3>
 
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>use GDS Transport Website Bold</li>
     <li>use sentence case for headings</li>
     <li>use headings consistently to create a clear hierarchy</li>
@@ -71,7 +71,7 @@
     Lead paragraph
   </h3>
 
-  <ul class="list-bullet">
+  <ul class="list list-bullet">
     <li>use 24px for a lead paragraph</li>
     <li>there should only be one lead paragraph per page</li>
   </ul>
@@ -92,7 +92,7 @@
     Body copy
   </h3>
 
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>use GDS Transport Website Light</li>
     <li>avoid using bold and italics</li>
     <li>use 19px for body copy &ndash; 16px for smaller screens</li>
@@ -113,7 +113,7 @@
 </pre>
 
   <h3 class="heading-medium" id="typography-links">Links</h3>
-  <ul class="list-bullet text">
+  <ul class="list list-bullet text">
     <li>links within body copy should be blue and underlined</li>
     <li>links without surrounding text should not have a full stop at the end</li>
     <li>link colours can be found in the <a href="{{site.baseurl}}/colour">colour palette</a></li>
@@ -184,7 +184,7 @@
 
 
   <h3 class="heading-medium" id="examples">Examples</h3>
-  <ul class="list-bullet">
+  <ul class="list list-bullet">
     <li>
       <a href="{{ site.baseurl}}/typography/example-typography/">
         an example typography page

--- a/views/index.html
+++ b/views/index.html
@@ -24,7 +24,7 @@
   </div>
 
   <div class="grid-row">
-    <div class="column-third">
+    <div class="column-one-third">
 
       <h2 class="heading-medium"><a href="{{site.baseurl}}/layout/">Layout</a></h2>
       <p>
@@ -32,7 +32,7 @@
       </p>
 
     </div>
-    <div class="column-third">
+    <div class="column-one-third">
 
       <h2 class="heading-medium"><a href="{{site.baseurl}}/typography/">Typography</a></h2>
       <p>
@@ -40,7 +40,7 @@
       </p>
 
     </div>
-    <div class="column-third">
+    <div class="column-one-third">
 
       <h2 class="heading-medium"><a href="{{site.baseurl}}/colour/">Colour</a></h2>
       <p>
@@ -51,7 +51,7 @@
   </div>
 
   <div class="grid-row">
-    <div class="column-third">
+    <div class="column-one-third">
 
       <h2 class="heading-medium"><a href="{{site.baseurl}}/icons-images/">Icons and images</a></h2>
       <p>
@@ -59,7 +59,7 @@
       </p>
 
     </div>
-    <div class="column-third">
+    <div class="column-one-third">
 
       <h2 class="heading-medium"><a href="{{site.baseurl}}/data/">Data</a></h2>
       <p>
@@ -67,7 +67,7 @@
       </p>
 
     </div>
-    <div class="column-third">
+    <div class="column-one-third">
 
       <h2 class="heading-medium"><a href="{{site.baseurl}}/buttons/">Buttons</a></h2>
       <p>
@@ -78,7 +78,7 @@
   </div>
 
   <div class="grid-row">
-    <div class="column-third">
+    <div class="column-one-third">
 
       <h2 class="heading-medium"><a href="{{site.baseurl}}/form-elements/">Form elements</a></h2>
       <p>
@@ -86,7 +86,7 @@
       </p>
 
     </div>
-    <div class="column-third">
+    <div class="column-one-third">
 
       <h2 class="heading-medium"><a href="{{site.baseurl}}/errors/">Errors and validation</a></h2>
       <p>
@@ -94,7 +94,7 @@
       </p>
 
     </div>
-    <div class="column-third">
+    <div class="column-one-third">
 
       <h2 class="heading-medium"><a href="{{site.baseurl}}/alpha-beta-banners/">Alpha and beta banners</a></h2>
       <p>

--- a/views/layout_example.html
+++ b/views/layout_example.html
@@ -7,7 +7,7 @@
     /* Styles for this example page */
 
     /* Indented panels within bulleted lists */
-    .list-bullet .panel-indent {
+    .list-bullet .panel-border-narrow {
       display: block;
       margin-top: 5px;
       margin-bottom: 15px;

--- a/views/snippets/form_inset_checkboxes.html
+++ b/views/snippets/form_inset_checkboxes.html
@@ -23,7 +23,7 @@
         <input id="nationalities-other" name="nationalities" type="checkbox" value="Citizen of a different country">
         Citizen of a different country
       </label>
-      <div class="panel-indent js-hidden" id="example-different-country">
+      <div class="panel panel-border-narrow js-hidden" id="example-different-country">
         <label class="form-label" for="nationalities-other-country">Country name</label>
         <input class="form-control" type="text" id="nationalities-other-country" name="nationalities-other-country">
       </div>

--- a/views/snippets/form_inset_radios.html
+++ b/views/snippets/form_inset_radios.html
@@ -19,7 +19,7 @@
         No
       </label>
 
-      <div class="panel-indent js-hidden" id="example-ni-no">
+      <div class="panel panel-border-narrow js-hidden" id="example-ni-no">
         <label class="form-label" for="national-insurance">National Insurance number</label>
         <input class="form-control" name="national-insurance" type="text" id="national-insurance">
       </div>

--- a/views/snippets/layout_grid_halves.html
+++ b/views/snippets/layout_grid_halves.html
@@ -1,10 +1,10 @@
 <div class="grid-row">
 
-  <div class="column-half">
+  <div class="column-one-half">
     <p>Content</p>
   </div>
 
-  <div class="column-half">
+  <div class="column-one-half">
     <p>Content</p>
   </div>
 

--- a/views/snippets/layout_grid_quarters.html
+++ b/views/snippets/layout_grid_quarters.html
@@ -1,18 +1,18 @@
 <div class="grid-row">
 
-  <div class="column-quarter">
+  <div class="column-one-quarter">
     <p>Content</p>
   </div>
 
-  <div class="column-quarter">
+  <div class="column-one-quarter">
     <p>Content</p>
   </div>
 
-  <div class="column-quarter">
+  <div class="column-one-quarter">
     <p>Content</p>
   </div>
 
-  <div class="column-quarter">
+  <div class="column-one-quarter">
     <p>Content</p>
   </div>
 

--- a/views/snippets/layout_grid_thirds.html
+++ b/views/snippets/layout_grid_thirds.html
@@ -1,14 +1,14 @@
 <div class="grid-row">
 
-  <div class="column-third">
+  <div class="column-one-third">
     <p>Content</p>
   </div>
 
-  <div class="column-third">
+  <div class="column-one-third">
     <p>Content</p>
   </div>
 
-  <div class="column-third">
+  <div class="column-one-third">
     <p>Content</p>
   </div>
 

--- a/views/snippets/layout_grid_thirds_one_third_two_thirds.html
+++ b/views/snippets/layout_grid_thirds_one_third_two_thirds.html
@@ -1,6 +1,6 @@
 <div class="grid-row">
 
-  <div class="column-third">
+  <div class="column-one-third">
     <p>Content</p>
   </div>
 

--- a/views/snippets/layout_grid_thirds_two_thirds_one_third.html
+++ b/views/snippets/layout_grid_thirds_two_thirds_one_third.html
@@ -4,7 +4,7 @@
     <p>Content</p>
   </div>
 
-  <div class="column-third">
+  <div class="column-one-third">
     <p>Content</p>
   </div>
 

--- a/views/snippets/layout_spacing.html
+++ b/views/snippets/layout_spacing.html
@@ -1,8 +1,8 @@
 <div class="grid-row">
-  <div class="column-half">
+  <div class="column-one-half">
     <img src="/public/images/examples/15px-gutter-example.png" alt="15px gutter example">
   </div>
-  <div class="column-half">
+  <div class="column-one-half">
     <img src="/public/images/examples/30px-gutter-example.png" alt="30px gutter example">
   </div>
 </div>

--- a/views/snippets/typography_inset_text.html
+++ b/views/snippets/typography_inset_text.html
@@ -1,4 +1,4 @@
-<div class="panel-indent panel-indent-info">
+<div class="panel panel-border-wide">
   <p>
     It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.
   </p>

--- a/views/snippets/typography_lists.html
+++ b/views/snippets/typography_lists.html
@@ -1,13 +1,20 @@
-<ul class="list-bullet">
+<ul class="list list-bullet">
   <li>here is a bulleted list</li>
   <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
   <li>vestibulum id ligula porta felis euismod semper</li>
   <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
 </ul>
 
-<ol class="list-number">
+<ol class="list list-number">
   <li>here is a numbered list</li>
   <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
   <li>vestibulum id ligula porta felis euismod semper</li>
   <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
 </ol>
+
+<ul class="list list-links">
+  <li><a href="#">Related link</a></li>
+  <li><a href="#">Related link</a></li>
+  <li><a href="#">Related link</a></li>
+  <li><a href="#" class="bold-xsmall">More</a></li>
+</ul>

--- a/views/snippets/typography_progressive_disclosure.html
+++ b/views/snippets/typography_progressive_disclosure.html
@@ -2,7 +2,7 @@
 
   <summary><span class="summary">Help with nationality</span></summary>
 
-  <div class="panel-indent">
+  <div class="panel panel-border-narrow">
 
     <p>
       If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.


### PR DESCRIPTION
Use a common base class and modifier class pattern for lists, panels, icons (the changes to icons have already been made in #129).

Also use a common naming convention for grid columns, add `.column-one-third` and `.column-one-half`, update the examples to show use of these new classnames (while .column-third and .column-half remain, this isn't a breaking change - but aims to make our classnames for layout easier to guess).

cc. @robinwhittleton.