### PR TITLE
Lists of links don't require a modifier class

### DIFF
--- a/views/examples/example_typography.html
+++ b/views/examples/example_typography.html
@@ -53,7 +53,7 @@
       <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
     </ol>
 
-    <ul class="list list-links">
+    <ul class="list">
       <li><a href="#">Related link</a></li>
       <li><a href="#">Related link</a></li>
       <li><a href="#">Related link</a></li>

--- a/views/snippets/typography_lists.html
+++ b/views/snippets/typography_lists.html
@@ -12,7 +12,7 @@
   <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
 </ol>
 
-<ul class="list list-links">
+<ul class="list">
   <li><a href="#">Related link</a></li>
   <li><a href="#">Related link</a></li>
   <li><a href="#">Related link</a></li>


### PR DESCRIPTION
They don’t have bullets, or numbers and use the default .list spacing.