### PR TITLE
Comment out the govuk-template-base partial

### DIFF
--- a/public/sass/_govuk-elements.scss
+++ b/public/sass/_govuk-elements.scss
@@ -32,7 +32,7 @@
 // Base (unclassed HTML elements)
 // These are predefined by govuk_template
 // If you're not using govuk_template, uncomment the line below.
-@import "elements/govuk-template-base";           // Base styles set by GOV.UK template
+// @import "elements/govuk-template-base";        // Base styles set by GOV.UK template
 
 // Objects (unstyled design patterns)
 @import "elements/layout";                        // Main content container. Grid layout - rows and column widths


### PR DESCRIPTION
This is only required when govuk_template isn’t being used, which isn’t
true for govuk_elements.

This undoes the change introduced in 7777182b1121b3fb4bdebb7f35a308fe1d91a17f.