### PR TITLE
Split deploy for staging and production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,19 @@ notifications:
   email: false
 
 deploy:
-  provider: heroku
-  app: govuk-elements-test
-  api_key:
-    secure: MSMzniJpxcjP1jbsjqaAR/bU/FtGRrYYrrIekzaXNXtUiwNOsnd2MMMiBiuwzRaqHlEZzUkh70jyCuAoztnMzr5vAlwy9IW5BnGhacbDZsyFZ8AS1Z0Glq0l7q0nh1akCEVYhdGyABrc2NMaAqtaVovEbAfZYCrSX8Uu0CRbPfY=
-  on: master
+  # Deploy master to staging (govuk-elements-test.herokuapp.com)
+  - provider: heroku
+    api_key:
+        secure: MSMzniJpxcjP1jbsjqaAR/bU/FtGRrYYrrIekzaXNXtUiwNOsnd2MMMiBiuwzRaqHlEZzUkh70jyCuAoztnMzr5vAlwy9IW5BnGhacbDZsyFZ8AS1Z0Glq0l7q0nh1akCEVYhdGyABrc2NMaAqtaVovEbAfZYCrSX8Uu0CRbPfY=
+    app: govuk-elements-test
+    on: master
+  # Deploy tagged build to production (govuk-elements.herokuapp.com)
+  - provider: heroku
+    api_key:
+        secure: MSMzniJpxcjP1jbsjqaAR/bU/FtGRrYYrrIekzaXNXtUiwNOsnd2MMMiBiuwzRaqHlEZzUkh70jyCuAoztnMzr5vAlwy9IW5BnGhacbDZsyFZ8AS1Z0Glq0l7q0nh1akCEVYhdGyABrc2NMaAqtaVovEbAfZYCrSX8Uu0CRbPfY=
+    app: govuk-elements
+    on:
+      all_branches: true
+      tags: true
 
 sudo: false


### PR DESCRIPTION
This PR modifies the existing deployment task to also add deployment to production. 

The master branch is deployed to a test Heroku app govuk-elements-test.herokuapp.com.

The most recent tagged build is deployed to production govuk-elements.herokuapp.com.

Deploying to Heroku is currently a manual process, this helps to ensure GOV.UK elements is kept up-to-date. 