### PR TITLE
Fix package json as npmignore isnt working

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,5 @@
-public/sass/main-ie6.scss
-public/sass/main-ie7.scss
-public/sass/main-ie8.scss
-public/sass/main.scss
-public/sass/elements-page-ie6.scss
-public/sass/elements-page-ie7.scss
-public/sass/elements-page-ie8.scss
-public/sass/elements-page.scss
-public/sass/prism.scss
+/*
+/public/*
+/public/sass/*
+!/public/sass/_govuk-elements.scss
+!/public/sass/elements

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "engines": {
     "node": "4.0"
   },
-  "files": [
-    "public/sass/"
-  ],
   "dependencies": {
     "govuk_frontend_toolkit": "^4.6.0"
   },


### PR DESCRIPTION
The current [govuk-elements-sass module](https://registry.npmjs.org/govuk-elements-sass) contains all files in `/public/sass/`, including those which are set to be ignored by the `.npmignore` file.

Rather than list files to be ignored within `/public/sass/` by setting `files` in package.json, list all files in the repository to be ignored in the `.npmignore` file and remove `files` from package.json.

Related: https://github.com/npm/npm/issues/7030
Testing this using npm pack works as expected.
