### PR TITLE
Fix missing list classes

### DIFF
--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -88,6 +88,12 @@
     color: $hm-government;
   }
 
+  // Remove default list style within examples
+  ol,
+  ul {
+    list-style-type: none;
+  }
+
   // Fix grid layout within example boxes for IE7 and below
   // where box-sizing isn't supported: http://caniuse.com/#search=box-sizing
   @mixin example-box-column($width) {

--- a/views/examples/example_icons.html
+++ b/views/examples/example_icons.html
@@ -32,7 +32,7 @@
 
     <div class="column-third">
       <h2 class="heading-medium">Step icons</h2>
-      <ol class="example-icon-list">
+      <ol class="list example-icon-list">
         <li><i class="icon icon-step-1"></i> <p>icon-step-1.png</p></li>
         <li><i class="icon icon-step-2"></i> <p>icon-step-2.png</p></li>
         <li><i class="icon icon-step-3"></i> <p>icon-step-3.png</p></li>
@@ -52,7 +52,7 @@
 
     <div class="column-third">
       <h2 class="heading-medium">Step circles</h2>
-      <ol class="example-icon-list">
+      <ol class="list example-icon-list">
         <li> <span class="circle circle-step">1</span>  <span class="circle circle-step-large">1</span>  </li>
         <li> <span class="circle circle-step">2</span>  <span class="circle circle-step-large">2</span>  </li>
         <li> <span class="circle circle-step">3</span>  <span class="circle circle-step-large">3</span>  </li>
@@ -72,7 +72,7 @@
 
     <div class="column-third">
       <h2 class="heading-medium">Icons</h2>
-      <ul class="example-icon-list">
+      <ul class="list example-icon-list">
         <li>
           <i class="icon icon-calendar"></i>
           <p>icon-calendar.png</p>
@@ -99,7 +99,7 @@
 
     <div class="column-third">
       <h2 class="heading-medium">White or semi-transparent icons</h2>
-      <ul class="example-icon-list example-icon-list-background">
+      <ul class="list example-icon-list example-icon-list-background">
         <li>
           <i class="icon icon-pointer"></i>
           <p>icon-pointer.png</p>

--- a/views/guide_icons_images.html
+++ b/views/guide_icons_images.html
@@ -77,7 +77,7 @@
   </div>
 
   <h3 class="heading-medium" id="examples">Examples</h3>
-  <ul>
+  <ul class="list list-bullet">
     <li><a href="{{site.baseurl}}/icons-images/example-icons/">Example page: Icons in the GOV.UK frontend toolkit</a></li>
   </ul>
 


### PR DESCRIPTION
Add missing `.list` class to lists.

`list-style-type: none`, should probably be a default, so the `.list` class isn't needed to apply this.

This relates to #134, these HTML element styles should be set in `_base.scss`.
I'll raise an issue.