### PR TITLE
Bump govuk frontend toolkit to 4.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^4.10.0"
+    "govuk_frontend_toolkit": "^4.11.0"
   },
   "devDependencies": {
     "consolidate": "^0.10.0",


### PR DESCRIPTION
# 4.11.0

- Remove the GDS-Logo font-face definition

- Move the @viewport statements to govuk_template. If you
upgrade to this version of govuk_frontend_toolkit and you’re also using
govuk_template you’ll need to upgrade that to at least 0.17.2 to
maintain compatibility with desktop IE10 in snap mode.