### PR TITLE
Fix warning for npm engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "GOVUK elements Sass files",
   "repository": "alphagov/govuk_elements",
   "engines": {
-    "node": "4.0"
+    "node": ">=4.0.0"
   },
   "dependencies": {
     "govuk_frontend_toolkit": "^4.6.0"


### PR DESCRIPTION
When `govuk-elements-sass` is installed, a warning is shown for the engine -
setting this to be greater than or equal to 4.0.0 fixes this.

@edwardhorsford, let me know if this fixes #165.