### PR TITLE
Use 19px as the default font size for tabular data

### DIFF
--- a/public/sass/elements/_tables.scss
+++ b/public/sass/elements/_tables.scss
@@ -8,8 +8,8 @@ table {
 
   th,
   td {
-    @include core-16;
-    padding: em(12, 16) em(20, 16) em(9, 16) 0;
+    @include core-19;
+    padding: em(12, 19) em(20, 19) em(9, 19) 0;
 
     text-align: left;
     color: $black;
@@ -28,5 +28,21 @@ table {
   td.numeric {
     @include core-16($tabular-numbers: true);
     text-align: right;
+  }
+}
+
+.table-font-xsmall {
+
+  th {
+    @include bold-16;
+  }
+
+  td {
+    @include core-16;
+  }
+
+  th,
+  td {
+    padding: em(12, 16) em(20, 16) em(9, 16) 0;
   }
 }


### PR DESCRIPTION
All body copy should be the same, at 19px, this includes tabular data.

GOV.UK has tables set at 16px, these are to stand out from large areas
of body copy at 19px.

Add a .table-font-xsmall class, to recreate these smaller table styles.

After:

16px
![16px - data gov uk elements](https://cloud.githubusercontent.com/assets/417754/13285458/9dfb1416-daf2-11e5-9af2-656d94e32c4e.png)

19px
![19px - data gov uk elements](https://cloud.githubusercontent.com/assets/417754/13285457/9a772be0-daf2-11e5-8831-a4046f3bbfed.png)