### PR TITLE
[For discussion, do not merge] Aim to make margins and spacing more consistent

### DIFF
--- a/public/sass/elements/_elements-typography.scss
+++ b/public/sass/elements/_elements-typography.scss
@@ -67,12 +67,12 @@ main {
 .heading-xlarge {
   @include bold-48();
 
-  margin-top: em(15, 32);
-  margin-bottom: em(30, 32);
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
 
   @include media(tablet) {
-    margin-top: em(30, 48);
-    margin-bottom: em(60, 48);
+    margin-top: $gutter * 1.5;
+    margin-bottom: $gutter * 1.5;
   }
 
   .heading-secondary {
@@ -87,12 +87,12 @@ main {
 .heading-large {
   @include bold-36();
 
-  margin-top: em(25, 24);
-  margin-bottom: em(10, 24);
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
 
   @include media(tablet) {
-    margin-top: em(45, 36);
-    margin-bottom: em(20, 36);
+    margin-top: $gutter * 1.5;
+    margin-bottom: $gutter * 1.5;
   }
 
   .heading-secondary {
@@ -107,12 +107,12 @@ main {
 .heading-medium {
   @include bold-24();
 
-  margin-top: em(25, 20);
-  margin-bottom: em(10, 20);
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
 
   @include media(tablet) {
-    margin-top: em(45, 24);
-    margin-bottom: em(20, 24);
+    margin-top: $gutter;
+    margin-bottom: $gutter;
   }
 
 }
@@ -120,30 +120,39 @@ main {
 .heading-small {
   @include bold-19();
 
-  margin-top: em(10, 16);
-  margin-bottom: em(5, 16);
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
 
   @include media(tablet) {
-    margin-top: em(20, 19);
+    margin-top: $gutter-two-thirds;
+    margin-bottom: $gutter-two-thirds;
   }
 
 }
 
 // Text
 p {
-  margin-top: em(5, 16);
-  margin-bottom: em(20, 16);
+  @include core-19;
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
 
   @include media(tablet) {
-    margin-top: em(5);
-    margin-bottom: em(20);
+    margin-top: $gutter-two-thirds;
+    margin-bottom: $gutter-two-thirds;
   }
-
 }
 
 // Lede, or intro text
 .lede {
   @include core-24;
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-top: $gutter;
+    margin-bottom: $gutter;
+  }
 }
 
 // Set a max-width for text blocks
@@ -259,8 +268,15 @@ hr {
   background: $border-colour;
   border: 0;
   height: 1px;
-  margin-top: $gutter;
-  margin-bottom: $gutter;
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-top: $gutter-two-thirds;
+    margin-bottom: $gutter-two-thirds;
+  }
+
   padding: 0;
   @include ie-lte(7) {
     color: $border-colour;
@@ -271,6 +287,15 @@ hr {
 .notice {
   @extend %contain-floats;
   position: relative;
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-top: $gutter;
+    margin-bottom: $gutter;
+  }
+
   .icon {
     position: absolute;
     left: 0;

--- a/public/sass/elements/_lists.scss
+++ b/public/sass/elements/_lists.scss
@@ -8,8 +8,21 @@ ol {
 
 .list {
   padding: 0;
-  margin-top: 5px;
-  margin-bottom: 20px;
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-top: $gutter-two-thirds;
+    margin-bottom: $gutter-two-thirds;
+  }
+
+  ul,
+  ol {
+    margin-top: 5px;
+    margin-bottom: 0;
+  }
+
 }
 
 .list li {

--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -8,7 +8,14 @@
   border-color: $border-colour;
 
   padding: em(15,19);
-  margin-bottom: em(15,19);
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-top: $gutter-two-thirds;
+    margin-bottom: $gutter-two-thirds;
+  }
 
   :first-child {
     margin-top: 0;

--- a/public/sass/elements/_tables.scss
+++ b/public/sass/elements/_tables.scss
@@ -6,6 +6,14 @@ table {
   border-spacing: 0;
   width: 100%;
 
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-top: $gutter-two-thirds;
+    margin-bottom: $gutter-two-thirds;
+  }
+
   th,
   td {
     @include core-16;

--- a/routes.js
+++ b/routes.js
@@ -48,6 +48,14 @@ module.exports = {
       res.redirect('/typography/example-typography');
     });
 
+    // Example page: Margins and spacing
+    app.get('/typography/example-margins-spacing', function (req, res) {
+      var section = "typography";
+      var section_name = "Typography";
+      var page_name = "Example: Margins and spacing";
+      res.render('examples/example_margins_spacing', {'assetPath' : assetPath, 'section': section, 'section_name' : section_name, 'page_name' : page_name });
+    });
+
     // Example page: Progressive disclosure
     app.get('/typography/example-details-summary', function (req, res) {
       var section = "typography";

--- a/views/examples/example_margins_spacing.html
+++ b/views/examples/example_margins_spacing.html
@@ -102,13 +102,13 @@
         <li>Possible risk factors include steroid use and chemotherapy, with or without local risk factors such as infection or trauma
           <ol class="list list-number">
             <li>
-              Sub list item one
+              Possible risk factors include steroid use and chemotherapy
             </li>
             <li>
-              Sub list item two
+              Possible risk factors include steroid use and chemotherapy
             </li>
             <li>
-              Sub list item three
+              Possible risk factors include steroid use and chemotherapy
             </li>
           </ol>
         </li>

--- a/views/examples/example_margins_spacing.html
+++ b/views/examples/example_margins_spacing.html
@@ -8,6 +8,143 @@
   <div class="grid-row">
     <div class="column-two-thirds">
 
+      <h1 class="heading-xlarge">
+        <span class="heading-secondary">Typography</span>
+        Margins and spacing
+      </h1>
+
+      <h1 class="heading-xlarge">
+        <span class="heading-secondary">A 27px section heading</span>
+        A 48px heading
+      </h1>
+
+      <p class="lede">
+        This is an intro paragraph at 24px. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.
+      </p>
+
+      <h1 class="heading-large">
+        <span class="heading-secondary">A 27px section heading</span>
+        A 36px heading for longer titles
+      </h1>
+
+      <p class="lede">
+        This is an intro paragraph at 24px. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.
+      </p>
+
+      <h2 class="heading-large">A 36px heading</h2>
+
+      <p>
+        This is a body copy paragraph at 19px. Donec id elit non mi porta gravida at eget metus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec sed odio dui. Aenean lacinia bibendum nulla sed consectetur. Aenean lacinia bibendum nulla sed consectetur. Sed posuere consectetur est at lobortis.
+      </p>
+
+      <h3 class="heading-medium">A 24px heading</h3>
+
+      <p>
+        Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum. Vestibulum id ligula porta felis euismod semper. Donec id elit non mi porta gravida at eget metus.
+      </p>
+
+      <h4 class="heading-small">A 19px heading</h4>
+
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
+      </p>
+
+      {{>typography_paragraphs}}
+
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
+      </p>
+
+      {{>typography_lists}}
+
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
+      </p>
+
+      <h4 class="heading-small">An ordered list</h4>
+
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.
+      </p>
+
+      <ol class="list list-number">
+        <li>Alendronic acid</li>
+        <li>Ibandronic acid</li>
+        <li>Pamidronate disodium</li>
+        <li>Risedronate sodium</li>
+        <li>Sodium clodronate</li>
+        <li>Zoledronic acid</li>
+      </ol>
+
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.
+      </p>
+
+      <h4 class="heading-small">An unordered list</h4>
+
+      <ul class="list list-bullet">
+        <li>Alendronic acid</li>
+        <li>Ibandronic acid</li>
+        <li>Pamidronate disodium</li>
+        <li>Risedronate sodium</li>
+        <li>Sodium clodronate</li>
+        <li>Zoledronic acid</li>
+      </ul>
+
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.
+      </p>
+
+      <h4 class="heading-small">An unordered list with nested ordered list</h4>
+
+      <ul class="list list-bullet">
+        <li>The possibility of osteonecrosis of the external auditory canal should be considered in patients receiving bisphosphonates who present with ear symptoms, including chronic ear infections, or in patients with suspected cholesteatoma</li>
+        <li>Possible risk factors include steroid use and chemotherapy, with or without local risk factors such as infection or trauma
+          <ol class="list list-number">
+            <li>
+              Sub list item one
+            </li>
+            <li>
+              Sub list item two
+            </li>
+            <li>
+              Sub list item three
+            </li>
+          </ol>
+        </li>
+        <li>Patients should be advised to report any ear pain, discharge from the ear, or an ear infection during bisphosphonate treatment</li>
+        <li>Report any cases of osteonecrosis of the external auditory canal suspected to be associated with bisphosphonates or any other medicines, including denosumab, on a <a rel="external" href="http://www.mhra.gov.uk/yellowcard">Yellow Card</a>
+        </li>
+      </ul>
+
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.
+      </p>
+
+      {{>typography_legal_text}}
+
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.
+      </p>
+
+      {{>typography_inset_text}}
+
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.
+      </p>
+
+      {{>data_table}}
+
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.
+      </p>
+
+      {{>data_table_numeric}}
+
+      <p>
+        Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.
+      </p>
+
     </div>
   </div>
 </main>

--- a/views/examples/example_margins_spacing.html
+++ b/views/examples/example_margins_spacing.html
@@ -1,0 +1,16 @@
+{{<layout_example}}
+
+{{$pageTitle}}Example: Margins and spacing — Typography — GOV.UK elements{{/pageTitle}}
+
+{{$content}}
+<main id="content" role="main">
+  {{>breadcrumb}}
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+    </div>
+  </div>
+</main>
+{{/content}}
+
+{{/layout_example}}


### PR DESCRIPTION
I think this can be split into 2 PRs.

1. To set consistent margins for lists, panels and tables to match body text:
15px (`$gutter-half`) for smaller viewports, 20px (`$gutter-two-thirds`) for larger viewports 

2. To make the margins on `.heading-size` classes in GOV.UK elements more sensible.

For large headings - make the margins consistent with the govspeak
titles - for both 48px and 36px titles, use margins of 15px for
smaller viewports and 45px (`$gutter * 1.5`) for larger viewports.

For smaller headings, use 15px for
smaller viewports and 30px (`$gutter`) for larger viewports. 

### Before:

![before - example margins and spacing typography gov uk elements](https://cloud.githubusercontent.com/assets/417754/13177750/13e692ba-d713-11e5-8e3f-681c5d6289d7.png)

### After: 

![after - example margins and spacing typography gov uk elements](https://cloud.githubusercontent.com/assets/417754/13177760/1df2f456-d713-11e5-8f72-e7eecc67f295.png)

### 
With a background colour to make the margins easier to see.

### Before:

![before - pink - example margins and spacing typography gov uk elements](https://cloud.githubusercontent.com/assets/417754/13177776/354fd84e-d713-11e5-9ae5-51057152249f.png)

### After: 
![after - pink - example margins and spacing typography gov uk elements](https://cloud.githubusercontent.com/assets/417754/13177781/397acea6-d713-11e5-871a-686d14e48c6b.png)
