### PR TITLE
Update the package name to use the govuk convention

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "govuk-elements",
-  "description": "GOVUK prototyping app in Express",
+  "name": "govuk_elements",
+  "description": "A style guide for GOV.UK services",
   "version": "0.0.1",
   "private": true,
   "engines": {


### PR DESCRIPTION
Both the govuk template and govuk frontend toolkit use underscores,
rather than hyphens in the name. Use an underscore here for consistency.

Also update the description.

Once this has been merged, the [govuk prototype kit PR](https://github.com/alphagov/govuk_prototype_kit/pull/103) to keep govuk elements up-to-date in the kit can be updated too.