### PR TITLE
Bump govuk template to 0.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "consolidate": "^0.10.0",
     "express": "^3.18.4",
     "express-writer": "0.0.4",
-    "govuk_template_mustache": "^0.17.0",
+    "govuk_template_mustache": "^0.17.1",
     "grunt": "^0.4.2",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "^0.4.3",


### PR DESCRIPTION
[# 0.17.1](https://raw.githubusercontent.com/alphagov/govuk_template/master/CHANGELOG.md)

- Reduce file size of template: removes HTML comments, `type` attributes on
  scripts, and uses HTML5 charset declaration. #208
- Switch external link media query to be mobile first #205
- Sass file cleanups
  - Replace old grid mixins with newer grid from frontend toolkit #134
  - Remove duplicate grey variables #201
