### PR TITLE
Make error messages plural rather than using (s)

### DIFF
--- a/views/snippets/form_error_multiple.html
+++ b/views/snippets/form_error_multiple.html
@@ -6,7 +6,7 @@
   </h1>
 
   <p>
-    Optional description of the error(s) and how to correct them
+    Optional description of the errors and how to correct them
   </p>
 
   <ul class="error-summary-list">

--- a/views/snippets/form_error_multiple_show_errors.html
+++ b/views/snippets/form_error_multiple_show_errors.html
@@ -5,7 +5,7 @@
   </h1>
 
   <p>
-    Optional description of the error(s) and how to correct them
+    Optional description of the errors and how to correct them
   </p>
 
   <ul class="error-summary-list">

--- a/views/snippets/form_error_radio.html
+++ b/views/snippets/form_error_radio.html
@@ -6,7 +6,7 @@
   </h1>
 
   <p>
-    Optional description of the error(s) and how to correct them
+    Optional description of the errors and how to correct them
   </p>
 
   <ul class="error-summary-list">

--- a/views/snippets/form_error_radio_show_errors.html
+++ b/views/snippets/form_error_radio_show_errors.html
@@ -5,7 +5,7 @@
   </h1>
 
   <p>
-    Optional description of the error(s) and how to correct them
+    Optional description of the errors and how to correct them
   </p>
 
   <ul class="error-summary-list">


### PR DESCRIPTION
We avoid using `(s)` in content on GOV.UK - the preference is to use the plural form where it's ambiguous.

I know these are just examples, but would be good to match content style.