### PR TITLE
Fix toggled content

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -34,14 +34,14 @@ function ShowHideContent() {
             var $groupDataTarget = $('#' + groupDataTarget);
 
             // Hide toggled content
-            $groupDataTarget.hide();
+            $groupDataTarget.addClass('js-hidden');
             // Set aria-expanded and aria-hidden for hidden content
             $this.attr('aria-expanded', 'false');
             $groupDataTarget.attr('aria-hidden', 'true');
           });
 
           var $dataTarget = $('#' + dataTarget);
-          $dataTarget.show();
+          $dataTarget.removeClass('js-hidden');
           // Set aria-expanded and aria-hidden for clicked radio
           $radio.attr('aria-expanded', 'true');
           $dataTarget.attr('aria-hidden', 'false');
@@ -61,7 +61,7 @@ function ShowHideContent() {
             var $groupDataTarget = $('#' + groupDataTarget);
 
             // Hide toggled content
-            $groupDataTarget.hide();
+            $groupDataTarget.addClass('js-hidden');
             // Set aria-expanded and aria-hidden for hidden content
             $(this).attr('aria-expanded', 'false');
             $groupDataTarget.attr('aria-hidden', 'true');

--- a/public/sass/elements/_helpers.scss
+++ b/public/sass/elements/_helpers.scss
@@ -26,12 +26,6 @@
 
 }
 
-// Hide for both screenreaders and browsers
-.hidden {
-  display: none;
-  visibility: hidden;
-}
-
 // Hide, but not for screenreaders
 .visually-hidden,
 .visuallyhidden {
@@ -43,9 +37,4 @@
   margin: -1px;
   padding: 0;
   border: 0;
-}
-
-// Hide, only when JavaScript is enabled
-.js-enabled .js-hidden {
-  display: none;
 }


### PR DESCRIPTION
Rather than setting `display:none` and `display:block` using `show()`; and
`hide()`, add and remove the `.js-hidden` class.

[I think this was introduced by this change to the GOV.UK template](https://github.com/alphagov/govuk_template/commit/0b6684331ba0aac717dfe4dbe3a2743e2108e54f), which sets both display:none and visibility:hidden, and the visibility:hidden isn't removed when show and hide are used.

This fixes #197.

I've also removed .js-enabled .js-hidden from GOV.UK elements as this is defined in the template.

It is worth noting that #183 has a much better implementation of the JS for toggles.

cc. @robinwhittleton @edwardhorsford.