### PR TITLE
Remove padding from .button class

### DIFF
--- a/public/sass/elements/_buttons.scss
+++ b/public/sass/elements/_buttons.scss
@@ -4,7 +4,6 @@
 .button {
   @include button ($button-colour);
   @include box-sizing (border-box);
-  padding: em(10) em(15) em(5);
   vertical-align: top;
 
   @include media (mobile) {


### PR DESCRIPTION
fixes #228 
This padding should be referenced in GOVUK Frontend Toolkits Button mixin. A separate PR for the toolkit will be submitted.