### PR TITLE
Use locally installed grunt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ before_install:
 install:
   - npm install
 script:
-  - grunt test
+  # Reference the locally-installed version of Grunt
+  - ./node_modules/grunt-cli/bin/grunt test
 
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "govuk_frontend_toolkit": "^4.5.0",
     "govuk_template_mustache": "^0.15.1",
     "grunt": "^0.4.2",
+    "grunt-cli": "0.1.13",
     "grunt-concurrent": "^0.4.3",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-copy": "^0.5.0",


### PR DESCRIPTION
Reference the locally-installed version of Grunt for the 'test' task to check that the app runs.

This updates the govuk elements Travis file to match the [govuk prototype kit](https://github.com/alphagov/govuk_prototype_kit/pull/112).