### PR TITLE
Remove $white background color on selected option

### DIFF
--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -57,7 +57,6 @@
 
 // Add selected state
 .js-enabled label.selected {
-  background: $white;
   border-color: $black;
 }
 


### PR DESCRIPTION
Some projects (e.g. Verify) use different default colours.
Having a $white background for selected options causes
unacceptably low contrast (in our case white on white).

See alphagov/verify-frontend#18