### PR TITLE
Remove matrix, this is causing deploy to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ notifications:
   email: false
 
 deploy:
-  matrix:
   # Deploy master to staging (govuk-elements-test.herokuapp.com)
   - provider: heroku
     api_key:


### PR DESCRIPTION
When validated using the Travis command line tool, the following errors
occur:

Warnings for .travis.yml:
[x] value for deploy section is empty, dropping
[x] in deploy section: missing key provider

Removing the matrix field fixes this.