### PR TITLE
Use a branch as an alias of the latest release

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -16,5 +16,8 @@ if [ "$MASTER_SHA" == "$HEAD_SHA" ]; then
     echo "Creating new tag: $VERSION_TAG"
     git tag $VERSION_TAG
     git push origin $VERSION_TAG
+
+    # Alias branch for the most recently released tag, for easier diffing
+    git push origin master:latest-release
   fi
 fi


### PR DESCRIPTION
This is to make diffing master against  whatever the latest released version
of the package is. This allows us to easily see what has been committed to
master but not yet released in a consistent way, eg with a diff like:

https://github.com/alphagov/govuk_elements/compare/latest-release...master

This means we don't need to know the latest release is tag `v4.10.0` (for example)

This also lets us track un-released package changes in tools like the deploy-lag-radiator
(https://github.com/dsingleton/deploy-lag-radiator)