### PR TITLE
Remove this style for the spacing under related links

### DIFF
--- a/public/sass/elements/_lists.scss
+++ b/public/sass/elements/_lists.scss
@@ -31,9 +31,3 @@ ol {
     padding-left: 28px;
   }
 }
-
-// Lists of related links
-.list-links li {
-  margin-bottom: 10px;
-}
-


### PR DESCRIPTION
These styles will be updated to match the govuk related content
component, remove the .list-links classname. [This has already been
removed from the lists snippet](https://github.com/alphagov/govuk_elements/commit/f3907a5038a845847b6f08a451e26e1cca33bc42) and was left here by mistake.