### PR TITLE
Consistent spacing underneath block labels and toggled content

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -46,7 +46,7 @@ textarea {
   margin-bottom: $gutter;
 
   @include media(tablet) {
-    margin-bottom: $gutter*2;
+    margin-bottom: $gutter * 2;
   }
 }
 

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -35,6 +35,21 @@ textarea {
 // 2. Form wrappers
 // ==========================================================================
 
+// Form section is used to create spacing between form sections
+.form-section {
+  @extend %contain-floats;
+  @include box-sizing(border-box);
+
+  float: left;
+  width: 100%;
+
+  margin-bottom: $gutter;
+
+  @include media(tablet) {
+    margin-bottom: $gutter*2;
+  }
+}
+
 // Form group is used to wrap label and input pairs
 .form-group {
   @extend %contain-floats;

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -35,7 +35,7 @@ textarea {
 // 2. Form wrappers
 // ==========================================================================
 
-// Form section is used to create spacing between form sections
+// Form section is used to wrap .form-group and has twice its margin
 .form-section {
   @extend %contain-floats;
   @include box-sizing(border-box);

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -89,6 +89,7 @@ textarea {
 .form-label-bold {
   display: block;
   color: $text-colour;
+  padding-bottom: 2px;
 }
 
 .form-label {
@@ -97,23 +98,6 @@ textarea {
 
 .form-label-bold {
   @include bold-19;
-}
-
-// Add spacing under spans within labels
-legend {
-  .form-label,
-  .form-label-bold {
-    padding-bottom: 7px;
-  }
-}
-
-// Remove spacing when error messages are shown
-// TODO: Move into /forms/_form-validation.scss
-.error legend {
-  .form-label,
-  .form-label-bold {
-    padding-bottom: 0;
-  }
 }
 
 // Used for the 'or' in between block label options
@@ -140,9 +124,16 @@ legend {
   display: block;
   color: $secondary-text-colour;
   font-weight: normal;
-  margin-bottom: 5px;
+
+  margin-top: -2px;
+  padding-bottom: 2px;
 }
 
+.form-label .form-hint,
+.form-label-bold .form-hint {
+  margin-top: 0;
+  padding-bottom: 0;
+}
 
 // 5. Form controls
 // ==========================================================================

--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -2,6 +2,7 @@
 // ==========================================================================
 
 .panel {
+  @include box-sizing(border-box);
   @extend %contain-floats;
   clear: both;
   border-left-style: solid;
@@ -30,7 +31,31 @@
 }
 
 // Panels within form groups
-// Remove the bottom padding as .form-group sets a bottom margin
+// By default, panels have 15px bottom margin
 .form-group .panel-border-narrow {
+  float: left;
+  width: 100%;
+  // Remove the bottom padding as .form-group sets a bottom margin
   padding-bottom: 0;
+  // Don't remove the bottom margin for all panels, assume they are often within stacked groups
 }
+
+// Note: This is incredibly fragile, and needs rebuilding.
+
+// The first panel in a group
+.form-group .panel-border-narrow:first-child {
+  margin-top: 10px;
+}
+
+// The last panel in a group
+.form-group .panel-border-narrow:last-child {
+  margin-top: 10px;
+  margin-bottom: 0;
+}
+
+// For inline panels
+.inline .form-group .panel-border-narrow {
+  margin-top: 10px;
+  margin-bottom: 0;
+}
+

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -41,16 +41,19 @@
     border-color: $black;
   }
 
-}
-
-.block-label:last-child {
-  margin-bottom: 0;
+  &:last-child,
+  &:last-of-type {
+    margin-bottom: 0;
+  }
 }
 
 // To stack horizontally, use .inline on parent, to sit block labels next to each other
 .inline .block-label {
   clear: none;
-  margin-right: 10px;
+  @include media (tablet) {
+    margin-bottom: 0;
+    margin-right: 10px;
+  }
 }
 
 // Selected and focused states

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -50,6 +50,7 @@
 // To stack horizontally, use .inline on parent, to sit block labels next to each other
 .inline .block-label {
   clear: none;
+
   @include media (tablet) {
     margin-bottom: 0;
     margin-right: 10px;

--- a/public/sass/elements/forms/_form-date.scss
+++ b/public/sass/elements/forms/_form-date.scss
@@ -24,7 +24,7 @@ input[type=number] {
 
     label {
       display: block;
-      margin-bottom: 5px;
+      padding-bottom: 2px;
     }
 
     input {

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -19,10 +19,6 @@
     border: 4px solid $error-colour;
   }
 
-  .form-hint {
-    margin-bottom: 0;
-  }
-
 }
 
 .error,
@@ -45,7 +41,13 @@
   clear: both;
 
   margin: 0;
-  padding: 5px 0 7px;
+  padding: 2px 0 2px 0;
+}
+
+.form-label .error-message,
+.form-label-bold .error-message {
+  padding-top: 4px;
+  padding-bottom: 0;
 }
 
 // Summary of multiple error messages

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -41,7 +41,7 @@
   clear: both;
 
   margin: 0;
-  padding: 2px 0 2px 0;
+  padding: 2px 0;
 }
 
 .form-label .error-message,

--- a/views/examples/example_form_elements.html
+++ b/views/examples/example_form_elements.html
@@ -10,78 +10,524 @@
   <div class="grid-row">
     <div class="column-two-thirds">
 
+      <h1 class="heading-large">
+        <span class="heading-secondary">Form elements</span>
+        Example: Form elements
+      </h1>
+
       <form action="/" method="post" class="form">
 
-        <h1 class="heading-large">
-          <span class="heading-secondary">Form elements</span>
-          Example: Form elements
-        </h1>
+        <h2 class="heading-medium">
+          The examples below show the spacing between form labels, hint text and error messages
+        </h2>
 
-        <!-- Input type="text" -->
-        <div class="form-group">
-          <label class="form-label" for="input-text">Single line text fields</label>
-          <input class="form-control" id="input-text" type="text">
+        <div class="form-section">
+          <p>
+            There should be 10px under the label or legend and the input
+          </p>
+          <!-- Text inside a label -->
+          <div class="form-group">
+            <label class="form-label-bold" for="example-form-label">
+              This is the label text in bold
+            </label>
+            <input class="form-control" id="example-form-label" type="text">
+          </div>
+          <!-- Text inside a legend -->
+          <div class="form-group">
+            <fieldset>
+              <legend>
+                <span class="form-label-bold">
+                  This is the label text in bold
+                </span>
+              </legend>
+              <label class="block-label" for="example-radio-yes-no-yes">
+                <input id="example-radio-yes-no-yes" type="radio" name="example-yes-no-group" value="Yes">
+                  Yes
+              </label>
+            </fieldset>
+          </div>
         </div>
 
-        <!-- Textarea -->
-        <div class="form-group">
-          <label class="form-label" for="textarea">Multi-line text fields</label>
-          <textarea class="form-control" id="textarea" cols="30" rows="10"></textarea>
+        <div class="form-section">
+          <p>
+            There should be 10px under the label or legend and the input (when hint text is shown)
+          </p>
+
+          <!-- Hint text inside a label -->
+          <div class="form-group">
+            <label class="form-label-bold" for="example-form-label-bold">
+              This is the label text in bold
+              <span class="form-hint">
+                This is hint text
+              </span>
+            </label>
+            <input class="form-control" id="example-form-label-bold" type="text">
+          </div>
+
+          <!-- Hint text outside a label (preference is inside, to be read by AT) -->
+          <div class="form-group">
+            <label class="form-label-bold" for="example-form-label-bold">
+              This is the label text in bold
+            </label>
+            <span class="form-hint">
+              This is hint text
+            </span>
+            <input class="form-control" id="example-form-label-bold" type="text">
+          </div>
+
+          <!-- Text inside a legend -->
+          <div class="form-group">
+            <fieldset>
+              <legend>
+                <span class="form-label-bold">
+                  This is the label text in bold
+                </span>
+                <span class="form-hint">
+                  This is hint text
+                </span>
+              </legend>
+              <label class="block-label" for="radio-yes-no-yes-b">
+                <input id="radio-yes-no-yes-b" type="radio" name="yes-no-group-b" value="Yes">
+                  Yes
+              </label>
+            </fieldset>
+          </div>
+
+          <!-- Date of birth -->
+          <div class="form-group">
+            <fieldset>
+              <legend>
+                <span class="form-label-bold">This is the label text in bold</span>
+                <span class="form-hint" id="dob-hint">This is hint text</span>
+              </legend>
+              <div class="form-date">
+                <div class="form-group form-group-day">
+                  <label class="form-label" for="dob-day">Day</label>
+                  <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="dob-hint">
+                </div>
+                <div class="form-group form-group-month">
+                  <label class="form-label" for="dob-month">Month</label>
+                  <input class="form-control" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+                </div>
+                <div class="form-group form-group-year">
+                  <label class="form-label" for="dob-year">Year</label>
+                  <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+                </div>
+              </div>
+            </fieldset>
+          </div>
         </div>
 
-        <!-- Select box -->
-        <div class="form-group">
-          <label class="form-label" for="select-box">Drop down content</label>
-          <select class="form-control" id="select-box">
-            <option>Banana</option>
-            <option>Cherry</option>
-            <option>Lemon</option>
-          </select>
+        <div class="form-section">
+          <p>
+            There should be 10px under the label or legend and the input (when an error message is shown) and 15px above the error message.
+          </p>
+
+          <!-- Text inside a label - error -->
+          <div class="form-group error">
+            <label class="form-label-bold" for="example-form-control">
+              This is the label text
+              <span class="form-hint">
+                This is hint text
+              </span>
+              <span class="error-message">
+                Error message goes here
+              </span>
+            </label>
+            <input class="form-control" id="example-form-control" type="text">
+          </div>
+
+          <!-- Hint text outside a label (preference is inside, to be read by AT) - error -->
+          <div class="form-group error">
+            <label class="form-label-bold" for="example-form-control">
+              This is the label text
+            </label>
+            <span class="form-hint">
+              This is hint text
+            </span>
+            <span class="error-message">
+              Error message goes here
+            </span>
+            <input class="form-control" id="example-form-control" type="text">
+          </div>
+
+          <!-- Text inside a legend - error -->
+          <div class="form-group error">
+            <fieldset>
+
+              <legend>
+                <span class="form-label-bold">
+                  Do you have a National Insurance number?
+                </span>
+                <span class="form-hint">
+                  This is hint text
+                </span>
+                <span class="error-message">
+                  Error message goes here
+                </span>
+              </legend>
+              <label class="block-label" for="radio-yes-no-yes-c">
+                <input id="radio-yes-no-yes-c" type="radio" name="yes-no-group-c" value="Yes">
+                  Yes
+              </label>
+            </fieldset>
+          </div>
+
+          <!-- Date of birth -->
+          <div class="form-group error">
+            <fieldset>
+              <legend>
+                <span class="form-label-bold">Date of birth</span>
+                <span class="form-hint" id="example-dob-hint">For example, 31 3 1980</span>
+                <span class="error-message">Error message goes here</span>
+              </legend>
+              <div class="form-date">
+                <div class="form-group form-group-day">
+                  <label class="form-label" for="example-dob-day">Day</label>
+                  <input class="form-control" id="example-dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint">
+                </div>
+                <div class="form-group form-group-month">
+                  <label class="form-label" for="example-dob-month">Month</label>
+                  <input class="form-control" id="example-dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+                </div>
+                <div class="form-group form-group-year">
+                  <label class="form-label" for="example-dob-year">Year</label>
+                  <input class="form-control" id="example-dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+                </div>
+              </div>
+            </fieldset>
+          </div>
         </div>
 
-        <!-- Check box -->
-        <div class="form-group">
-          <label class="form-checkbox" for="checkbox-telephone-number" >
-            <input id="checkbox-telephone-number" type="checkbox" value="checkbox-telephone-number">
-            Native check box
-          </label>
+        <div class="form-section">
+          <h3 class="heading-medium">
+            These examples show legend text styled to look like a label
+          </h3>
+
+          <!-- Yes or No question (without revealed content ) -->
+          <fieldset class="inline">
+            <legend>
+              <span class="form-label-bold">
+                Do you already have a personal user account?
+              </span>
+            </legend>
+            <label class="block-label" for="radio-inline-1a">
+              <input id="radio-inline-1a" type="radio" name="radio-inline-group" value="Yes">
+              Yes
+            </label>
+            <label class="block-label" for="radio-inline-2a">
+              <input id="radio-inline-2a" type="radio" name="radio-inline-group" value="No">
+              No
+            </label>
+          </fieldset>
         </div>
 
-        <!-- Chunky check box -->
-
-        <div class="form-group">
-          <label class="block-label" for="checkbox-1">
-            <input id="checkbox-1" type="checkbox" value="waste-animal">
-            Checkbox
-          </label>
-          <label class="block-label" for="checkbox-2">
-            <input id="checkbox-2" type="checkbox" value="waste-mines">
-            Checkbox
-          </label>
-          <label class="block-label" for="checkbox-3">
-            <input id="checkbox-3" type="checkbox" value="farm-agricultural">
-            Checkbox
-          </label>
+        <div class="form-section">
+          <!-- Yes or No question (select one option to reveal content) -->
+          <fieldset class="inline">
+            <legend>
+              <span class="form-label-bold">
+                This is the label text
+              </span>
+              <span class="form-hint">
+                This is the hint text
+              </span>
+            </legend>
+            <div class="form-group">
+              <label class="block-label" data-target="yes-and-do-next" for="radio-yes-no-yes-a">
+                <input id="radio-yes-no-yes-a" type="radio" name="yes-no-group-a" value="Yes">
+                Yes
+              </label>
+              <label class="block-label" data-target="no-and-do-next" for="radio-yes-no-no-a">
+                <input id="radio-yes-no-no-a" type="radio" name="yes-no-group-a" value="No">
+                No
+              </label>
+              <div class="panel panel-border-narrow js-hidden" id="yes-and-do-next-a">
+                <label class="form-label" for="yes-next-a">Yes, this next</label>
+                <input class="form-control" name="yes-next" type="text" id="yes-next-a">
+              </div>
+              <div class="panel panel-border-narrow js-hidden" id="no-and-do-next-a">
+                <label class="form-label" for="no-next-a">No, this next</label>
+                <input class="form-control" name="no-next" type="text" id="no-next-a">
+              </div>
+            </div>
+          </fieldset>
         </div>
 
-        <!-- Radio button -->
+        <div class="form-section">
 
-        <div class="form-group">
-          <label class="block-label" for="radio-1">
-            <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">
-            Radio
-          </label>
-          <label class="block-label" for="radio-2">
-            <input id="radio-2" type="radio" name="radio-group" value="Isle of Man or the Channel Islands">
-            Radio
-          </label>
-          <label class="block-label" for="radio-3">
-            <input id="radio-3" type="radio" name="radio-group" value="I am a British citizen living abroad">
-            Radio
-          </label>
+          <h2 class="heading-medium">
+            Example: input type="text" and error
+          </h2>
+
+          <!-- Input type="text" -->
+          <div class="form-group">
+            <label class="form-label" for="input-text-a">
+              This is the label text
+            </label>
+            <input class="form-control" id="input-text-a" type="text">
+          </div>
+
+          <!-- Input type="text" - error -->
+          <div class="form-group error">
+            <label class="form-label" for="input-text-b">
+              This is the label text
+              <span class="error-message">
+                Error message goes here
+              </span>
+            </label>
+            <input class="form-control" id="input-text-b" type="text">
+          </div>
+
+          <!-- Input type="text" (bold label) -->
+          <div class="form-group">
+            <label class="form-label-bold" for="input-text-c">
+              This is the label text in bold
+            </label>
+            <input class="form-control" id="input-text-c" type="text">
+          </div>
+
+          <!-- Input type="text" - error (bold label) -->
+          <div class="form-group error">
+            <label class="form-label-bold" for="input-text-d">
+              This is the label text in bold
+              <span class="error-message">
+                Error message goes here
+              </span>
+            </label>
+            <input class="form-control" id="input-text-d" type="text">
+          </div>
+
+          <!-- Input type="text" (bold label with hint text) -->
+          <div class="form-group">
+            <label class="form-label-bold" for="input-text-g">
+              This is the label text
+              <span class="form-hint">
+                This is hint text
+              </span>
+            </label>
+            <input class="form-control" id="input-text-g" type="text">
+          </div>
+
+          <div class="form-group">
+            <label class="form-label-bold" for="input-text-g">
+              This is the label text
+            </label>
+            <span class="form-hint">
+              This is hint text
+            </span>
+            <input class="form-control" id="input-text-g" type="text">
+          </div>
+
+          <!-- Input type="text" - error (bold label with hint text) -->
+          <div class="form-group error">
+            <label class="form-label-bold" for="input-text-h">
+              This is the label text
+              <span class="form-hint">
+                This is hint text
+              </span>
+              <span class="error-message">
+                Error message goes here
+              </span>
+            </label>
+            <input class="form-control" id="input-text-h" type="text">
+          </div>
+        </div>
+
+        <div class="form-section">
+          <h2 class="heading-medium">
+            Example: textarea and error
+          </h2>
+
+          <!-- Textarea -->
+          <div class="form-group">
+            <label class="form-label" for="textarea-a">
+              This is the label text
+            </label>
+            <textarea class="form-control" id="textarea-a" cols="30" rows="10"></textarea>
+          </div>
+
+          <!-- Textarea - error -->
+          <div class="form-group error">
+            <label class="form-label" for="textarea-b">
+              This is the label text
+              <span class="error-message">
+                Error message goes here
+              </span>
+            </label>
+            <textarea class="form-control" id="textarea-b" cols="30" rows="10"></textarea>
+          </div>
+
+          <!-- Textarea (bold label) -->
+          <div class="form-group">
+            <label class="form-label-bold" for="textarea-c">
+              This is the label text in bold
+            </label>
+            <textarea class="form-control" id="textarea-c" cols="30" rows="10"></textarea>
+          </div>
+
+          <!-- Textarea - error (bold label) -->
+          <div class="form-group error">
+            <label class="form-label-bold" for="textarea-d">
+              This is the label text in bold
+              <span class="error-message">
+                Error message goes here
+              </span>
+            </label>
+            <textarea class="form-control" id="textarea-d" cols="30" rows="10"></textarea>
+          </div>
+
+          <!-- Textarea (bold label, with hint text) -->
+          <div class="form-group">
+            <label class="form-label-bold" for="textarea-e">
+              This is the label text
+              <span class="form-hint">This is hint text</span>
+            </label>
+            <textarea class="form-control" id="textarea-e" cols="30" rows="10"></textarea>
+          </div>
+
+          <!-- Textarea - error (bold label, with hint text) -->
+          <div class="form-group error">
+            <label class="form-label-bold" for="textarea-f">
+              This is the label text
+              <span class="form-hint">This is hint text</span>
+              <span class="error-message">
+                Error message goes here
+              </span>
+            </label>
+            <textarea class="form-control" id="textarea-f" cols="30" rows="10"></textarea>
+          </div>
+        </div>
+
+        <div class="form-section">
+          <h2 class="heading-medium">
+            Example: select boxes and error
+          </h2>
+
+          <!-- Select box -->
+          <div class="form-group">
+            <label class="form-label" for="select-box-a">This is the label text</label>
+            <select class="form-control" id="select-box-a">
+              <option>GOV.UK elements option 1</option>
+              <option>GOV.UK elements option 2</option>
+              <option>GOV.UK elements option 3</option>
+            </select>
+          </div>
+
+          <!-- Select box - error -->
+          <div class="form-group error">
+            <label class="form-label" for="select-box-b">
+              This is the label text
+              <span class="error-message">
+                Error message goes here
+              </span>
+            </label>
+            <select class="form-control" id="select-box-b">
+              <option>GOV.UK elements option 1</option>
+              <option>GOV.UK elements option 2</option>
+              <option>GOV.UK elements option 3</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="form-section">
+          <!-- Select box (with bold text) -->
+          <div class="form-group">
+            <label class="form-label-bold" for="select-box-c">
+              This is the label text
+            </label>
+            <select class="form-control" id="select-box-c">
+              <option>GOV.UK elements option 1</option>
+              <option>GOV.UK elements option 2</option>
+              <option>GOV.UK elements option 3</option>
+            </select>
+          </div>
+
+          <!-- Select box - error (with bold text) -->
+          <div class="form-group error">
+            <label class="form-label-bold" for="select-box-d">
+              This is the label text
+              <span class="error-message">
+                Error message goes here
+              </span>
+            </label>
+            <select class="form-control" id="select-box-d">
+              <option>GOV.UK elements option 1</option>
+              <option>GOV.UK elements option 2</option>
+              <option>GOV.UK elements option 3</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="form-section">
+          <!-- Select box (with bold text and hint text) -->
+          <div class="form-group">
+            <label class="form-label-bold" for="select-box-g">
+              This is the label text
+              <span class="form-hint">
+                This the hint text
+              </span>
+            </label>
+            <select class="form-control" id="select-box-g">
+              <option>GOV.UK elements option 1</option>
+              <option>GOV.UK elements option 2</option>
+              <option>GOV.UK elements option 3</option>
+            </select>
+          </div>
+
+          <!-- Select box - error (with bold text and hint text) -->
+          <div class="form-group error">
+            <label class="form-label-bold" for="select-box-h">
+              This is the label text
+              <span class="form-hint">
+                This is the hint text
+              </span>
+              <span class="error-message">
+                Error message goes here
+              </span>
+            </label>
+            <select class="form-control" id="select-box-h">
+              <option>GOV.UK elements option 1</option>
+              <option>GOV.UK elements option 2</option>
+              <option>GOV.UK elements option 3</option>
+            </select>
+          </div>
         </div>
 
       </form>
+
+      <div class="form-section">
+        <h3 class="heading-medium">
+          These examples are one-question-per-page examples and use a heading for the question, with a visually hidden legend inside a fieldset.
+        </h3>
+        <!-- "Chunky" Radio buttons, stacked -->
+        {{> form_radio_buttons }}
+      </div>
+
+      <div class="form-section">
+        <!-- "Chunky" Checkboxes, stacked -->
+        {{> form_checkboxes }}
+      </div>
+
+      <div class="form-section">
+        <!-- Yes or No question (without revealed content ) -->
+        {{> form_radio_buttons_inline }}
+      </div>
+
+      <div class="form-section">
+        <!-- Yes or No question (select one option to reveal content) -->
+        {{> form_radio_inline_yes_no }}
+      </div>
+
+      <div class="form-section">
+        <!-- Radio buttons (select one option to reveal content) -->
+        {{> form_inset_radios }}
+      </div>
+
+      <div class="form-section">
+        <!-- Checkboxes (select more than option to reveal content) -->
+        {{> form_inset_checkboxes }}
+      </div>
 
     </div>
   </div>

--- a/views/snippets/form_date.html
+++ b/views/snippets/form_date.html
@@ -1,29 +1,26 @@
-<h1 class="heading-small">What is your date of birth?</h1>
-
 <form>
-  <fieldset>
-
-    <legend class="visuallyhidden">Date of birth</legend>
-
-    <div class="form-date">
-
-      <p class="form-hint" id="dob-hint">For example, 31 3 1980</p>
-
-      <div class="form-group form-group-day">
-        <label for="dob-day">Day</label>
-        <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="dob-hint">
+  <div class="form-group">
+    <fieldset>
+      <legend>
+        <span class="form-label-bold">
+          What is your date of birth?
+        </span>
+        <span class="form-hint" id="dob-hint">For example, 31 3 1980</span>
+      </legend>
+      <div class="form-date">
+        <div class="form-group form-group-day">
+          <label class="form-label" for="dob-day">Day</label>
+          <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="dob-hint">
+        </div>
+        <div class="form-group form-group-month">
+          <label class="form-label" for="dob-month">Month</label>
+          <input class="form-control" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+        </div>
+        <div class="form-group form-group-year">
+          <label class="form-label" for="dob-year">Year</label>
+          <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+        </div>
       </div>
-
-      <div class="form-group form-group-month">
-        <label for="dob-month">Month</label>
-        <input class="form-control" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
-      </div>
-
-      <div class="form-group form-group-year">
-        <label for="dob-year">Year</label>
-        <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
-      </div>
-    </div>
-
-  </fieldset>
+    </fieldset>
+  </div>
 </form>

--- a/views/snippets/form_radio_inline_yes_no.html
+++ b/views/snippets/form_radio_inline_yes_no.html
@@ -1,0 +1,32 @@
+<h1 class="heading-medium">
+  Do you yes/no ?
+</h1>
+
+<form>
+  <fieldset class="inline">
+  <legend class="visuallyhidden">Do you yes/no?</legend>
+
+  <div class="form-group">
+
+    <label class="block-label" data-target="yes-and-do-next" for="radio-yes-no-yes">
+      <input id="radio-yes-no-yes" type="radio" name="yes-no-group" value="Yes">
+      Yes
+    </label>
+    <label class="block-label" data-target="no-and-do-next" for="radio-yes-no-no">
+      <input id="radio-yes-no-no" type="radio" name="yes-no-group" value="No">
+      No
+    </label>
+
+    <div class="panel panel-border-narrow js-hidden" id="yes-and-do-next">
+      <label class="form-label" for="yes-next">Yes, this next</label>
+      <input class="form-control" name="yes-next" type="text" id="yes-next">
+    </div>
+    <div class="panel panel-border-narrow js-hidden" id="no-and-do-next">
+      <label class="form-label" for="no-next">No, this next</label>
+      <input class="form-control" name="no-next" type="text" id="no-next">
+    </div>
+
+  </div>
+
+  </fieldset>
+</form>


### PR DESCRIPTION
> This PR sets consistent spacing between form labels and controls (1.), removes additional spacing between block labels - the large hit area radio buttons and checkboxes (2.) and adds more examples to the Form elements example page (3).

------------

1. Set 10px spacing underneath form labels, form hint text and an error message, when it is shown (see screenshot for 3).

2. Remove the spacing underneath block labels when they are inline (screenshots below).

There is currently a 10px bottom margin, to set spacing between block labels.

![before - opened](https://cloud.githubusercontent.com/assets/417754/15424794/72b0ee84-1e7c-11e6-9a20-0a6d84a512a5.png)

The above screenshots shows extra spacing underneath the YES/NO question.
This bottom margin works well when they are stacked, but when they are inline - it should be removed.

There is also extra bottom spacing underneath the toggled content (seen under National Insurance number and Country Name fields).

![after](https://cloud.githubusercontent.com/assets/417754/15424862/c2fa61c2-1e7c-11e6-873c-01de7ec55373.png)

This fixes #224.

3. This is the updated Form elements example page:

![example form elements form elements gov uk elements](https://cloud.githubusercontent.com/assets/417754/15532270/d9356724-2256-11e6-8074-9457c6d15d9b.png)

This fixes  #222, #224.