### PR TITLE
Fix: set only a left border for panels

### DIFF
--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -4,7 +4,7 @@
 .panel {
   @extend %contain-floats;
   clear: both;
-  border-style: solid;
+  border-left-style: solid;
   border-color: $border-colour;
 
   padding: em(15,19);


### PR DESCRIPTION
Before:
![before - typography gov uk elements](https://cloud.githubusercontent.com/assets/417754/11591998/dbe77534-9a93-11e5-93ee-76de9e6613ab.png)

After:
![after - typography gov uk elements](https://cloud.githubusercontent.com/assets/417754/11591995/da022a70-9a93-11e5-9727-49e1ff64925b.png)

