### PR TITLE
Fix: Update the selector used by the notice styles

### DIFF
--- a/public/sass/elements/_elements-typography.scss
+++ b/public/sass/elements/_elements-typography.scss
@@ -277,7 +277,7 @@ hr {
     top: 50%;
     margin-top: -17px; // Half the height of the important icon
   }
-  p {
+  strong {
     padding-left: (35 + 30)+px;
     margin-left: -$gutter-half;
   }


### PR DESCRIPTION
This now uses the strong element.

Before:
![before - typography gov uk elements](https://cloud.githubusercontent.com/assets/417754/11592150/b70fe1a0-9a94-11e5-84f2-e330ebdad309.png)


After:
![after - typography gov uk elements](https://cloud.githubusercontent.com/assets/417754/11592148/b3f4ecb8-9a94-11e5-950b-2334c9930d71.png)

