### PR TITLE
Use aria-describedby to associate the hint with the form fields

### DIFF
--- a/views/snippets/form_date.html
+++ b/views/snippets/form_date.html
@@ -7,11 +7,11 @@
 
     <div class="form-date">
 
-      <p class="form-hint">For example, 31 3 1980</p>
+      <p class="form-hint" id="dob-hint">For example, 31 3 1980</p>
 
       <div class="form-group form-group-day">
         <label for="dob-day">Day</label>
-        <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+        <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="dob-hint">
       </div>
 
       <div class="form-group form-group-month">


### PR DESCRIPTION
This will cause screen readers to announce the hint (after they
announce the legend and/or form label for the field).

cc. @aduggin.