### PR TITLE
Fix the summary arrow in recent Firefox

### DIFF
--- a/public/sass/_govuk-elements.scss
+++ b/public/sass/_govuk-elements.scss
@@ -52,3 +52,4 @@
 @import "elements/breadcrumbs";                   // Breadcrumbs
 @import "elements/phase-banner";                  // Alpha and beta banners and tags
 @import "elements/components";                    // GOV.UK prefixed styles - blue highlighted box
+@import "elements/shame";                         // Hacks and workarounds that will go away eventually

--- a/public/sass/elements/_details.scss
+++ b/public/sass/elements/_details.scss
@@ -36,13 +36,13 @@ details {
 // Show the summary arrow in Firefox
 // The current Firefox implementation uses display: list-item to show the arrow marker.
 // We want to use display: inline-block to shrink-wrap the focus outline around the text.
-// This will turn off inline-block for Firefox only.
+// This will turn off inline-block for Firefox that’s not using the polyfill only.
 // @-moz-document is going away: https://bugzilla.mozilla.org/show_bug.cgi?id=1035091 .
 // Hopefully they’ll fix <summary> first but if not it’ll fall back to no arrow:
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1270163
 // If Mozilla add display: revert and remove list-item from summary then this will fall through.
 @-moz-document regexp('.*') {
-  details summary {
+  details summary:not([tabindex]) {
     display: list-item;
     display: revert;
   }

--- a/public/sass/elements/_details.scss
+++ b/public/sass/elements/_details.scss
@@ -32,3 +32,18 @@ details {
   }
 
 }
+
+// Show the summary arrow in Firefox
+// The current Firefox implementation uses display: list-item to show the arrow marker.
+// We want to use display: inline-block to shrink-wrap the focus outline around the text.
+// This will turn off inline-block for Firefox only.
+// @-moz-document is going away: https://bugzilla.mozilla.org/show_bug.cgi?id=1035091 .
+// Hopefully they’ll fix <summary> first but if not it’ll fall back to no arrow:
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1270163
+// If Mozilla add display: revert and remove list-item from summary then this will fall through.
+@-moz-document regexp('.*') {
+  details summary {
+    display: list-item;
+    display: revert;
+  }
+}

--- a/public/sass/elements/_details.scss
+++ b/public/sass/elements/_details.scss
@@ -32,18 +32,3 @@ details {
   }
 
 }
-
-// Show the summary arrow in Firefox
-// The current Firefox implementation uses display: list-item to show the arrow marker.
-// We want to use display: inline-block to shrink-wrap the focus outline around the text.
-// This will turn off inline-block for Firefox that’s not using the polyfill only.
-// @-moz-document is going away: https://bugzilla.mozilla.org/show_bug.cgi?id=1035091 .
-// Hopefully they’ll fix <summary> first but if not it’ll fall back to no arrow:
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1270163
-// If Mozilla add display: revert and remove list-item from summary then this will fall through.
-@-moz-document regexp('.*') {
-  details summary:not([tabindex]) {
-    display: list-item;
-    display: revert;
-  }
-}

--- a/public/sass/elements/_shame.scss
+++ b/public/sass/elements/_shame.scss
@@ -1,0 +1,14 @@
+// Show the arrow on summary elements in Firefox - _details.scss
+// The current Firefox implementation uses display: list-item to show the arrow marker.
+// We want to use display: inline-block to shrink-wrap the focus outline around the text.
+// This will turn off inline-block for Firefox that’s not using the polyfill only.
+// @-moz-document is going away: https://bugzilla.mozilla.org/show_bug.cgi?id=1035091 .
+// Hopefully they’ll fix <summary> first but if not it’ll fall back to no arrow:
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1270163
+// If Mozilla add display: revert and remove list-item from summary then this will fall through.
+@-moz-document regexp('.*') {
+  details summary:not([tabindex]) {
+    display: list-item;
+    display: revert;
+  }
+}


### PR DESCRIPTION
This is a pretty hacky fix so I’ve tried to describe it as accurately as possible in the comments. It can be removed if either of the following happens:

* Mozilla fixes their summary arrow with `display: inline-block`
* Mozilla remove their support for `@-moz-document`

Fixes https://github.com/alphagov/govuk_elements/issues/221