### PR TITLE
Update max for date pattern to include this year

### DIFF
--- a/views/snippets/form_date.html
+++ b/views/snippets/form_date.html
@@ -21,7 +21,7 @@
 
       <div class="form-group form-group-year">
         <label for="dob-year">Year</label>
-        <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2014">
+        <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
       </div>
     </div>
 


### PR DESCRIPTION
This should be `2016`, and fixes #174.

cc. @robinwhittleton, @joelanman, @henryhadlow.