### PR TITLE
Fix the breadcrumbs for Icons and images

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -75,8 +75,8 @@ module.exports = {
 
     // Example page: Icons
     app.get('/icons-images/example-icons', function (req, res) {
-      var section = "Icons and images";
-      var section_name = "Icons";
+      var section = "icons-images";
+      var section_name = "Icons and images";
       var page_name = "Example: Icons";
       res.render('examples/example_icons', {'assetPath' : assetPath, 'section': section, 'section_name' : section_name, 'page_name' : page_name });
     });


### PR DESCRIPTION
Change the section to `icons-images`, so the middle breadcrumb links back to the “Icons and images” section.