### PR TITLE
Bump the govuk frontend toolkit to 4.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "4.0"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^4.6.0"
+    "govuk_frontend_toolkit": "^4.6.1"
   },
   "devDependencies": {
     "consolidate": "^0.10.0",

--- a/views/guide_colour.html
+++ b/views/guide_colour.html
@@ -78,7 +78,7 @@
 
       <div class="swatch swatch-link-colour-hover"></div>
       <ul>
-        <li><b>#2e8aca</b></li>
+        <li><b>#2b8cc4</b></li>
         <li>$link-hover-colour</li>
       </ul>
 


### PR DESCRIPTION
The latest version updates the _colours.scss partial, so
$link-hover-colour is now $light-blue.

Update the HEX value in the GOV.UK elements colour swatch for
$link-hover-colour to reflect this.

This is the corresponding PR for elements, @robinwhittleton.