### PR TITLE
Update package json to publish govuk-elements-sass

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+public/sass/main-ie6.scss
+public/sass/main-ie7.scss
+public/sass/main-ie8.scss
+public/sass/main.scss
+public/sass/elements-page-ie6.scss
+public/sass/elements-page-ie7.scss
+public/sass/elements-page-ie8.scss
+public/sass/elements-page.scss
+public/sass/prism.scss

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.1
+  - 4.0
 before_install:
   - npm install -g grunt-cli
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,26 @@ notifications:
   email: false
 
 deploy:
+  matrix:
   # Deploy master to staging (govuk-elements-test.herokuapp.com)
   - provider: heroku
     api_key:
-        secure: MSMzniJpxcjP1jbsjqaAR/bU/FtGRrYYrrIekzaXNXtUiwNOsnd2MMMiBiuwzRaqHlEZzUkh70jyCuAoztnMzr5vAlwy9IW5BnGhacbDZsyFZ8AS1Z0Glq0l7q0nh1akCEVYhdGyABrc2NMaAqtaVovEbAfZYCrSX8Uu0CRbPfY=
+      secure: MSMzniJpxcjP1jbsjqaAR/bU/FtGRrYYrrIekzaXNXtUiwNOsnd2MMMiBiuwzRaqHlEZzUkh70jyCuAoztnMzr5vAlwy9IW5BnGhacbDZsyFZ8AS1Z0Glq0l7q0nh1akCEVYhdGyABrc2NMaAqtaVovEbAfZYCrSX8Uu0CRbPfY=
     app: govuk-elements-test
     on: master
   # Deploy tagged build to production (govuk-elements.herokuapp.com)
   - provider: heroku
     api_key:
-        secure: MSMzniJpxcjP1jbsjqaAR/bU/FtGRrYYrrIekzaXNXtUiwNOsnd2MMMiBiuwzRaqHlEZzUkh70jyCuAoztnMzr5vAlwy9IW5BnGhacbDZsyFZ8AS1Z0Glq0l7q0nh1akCEVYhdGyABrc2NMaAqtaVovEbAfZYCrSX8Uu0CRbPfY=
+      secure: MSMzniJpxcjP1jbsjqaAR/bU/FtGRrYYrrIekzaXNXtUiwNOsnd2MMMiBiuwzRaqHlEZzUkh70jyCuAoztnMzr5vAlwy9IW5BnGhacbDZsyFZ8AS1Z0Glq0l7q0nh1akCEVYhdGyABrc2NMaAqtaVovEbAfZYCrSX8Uu0CRbPfY=
     app: govuk-elements
+    on:
+      all_branches: true
+      tags: true
+  # Release tagged commits to npm
+  - provider: npm
+    api_key:
+      secure: VAHPK3W0YVWqx03j659FbKjvEwd+UIDfb1x55to9u+PzyVqQp1CXalsYuKQSavxqInaV3gzNJpbANo6SIXlpAUxZPChiTk0rJwUhz7u1fRY0Lshb+aDOMnXSfjSqiIGThNRpjYdxBiJsnrYP1T6unHuo2A1K8mXjwdFtxhadh+w=
+    email: gemma.leigh@digital.cabinet-office.gov.uk
     on:
       all_branches: true
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ deploy:
   - provider: npm
     api_key:
       secure: VAHPK3W0YVWqx03j659FbKjvEwd+UIDfb1x55to9u+PzyVqQp1CXalsYuKQSavxqInaV3gzNJpbANo6SIXlpAUxZPChiTk0rJwUhz7u1fRY0Lshb+aDOMnXSfjSqiIGThNRpjYdxBiJsnrYP1T6unHuo2A1K8mXjwdFtxhadh+w=
-    email: gemma.leigh@digital.cabinet-office.gov.uk
+    email: govuk-dev@digital.cabinet-office.gov.uk
     on:
       all_branches: true
       tags: true

--- a/README.md
+++ b/README.md
@@ -3,12 +3,18 @@ GOV.UK elements
 
 ## What is it?
 
-GOV.UK elements is two things:
+GOV.UK elements is three things:
 
 1. an online design guide, explaining how to make your service look consistent with the rest of GOV.UK
 2. an example of how to use the code in the [GOV.UK template](https://github.com/alphagov/govuk_template) and the [GOV.UK front end toolkit](https://github.com/alphagov/govuk_frontend_toolkit)
+3. an npm package, only including the Sass files
 
 The guide can be seen here: http://govuk-elements.herokuapp.com/.
+This is the most recent tagged version of govuk elements.
+
+There is also a staging app, to preview what is currently in master:
+http://govuk-elements-test.herokuapp.com/
+
 
 ## How can it be used?
 
@@ -83,6 +89,51 @@ Take a look at `/public/sass/_govuk-elements.scss` to see how the Sass files wit
 
 
 Ignore the `/public/sass/elements-page.scss` files, these exist to style the page furniture of GOV.UK elements (for example, the HTML example boxes and colour swatches).
+
+## Using the govuk-elements-sass package
+
+If you would like to import the govuk elements Sass files into your project, you can do so using:
+
+    `npm install govuk-elements-sass`
+
+This will install the files within `public/sass` to `node_modules/govuk-elements-sass`.
+
+These Sass files have the variables, mixins and functions defined by the govuk frontend toolkit as a dependency.
+
+These files are listed at the top of the `_govuk_elements.scss` partial, shown below:
+
+    // GOV.UK front end toolkit
+    // Sass variables, mixins and functions
+    // https://github.com/alphagov/govuk_frontend_toolkit/tree/master/stylesheets
+
+    // Settings (variables)
+    @import "colours";                                // Colour variables
+    @import "font_stack";                             // Font family variables
+    @import "measurements";                           // Widths and gutter variables
+
+    // Mixins
+    @import "conditionals";                           // Media query mixin
+    @import "device-pixels";                          // Retina image mixin
+    @import "grid_layout";                            // Basic grid layout mixin
+    @import "typography";                             // Core bold and heading mixins, also external links
+    @import "shims";                                  // Inline block mixin, clearfix placeholder
+
+    // Mixins to generate components (chunks of UI)
+    @import "design-patterns/alpha-beta";
+    @import "design-patterns/buttons";
+
+    // Functions
+    // @import "url-helpers";                         // Function to output image-url, or prefixed path (Rails and Compass only)
+
+
+These files must be imported before the govuk elements Sass files.
+
+Either copy these files your Sass directory, or configure the `includeFiles` path if you’re using a task runner like Grunt.
+
+If you're not using the govuk template, you'll also need to uncomment the base partial in `_govuk_elements.scss`, or create your own.
+
+    // @import "elements/base";                       // HTML elements, set by the GOV.UK template
+
 
 ## Running this site locally
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "GOVUK elements Sass files",
   "repository": "alphagov/govuk_elements",
-  "private": true,
   "engines": {
     "node": "0.10.x"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "engines": {
     "node": "0.10.x"
   },
+  "files": [
+    "public/sass/"
+  ],
   "dependencies": {
     "govuk_frontend_toolkit": "^4.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-elements-sass",
+  "version": "1.0.0",
   "description": "GOVUK elements Sass files",
-  "version": "1.1.0",
   "repository": "alphagov/govuk_elements",
   "private": true,
   "engines": {
@@ -34,5 +34,6 @@
   },
   "scripts": {
     "test": "./node_modules/grunt-cli/bin/grunt test"
-  }
+  },
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,19 @@
 {
-  "name": "govuk-elements",
-  "description": "GOVUK prototyping app in Express",
-  "version": "0.0.1",
+  "name": "govuk-elements-sass",
+  "description": "GOVUK elements Sass files",
+  "version": "1.1.0",
+  "repository": "alphagov/govuk_elements",
   "private": true,
   "engines": {
     "node": "0.10.x"
   },
   "dependencies": {
+    "govuk_frontend_toolkit": "^4.6.0"
+  },
+  "devDependencies": {
     "consolidate": "^0.10.0",
     "express": "^3.18.4",
     "express-writer": "0.0.4",
-    "govuk_frontend_toolkit": "^4.6.0",
     "govuk_template_mustache": "^0.16.1",
     "grunt": "^0.4.2",
     "grunt-cli": "0.1.13",

--- a/package.json
+++ b/package.json
@@ -35,5 +35,7 @@
   "scripts": {
     "test": "./node_modules/grunt-cli/bin/grunt test"
   },
-  "license": "MIT"
+  "bugs": {
+    "url": "https://github.com/alphagov/govuk_elements/issues"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "GOVUK elements Sass files",
   "repository": "alphagov/govuk_elements",
   "engines": {
-    "node": "0.10.x"
+    "node": "4.0"
   },
   "files": [
     "public/sass/"

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "hogan.js": "3.0.2",
     "node-sass": "^3.2.0",
     "readdir": "0.0.6"
+  },
+  "scripts": {
+    "test": "./node_modules/grunt-cli/bin/grunt test"
   }
 }


### PR DESCRIPTION
One solution, to resolve #155 - would be to create a govuk_elements_sass_npm repo [as already exists for the govuk frontend toolkit](https://github.com/alphagov/govuk_frontend_toolkit_npm), with only the Sass files whitelisted, as below.

Here, updating `package.json` would make it possible to request only the Sass files, without the rest of the govuk elements application.

These changes make the files available within `public/sass`, excluding those in `.npmignore`.

