### PR TITLE
Add missing 2/3 width grid wrappers to example pages

### DIFF
--- a/views/examples/example_date.html
+++ b/views/examples/example_date.html
@@ -7,13 +7,18 @@
 
   {{>breadcrumb}}
 
-  <h1 class="heading-xlarge">
-    <span class="heading-secondary">Form elements</span>
-    Example: Date
-  </h1>
+  <div class="grid-row">
+    <div class="column-two-thirds">
 
-  <!-- Date of birth -->
-  {{> form_date }}
+      <h1 class="heading-xlarge">
+        <span class="heading-secondary">Form elements</span>
+        Example: Date
+      </h1>
+      <!-- Date of birth -->
+      {{> form_date }}
+
+    </div>
+  </div>
 
 </main><!-- /#content -->
 {{/content}}

--- a/views/examples/example_details_summary.html
+++ b/views/examples/example_details_summary.html
@@ -7,16 +7,16 @@
 
   {{>breadcrumb}}
 
-  <h1 class="heading-xlarge">
-    <span class="heading-secondary">Typography</span>
-    Example: Details summary
-  </h1>
-
   <div class="grid-row">
     <div class="column-two-thirds">
 
+      <h1 class="heading-xlarge">
+        <span class="heading-secondary">Typography</span>
+        Example: Details summary
+      </h1>
+
       <p>
-      This example page demonstrates conditionally revealing information, using the HTML5 <code class="code">details</code> and <code class="code">summary</code> elements, <a href="http://html5doctor.com/the-details-and-summary-elements/" rel="external">they are described here</a>.
+        This example page demonstrates conditionally revealing information, using the HTML5 <code class="code">details</code> and <code class="code">summary</code> elements, <a href="http://html5doctor.com/the-details-and-summary-elements/" rel="external">they are described here</a>.
       </p>
 
       <p>

--- a/views/examples/example_form_elements.html
+++ b/views/examples/example_form_elements.html
@@ -7,79 +7,84 @@
 
   {{>breadcrumb}}
 
-  <form action="/" method="post" class="form">
+  <div class="grid-row">
+    <div class="column-two-thirds">
 
-    <h1 class="heading-large">
-      <span class="heading-secondary">Form elements</span>
-      Example: Form elements
-    </h1>
+      <form action="/" method="post" class="form">
 
-    <!-- Input type="text" -->
-    <div class="form-group">
-      <label class="form-label" for="input-text">Single line text fields</label>
-      <input class="form-control" id="input-text" type="text">
+        <h1 class="heading-large">
+          <span class="heading-secondary">Form elements</span>
+          Example: Form elements
+        </h1>
+
+        <!-- Input type="text" -->
+        <div class="form-group">
+          <label class="form-label" for="input-text">Single line text fields</label>
+          <input class="form-control" id="input-text" type="text">
+        </div>
+
+        <!-- Textarea -->
+        <div class="form-group">
+          <label class="form-label" for="textarea">Multi-line text fields</label>
+          <textarea class="form-control" id="textarea" cols="30" rows="10"></textarea>
+        </div>
+
+        <!-- Select box -->
+        <div class="form-group">
+          <label class="form-label" for="select-box">Drop down content</label>
+          <select class="form-control" id="select-box">
+            <option>Banana</option>
+            <option>Cherry</option>
+            <option>Lemon</option>
+          </select>
+        </div>
+
+        <!-- Check box -->
+        <div class="form-group">
+          <label class="form-checkbox" for="checkbox-telephone-number" >
+            <input id="checkbox-telephone-number" type="checkbox" value="checkbox-telephone-number">
+            Native check box
+          </label>
+        </div>
+
+        <!-- Chunky check box -->
+
+        <div class="form-group">
+          <label class="block-label" for="checkbox-1">
+            <input id="checkbox-1" type="checkbox" value="waste-animal">
+            Checkbox
+          </label>
+          <label class="block-label" for="checkbox-2">
+            <input id="checkbox-2" type="checkbox" value="waste-mines">
+            Checkbox
+          </label>
+          <label class="block-label" for="checkbox-3">
+            <input id="checkbox-3" type="checkbox" value="farm-agricultural">
+            Checkbox
+          </label>
+        </div>
+
+        <!-- Radio button -->
+
+        <div class="form-group">
+          <label class="block-label" for="radio-1">
+            <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">
+            Radio
+          </label>
+          <label class="block-label" for="radio-2">
+            <input id="radio-2" type="radio" name="radio-group" value="Isle of Man or the Channel Islands">
+            Radio
+          </label>
+          <label class="block-label" for="radio-3">
+            <input id="radio-3" type="radio" name="radio-group" value="I am a British citizen living abroad">
+            Radio
+          </label>
+        </div>
+
+      </form>
+
     </div>
-
-    <!-- Textarea -->
-    <div class="form-group">
-      <label class="form-label" for="textarea">Multi-line text fields</label>
-      <textarea class="form-control" id="textarea" cols="30" rows="10"></textarea>
-    </div>
-
-    <!-- Select box -->
-    <div class="form-group">
-      <label class="form-label" for="select-box">Drop down content</label>
-      <select class="form-control" id="select-box">
-        <option>Banana</option>
-        <option>Cherry</option>
-        <option>Lemon</option>
-      </select>
-    </div>
-
-    <!-- Check box -->
-    <div class="form-group">
-      <label class="form-checkbox" for="checkbox-telephone-number" >
-        <input id="checkbox-telephone-number" type="checkbox" value="checkbox-telephone-number">
-        Native check box
-      </label>
-    </div>
-
-    <!-- Chunky check box -->
-
-    <div class="form-group">
-      <label class="block-label" for="checkbox-1">
-        <input id="checkbox-1" type="checkbox" value="waste-animal">
-        Checkbox
-      </label>
-      <label class="block-label" for="checkbox-2">
-        <input id="checkbox-2" type="checkbox" value="waste-mines">
-        Checkbox
-      </label>
-      <label class="block-label" for="checkbox-3">
-        <input id="checkbox-3" type="checkbox" value="farm-agricultural">
-        Checkbox
-      </label>
-    </div>
-
-    <!-- Radio button -->
-
-    <div class="form-group">
-      <label class="block-label" for="radio-1">
-        <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">
-        Radio
-      </label>
-      <label class="block-label" for="radio-2">
-        <input id="radio-2" type="radio" name="radio-group" value="Isle of Man or the Channel Islands">
-        Radio
-      </label>
-      <label class="block-label" for="radio-3">
-        <input id="radio-3" type="radio" name="radio-group" value="I am a British citizen living abroad">
-        Radio
-      </label>
-    </div>
-
-  </form>
-
+  </div>
 </main><!-- / #content -->
 {{/content}}
 

--- a/views/examples/example_form_validation_multiple_questions.html
+++ b/views/examples/example_form_validation_multiple_questions.html
@@ -7,58 +7,63 @@
 
   {{>breadcrumb}}
 
-  <form method="post" action="/errors/example-form-validation-multiple-questions">
-    {{> form_error_multiple }}
-  </form>
+  <div class="grid-row">
+    <div class="column-two-thirds">
 
-  <h2 class="heading-medium implementation-advice">Implementation advice</h2>
-  <p class="lead-in">When an error occurs:</p>
-  <ul class="list list-bullet text">
-    <li>
-      add a 5px red left border to the field with the error
-    </li>
-    <li>
-      show an error summary at the top of the page
-    </li>
-    <li>
-      move keyboard focus to the start of the summary
-      <span class="panel panel-border-narrow">
-        to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
-      </span>
-    </li>
-    <li>
-      indicate to screenreaders that the summary represents a collection of information
-      <span class="panel panel-border-narrow">
-        add the ARIA <code>role="group"</code> to the containing <code>div</code>
-      </span>
-    </li>
-    <li>
-      use a heading at the top of the summary
-    </li>
-    <li>
-      associate the heading with the summary box
-      <span class="panel panel-border-narrow">
-        use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
-      </span>
-    </li>
-    <li>
-      link from the error list in the summary to the fields with errors
-    </li>
-    <li>
-      show an error message before each field with an error
-    </li>
-    <li>
-      associate each error message with the corresponding field
-      <span class="panel panel-border-narrow">
-         add an ID to each error message and associate this with the field using <code>aria-describedby</code>
-      </span>
-    </li>
-  </ul>
+      <form method="post" action="/errors/example-form-validation-multiple-questions">
+        {{> form_error_multiple }}
+      </form>
 
-  <p class="text">
-    Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
-  </p>
+      <h2 class="heading-medium implementation-advice">Implementation advice</h2>
+      <p class="lead-in">When an error occurs:</p>
+      <ul class="list list-bullet text">
+        <li>
+          add a 5px red left border to the field with the error
+        </li>
+        <li>
+          show an error summary at the top of the page
+        </li>
+        <li>
+          move keyboard focus to the start of the summary
+          <span class="panel panel-border-narrow">
+            to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
+          </span>
+        </li>
+        <li>
+          indicate to screenreaders that the summary represents a collection of information
+          <span class="panel panel-border-narrow">
+            add the ARIA <code>role="group"</code> to the containing <code>div</code>
+          </span>
+        </li>
+        <li>
+          use a heading at the top of the summary
+        </li>
+        <li>
+          associate the heading with the summary box
+          <span class="panel panel-border-narrow">
+            use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
+          </span>
+        </li>
+        <li>
+          link from the error list in the summary to the fields with errors
+        </li>
+        <li>
+          show an error message before each field with an error
+        </li>
+        <li>
+          associate each error message with the corresponding field
+          <span class="panel panel-border-narrow">
+             add an ID to each error message and associate this with the field using <code>aria-describedby</code>
+          </span>
+        </li>
+      </ul>
 
+      <p class="text">
+        Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
+      </p>
+
+    </div>
+  </div>
 </main>
 {{/content}}
 

--- a/views/examples/example_form_validation_single_question_radio.html
+++ b/views/examples/example_form_validation_single_question_radio.html
@@ -7,64 +7,69 @@
 
   {{>breadcrumb}}
 
-  <form method="post" action="/errors/example-form-validation-single-question-radio">
-    {{> form_error_radio }}
-  </form>
+  <div class="grid-row">
+    <div class="column-two-thirds">
 
-  <h2 class="heading-medium implementation-advice">Implementation advice</h2>
-  <p class="lead-in">When an error occurs:</p>
-  <ul class="list list-bullet text">
-    <li>
-      add a 5px red left border to the field with the error
-    </li>
-    <li>
-      the error message be red and bold and appear after the question
-    </li>
-    <li>
-      the error message must sit inside the <code>&lt;legend&gt;</code>
-    </li>
-    <li>
-      show an error summary at the top of the page
-    </li>
-    <li>
-      move keyboard focus to the start of the summary
-      <span class="panel panel-border-narrow">
-        to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
-      </span>
-    </li>
-    <li>
-      indicate to screenreaders that the summary represents a collection of information
-      <span class="panel panel-border-narrow">
-        add the ARIA <code>role="group"</code> to the containing <code>div</code>
-      </span>
-    </li>
-    <li>
-      use a heading at the top of the summary
-    </li>
-    <li>
-      associate the heading with the summary box
-      <span class="panel panel-border-narrow">
-        use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
-      </span>
-    </li>
-    <li>
-      link from the error list in the summary to the fields with errors
-    </li>
-    <li>
-      show an error message before each field with an error
-    </li>
-    <li>
-      associate each error message with the corresponding field
-      <span class="panel panel-border-narrow">
-         add an ID to each error message and associate this with the field using <code>aria-describedby</code>
-      </span>
-    </li>
-  </ul>
+      <form method="post" action="/errors/example-form-validation-single-question-radio">
+        {{> form_error_radio }}
+      </form>
 
-  <p class="text">
-    Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
-  </p>
+      <h2 class="heading-medium implementation-advice">Implementation advice</h2>
+      <p class="lead-in">When an error occurs:</p>
+      <ul class="list list-bullet text">
+        <li>
+          add a 5px red left border to the field with the error
+        </li>
+        <li>
+          the error message be red and bold and appear after the question
+        </li>
+        <li>
+          the error message must sit inside the <code>&lt;legend&gt;</code>
+        </li>
+        <li>
+          show an error summary at the top of the page
+        </li>
+        <li>
+          move keyboard focus to the start of the summary
+          <span class="panel panel-border-narrow">
+            to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
+          </span>
+        </li>
+        <li>
+          indicate to screenreaders that the summary represents a collection of information
+          <span class="panel panel-border-narrow">
+            add the ARIA <code>role="group"</code> to the containing <code>div</code>
+          </span>
+        </li>
+        <li>
+          use a heading at the top of the summary
+        </li>
+        <li>
+          associate the heading with the summary box
+          <span class="panel panel-border-narrow">
+            use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
+          </span>
+        </li>
+        <li>
+          link from the error list in the summary to the fields with errors
+        </li>
+        <li>
+          show an error message before each field with an error
+        </li>
+        <li>
+          associate each error message with the corresponding field
+          <span class="panel panel-border-narrow">
+             add an ID to each error message and associate this with the field using <code>aria-describedby</code>
+          </span>
+        </li>
+      </ul>
 
+      <p class="text">
+        Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
+      </p>
+
+    </div>
+  </div>
 </main>
 {{/content}}
 

--- a/views/examples/example_grid_layout.html
+++ b/views/examples/example_grid_layout.html
@@ -7,14 +7,20 @@
 
   {{>breadcrumb}}
 
-  <h1 class="heading-xlarge">
-    <span class="heading-secondary">GOV.UK elements</span>
-    Example: Grid layout
-  </h1>
+  <div class="grid-row">
+    <div class="column-two-thirds">
 
-  <p>
-    <a href="#" class="js-highlight-grid">Toggle background colours</a> to see the size of each of the grid columns.
-  </p>
+      <h1 class="heading-xlarge">
+        <span class="heading-secondary">GOV.UK elements</span>
+        Example: Grid layout
+      </h1>
+
+      <p>
+        <a href="#" class="js-highlight-grid">Toggle background colours</a> to see the size of each of the grid columns.
+      </p>
+
+    </div>
+  </div>
 
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/views/examples/example_typography.html
+++ b/views/examples/example_typography.html
@@ -7,67 +7,74 @@
 
   {{>breadcrumb}}
 
-  <h1 class="heading-xlarge">
-    <span class="heading-secondary">Typography</span>
-    Example: Typography
-  </h1>
+  <div class="grid-row">
+    <div class="column-two-thirds">
 
-  <div class="text">
+      <h1 class="heading-xlarge">
+        <span class="heading-secondary">Typography</span>
+        Example: Typography
+      </h1>
 
-    <h1 class="heading-xlarge">
-      <span class="heading-secondary">A 27px section heading</span>
-      A 48px heading
-    </h1>
+      <h1 class="heading-xlarge">
+        <span class="heading-secondary">A 27px section heading</span>
+        A 48px heading
+      </h1>
 
-    <p class="lede">
-      This is an intro paragraph at 24px. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.
-    </p>
+      <p class="lede">
+        This is an intro paragraph at 24px. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.
+      </p>
 
-    <h2 class="heading-large">A 36px heading</h2>
+      <h2 class="heading-large">A 36px heading</h2>
 
-    <p>
-      This is a body copy paragraph at 19px. Donec id elit non mi porta gravida at eget metus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec sed odio dui. Aenean lacinia bibendum nulla sed consectetur. Aenean lacinia bibendum nulla sed consectetur. Sed posuere consectetur est at lobortis.
-    </p>
+      <p>
+        This is a body copy paragraph at 19px. Donec id elit non mi porta gravida at eget metus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec sed odio dui. Aenean lacinia bibendum nulla sed consectetur. Aenean lacinia bibendum nulla sed consectetur. Sed posuere consectetur est at lobortis.
+      </p>
 
-    <h3 class="heading-medium">A 24px heading</h3>
+      <h3 class="heading-medium">A 24px heading</h3>
 
-    <p>
-    Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum. Vestibulum id ligula porta felis euismod semper. Donec id elit non mi porta gravida at eget metus.
-    </p>
+      <p>
+        Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum. Vestibulum id ligula porta felis euismod semper. Donec id elit non mi porta gravida at eget metus.
+      </p>
 
-    <h4 class="heading-small">A 19px heading</h4>
+      <h4 class="heading-small">A 19px heading</h4>
 
-    <p>Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.</p>
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.
+      </p>
 
-    <ul class="list list-bullet">
-      <li>here is a bulleted list</li>
-      <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
-      <li>vestibulum id ligula porta felis euismod semper</li>
-      <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
-    </ul>
+      <ul class="list list-bullet">
+        <li>here is a bulleted list</li>
+        <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
+        <li>vestibulum id ligula porta felis euismod semper</li>
+        <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
+      </ul>
 
-    <ol class="list list-number">
-      <li>here is a numbered list</li>
-      <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
-      <li>vestibulum id ligula porta felis euismod semper</li>
-      <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
-    </ol>
+      <ol class="list list-number">
+        <li>here is a numbered list</li>
+        <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
+        <li>vestibulum id ligula porta felis euismod semper</li>
+        <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
+      </ol>
 
-    <ul class="list">
-      <li><a href="#">Related link</a></li>
-      <li><a href="#">Related link</a></li>
-      <li><a href="#">Related link</a></li>
-      <li><a href="#" class="bold-xsmall">More</a></li>
-    </ul>
+      <ul class="list">
+        <li><a href="#">Related link</a></li>
+        <li><a href="#">Related link</a></li>
+        <li><a href="#">Related link</a></li>
+        <li><a href="#" class="bold-xsmall">More</a></li>
+      </ul>
 
-    <p>Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.</p>
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.
+      </p>
 
-    <hr>
+      <hr>
 
-    <p>Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.</p>
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.
+      </p>
 
+    </div>
   </div>
-
 </main><!-- / #content -->
 {{/content}}
 


### PR DESCRIPTION
All main content should sit in a 2/3 column grid.
Add `.grid-row` and `.column-two-thirds` divs where they are missing.

This is most noticeable on the Errors and validation pages - the error message summary box should also be constrained by a wrapper which is 2/3 of the page width.

Screenshot before:

![before - example form validation errors gov uk elements](https://cloud.githubusercontent.com/assets/417754/12842824/1cb1457e-cbed-11e5-8bda-b07ea53f5801.png)

Screenshots after:

![example form validation errors gov uk elements](https://cloud.githubusercontent.com/assets/417754/12842787/da24b308-cbec-11e5-89a7-723bd0ffb9db.png)

![2 example form validation errors gov uk elements](https://cloud.githubusercontent.com/assets/417754/12842784/d2e33ad8-cbec-11e5-851d-cf44e17654fa.png)


