### PR TITLE
Copy base styles set by govuk template

### DIFF
--- a/public/sass/_govuk-elements.scss
+++ b/public/sass/_govuk-elements.scss
@@ -32,7 +32,7 @@
 // Base (unclassed HTML elements)
 // These are predefined by govuk_template
 // If you're not using govuk_template, uncomment the line below.
-// @import "elements/base";                       // HTML elements, set by the GOV.UK template
+@import "elements/govuk-template-base";           // Base styles set by GOV.UK template
 
 // Objects (unstyled design patterns)
 @import "elements/layout";                        // Main content container. Grid layout - rows and column widths

--- a/public/sass/elements/_govuk-template-base.scss
+++ b/public/sass/elements/_govuk-template-base.scss
@@ -1,7 +1,22 @@
 // https://github.com/alphagov/govuk_template/blob/master/source/assets/stylesheets/_basic.scss
 
 // basic styles for HTML5 and other elements
-html, body, div, h1, h2, h3, h4, h5, h6, article, aside, footer, header, hgroup, nav, section {
+html,
+body,
+div,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+article,
+aside,
+footer,
+header,
+hgroup,
+nav,
+section {
   margin: 0;
   padding: 0;
   vertical-align: baseline;
@@ -12,7 +27,6 @@ main {
   display: block;
 }
 
-// (Normalize.css)
 // 1. Corrects text resizing oddly in IE6/7 when body font-size is set using em units
 //    http://clagnut.com/blog/348/#c790
 //    note - font-size reduced to 62.5% to allow simple rem/px font-sizing and fallback
@@ -26,13 +40,13 @@ main {
 html {
   font-size: 62.5%; // 1
   overflow-y: scroll; // 2
-  -webkit-tap-highlight-color: rgba(0,0,0,0); // 3
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); // 3
   -webkit-text-size-adjust: 100%; // 4
   -ms-text-size-adjust: 100%; // 4
   -ms-overflow-style: scrollbar; // 5
+  background-color: $white;
 }
 
-// (Normalize.css)
 // 1. Font-size increased to compensate for change to html element font-size in
 //    order to support beta typography which was set in ems
 //    (62.5% * 160% = 100%)
@@ -41,9 +55,7 @@ html {
 body {
   font-size: 160%; // 1
   margin: 0; // 2
-}
 
-body {
   background: $white;
   color: $text-colour;
   line-height: 1.5;
@@ -52,7 +64,10 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-ol, ul, nav ol, nav ul {
+ol,
+ul,
+nav ol,
+nav ul {
   list-style: inherit;
 }
 
@@ -61,7 +76,6 @@ fieldset {
   padding: 0;
 }
 
-// (Normalize.css)
 b,
 strong {
   font-weight: 600;
@@ -73,7 +87,7 @@ img {
 
 @include ie-lte(7) {
   button {
-    overflow:visible;
+    overflow: visible;
   }
 }
 
@@ -101,13 +115,31 @@ a:active {
 // External link styles
 a[rel="external"] {
   @include external-link-default;
-  @include external-link-19;
-  @include media-down(mobile) {
-    @include external-link-16;
+  @include external-link-16;
+
+  @include media(tablet) {
+    @include external-link-19;
   }
 }
 
 .external-link {
   @include external-link-12-no-hover;
   @include external-link-heading;
+}
+
+// Set focus styles
+a {
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.3);
+}
+
+a:focus {
+  background-color: $focus-colour;
+  outline: 3px solid $focus-colour;
+}
+
+input:focus,
+textarea:focus,
+select:focus,
+button:focus {
+  outline: 3px solid $focus-colour;
 }

--- a/public/sass/elements/_govuk-template-base.scss
+++ b/public/sass/elements/_govuk-template-base.scss
@@ -1,30 +1,7 @@
-html,
-body,
-button,
-input,
-table,
-td,
-th {
-  font-family: $NTA-Light;
-}
+// https://github.com/alphagov/govuk_template/blob/master/source/assets/stylesheets/_basic.scss
 
 // basic styles for HTML5 and other elements
-html,
-body,
-div,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-article,
-aside,
-footer,
-header,
-hgroup,
-nav,
-section {
+html, body, div, h1, h2, h3, h4, h5, h6, article, aside, footer, header, hgroup, nav, section {
   margin: 0;
   padding: 0;
   vertical-align: baseline;
@@ -35,6 +12,7 @@ main {
   display: block;
 }
 
+// (Normalize.css)
 // 1. Corrects text resizing oddly in IE6/7 when body font-size is set using em units
 //    http://clagnut.com/blog/348/#c790
 //    note - font-size reduced to 62.5% to allow simple rem/px font-sizing and fallback
@@ -43,19 +21,18 @@ main {
 // 3. Removes Android and iOS tap highlight color to prevent entire container being highlighted
 //    www.yuiblog.com/blog/2010/10/01/quick-tip-customizing-the-mobile-safari-tap-highlight-color/
 // 4. Prevents iOS text size adjust after orientation change, without disabling user zoom.
+// 5. Force the scrollbar to always display in IE10/11
 
 html {
-  font-size: 62.5%;   // 1
+  font-size: 62.5%; // 1
   overflow-y: scroll; // 2
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); // 3
+  -webkit-tap-highlight-color: rgba(0,0,0,0); // 3
   -webkit-text-size-adjust: 100%; // 4
   -ms-text-size-adjust: 100%; // 4
-  // Set background colour to match footer background
-  background-color: $grey-8;
-  // Force the scrollbar to always display in IE10/11
-  -ms-overflow-style: scrollbar;
+  -ms-overflow-style: scrollbar; // 5
 }
 
+// (Normalize.css)
 // 1. Font-size increased to compensate for change to html element font-size in
 //    order to support beta typography which was set in ems
 //    (62.5% * 160% = 100%)
@@ -64,6 +41,9 @@ html {
 body {
   font-size: 160%; // 1
   margin: 0; // 2
+}
+
+body {
   background: $white;
   color: $text-colour;
   line-height: 1.5;
@@ -72,10 +52,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-ol,
-ul,
-nav ol,
-nav ul {
+ol, ul, nav ol, nav ul {
   list-style: inherit;
 }
 
@@ -84,6 +61,7 @@ fieldset {
   padding: 0;
 }
 
+// (Normalize.css)
 b,
 strong {
   font-weight: 600;
@@ -95,29 +73,12 @@ img {
 
 @include ie-lte(7) {
   button {
-    overflow: visible;
+    overflow:visible;
   }
 }
 
 abbr[title] {
   cursor: help;
-}
-
-// Set focus styles
-a {
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.3);
-}
-
-a:focus {
-  background-color: $focus-colour;
-  outline: 3px solid $focus-colour;
-}
-
-input:focus,
-textarea:focus,
-select:focus,
-button:focus {
-  outline: 3px solid $focus-colour;
 }
 
 // Link styles


### PR DESCRIPTION
This pull request removes any GOV.UK template-specific variables and mixins.
It aims to ensure that the govuk-elements-sass package can be used without govuk_template (so only the govuk_frontend_toolkit is a dependency).

The base partial is renamed to govuk-template-base.scss to make it clear where these styles have come from.

Variables used only by the GOV.UK template for header and footer colours, eg. $footer-background are removed. 

The `media-down(mobile)` mixin is swapped with `media(tablet)` for external links, [to match the template](https://github.com/alphagov/govuk_template/commit/86106bfb332ff5c0346b92310a4117daeb2d8c8d).

cc. @dsingleton, @robinwhittleton. 
