### PR TITLE
Fix path for rails and node environments

### DIFF
--- a/public/sass/_govuk-elements.scss
+++ b/public/sass/_govuk-elements.scss
@@ -20,7 +20,7 @@
 @import "design-patterns/breadcrumbs";
 
 // Functions
-// @import "url-helpers";                         // Function to output image-url, or prefixed path (Rails and Compass only)
+@import "url-helpers";                            // Function to output image-url, or prefixed path (Rails and Compass only)
 
 // GOV.UK elements
 

--- a/public/sass/elements/_helpers.scss
+++ b/public/sass/elements/_helpers.scss
@@ -1,8 +1,9 @@
 // Helpers
 // ==========================================================================
 
-// Path to assets for use with file-url() is not already defined
-@if ($path == false) {
+// If image-url is not defined (if we are not in a Rails environment)
+// Set a path to /public/images
+@if not(function-exists(image-url)) {
   $path: "/public/images/";
 }
 


### PR DESCRIPTION
Check to see if the `image-url` function exists

If `image-url` is not defined (if we are not in a Rails environment), set
a path to `/public/images`.

This will fix the issue where elements is overriding `$path` for the [govuk_elements_rails gem](https://github.com/alphagov/govuk_elements_rails). 

cc. @robinwhittleton @dsingleton.