### PR TITLE
Fix: Hex value for error colour, displayed above $error-colour variable

### DIFF
--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -301,6 +301,7 @@ $palette: (
   }
 
   ul {
+    list-style-type: none;
     padding-bottom: $gutter-half;
     @include media(mobile) {
       min-height: 50px;

--- a/views/guide_colour.html
+++ b/views/guide_colour.html
@@ -176,7 +176,7 @@
     <div class="swatch-wrapper">
       <div class="swatch swatch-error"></div>
       <ul>
-        <li><b>#af1324</b></li>
+        <li><b>#B10E1E</b></li>
         <li>$error-colour</li>
       </ul>
     </div>


### PR DESCRIPTION
Thanks to @edwardhorsford for spotting this one.

Before:
![before - colour gov uk elements](https://cloud.githubusercontent.com/assets/417754/11592337/d51a6ca0-9a95-11e5-95b6-8c7c88323aa2.png)

After: 

![after - colour gov uk elements](https://cloud.githubusercontent.com/assets/417754/11592333/d00d6488-9a95-11e5-8067-9efc86c334ec.png)
