### PR TITLE
Don't copy the govuk frontend toolkit images to an icons subfolder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,7 @@ module.exports = function (grunt) {
         expand: true,
         src: '**',
         cwd: 'node_modules/govuk_frontend_toolkit/images/',
-        dest: 'govuk_modules/public/images/icons/'
+        dest: 'govuk_modules/public/images/'
       },
 
     },

--- a/public/sass/elements/_buttons.scss
+++ b/public/sass/elements/_buttons.scss
@@ -35,17 +35,17 @@
 .button-start,
 .button-get-started {
   @include bold-24;
-  background-image: file-url("icons/icon-pointer.png");
+  background-image: file-url("icon-pointer.png");
   background-repeat: no-repeat;
   background-position: 100% 50%;
   padding: em(7) em(41) em(4) em(16);
 
   @include device-pixel-ratio {
-    background-image: file-url("icons/icon-pointer-2x.png");
+    background-image: file-url("icon-pointer-2x.png");
     background-size: 30px 19px;
   }
 
   @include ie(6) {
-    background-image: file-url("icons/icon-pointer-2x.png");
+    background-image: file-url("icon-pointer-2x.png");
   }
 }

--- a/public/sass/elements/_icons.scss
+++ b/public/sass/elements/_icons.scss
@@ -8,18 +8,18 @@
   height: #{$icon-height}px;
 
   @if $icon-sub-folder {
-    background-image: file-url("icons/#{$icon-sub-folder}/#{$icon-name}.png");
+    background-image: file-url("#{$icon-sub-folder}/#{$icon-name}.png");
 
     @include device-pixel-ratio() {
-      background-image: file-url("icons/#{$icon-sub-folder}/#{$icon-name}-2x.png");
+      background-image: file-url("#{$icon-sub-folder}/#{$icon-name}-2x.png");
       background-size: 100%;
     }
 
   } @else {
-    background-image: file-url("icons/#{$icon-name}.png");
+    background-image: file-url("#{$icon-name}.png");
 
     @include device-pixel-ratio() {
-      background-image: file-url("icons/#{$icon-name}-2x.png");
+      background-image: file-url("#{$icon-name}-2x.png");
       background-size: 100%;
     }
   }


### PR DESCRIPTION
Remove the icons subfolder.

These assets are now copied to `/public/images`, so the folder structure for
these assets is the same as that of the [govuk frontend toolkit's images folder](https://github.com/alphagov/govuk_frontend_toolkit/tree/master/images).

For the govuk-elements-rails gem, which uses the govuk_frontend_toolkit gem, the path to the image assets will be the same.

cc. @robinwhittleton @robmckinnon. 

