### PR TITLE
Bump govuk frontend toolkit to 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "consolidate": "^0.10.0",
     "express": "^3.18.4",
     "express-writer": "0.0.4",
-    "govuk_frontend_toolkit": "^4.3.0",
+    "govuk_frontend_toolkit": "^4.5.0",
     "govuk_template_mustache": "^0.15.1",
     "grunt": "^0.4.2",
     "grunt-concurrent": "^0.4.3",


### PR DESCRIPTION
# 4.5.0

- Find and auto-start JavaScript modules from markup:
`data-module="module-name"`(PR #227)

# 4.4.0

- Add helpers partial for functions
- Add px to em function and documentation