### PR TITLE
Bump govuk template to 0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "consolidate": "^0.10.0",
     "express": "^3.18.4",
     "express-writer": "0.0.4",
-    "govuk_template_mustache": "^0.16.1",
+    "govuk_template_mustache": "^0.17.0",
     "grunt": "^0.4.2",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "^0.4.3",


### PR DESCRIPTION
# 0.17.0

- Add CSS hook (`.js-hidden`) for hiding content when JS is enabled.
Some apps have an equivalent hook, which can be removed once upgraded
to this version