### PR TITLE
add margin-bottom to .code blocks

### DIFF
--- a/public/sass/elements/_elements-typography.scss
+++ b/public/sass/elements/_elements-typography.scss
@@ -251,6 +251,7 @@ p {
   background-color: $highlight-colour;
   border: 1px solid $border-colour;
   padding: 4px 4px 2px 4px;
+  margin-bottom: $gutter;
 }
 
 // Horizontal rule style


### PR DESCRIPTION
This has no effect on inline elements with the `code` class, but importantly adds a margin-bottom to any block elements.