### PR TITLE
Fix toggled content shown when a checkbox is checked

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -99,7 +99,7 @@ function ShowHideContent() {
           var state = $(this).attr('aria-expanded') === 'false' ? true : false;
 
           // Toggle hidden content
-          $('#'+$dataTarget).toggle();
+          $('#'+$dataTarget).toggleClass('js-hidden');
 
           // Update aria-expanded and aria-hidden attributes
           $(this).attr('aria-expanded', state);


### PR DESCRIPTION
This content is currently set to display:block or display:none using
toggle().

Instead use toggleClass to add or remove the `.js-hidden` class, this takes
advantage of `.js-enabled .js-hidden` set by the [govuk_template](https://github.com/alphagov/govuk_template/commit/0b6684331ba0aac717dfe4dbe3a2743e2108e54f) and fixes a bug where the content to be revealed currently isn’t shown, as the
.js-hidden class isn’t removed.

This should have been added in #198, but it appears only the fix for radio buttons was committed. 

