### PR TITLE
Remove invalid ARIA role

### DIFF
--- a/views/includes/breadcrumb.html
+++ b/views/includes/breadcrumb.html
@@ -1,5 +1,5 @@
 <div class="breadcrumbs">
-  <ol role="breadcrumbs">
+  <ol>
     <li><a href="{{site.baseurl}}/">GOV.UK elements</a></li>
     {{#section}}
     <li><a href="{{site.baseurl}}/{{section}}/">{{#section_name}}{{section_name}}{{/section_name}}</a></li>


### PR DESCRIPTION
This was copied from the [govuk-breadcrumb component](https://github.com/alphagov/static/pull/737), which has since removed `role=“breadcrumbs”`.

cc. @robinwhittleton, @fofr.