### PR TITLE
Bump the govuk frontend toolkit to 4.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^4.11.0"
+    "govuk_frontend_toolkit": "^4.12.0"
   },
   "devDependencies": {
     "consolidate": "^0.10.0",


### PR DESCRIPTION
This will bring in the updated button padding, will remove the
@font-face declaration for Helvetica, and remove the @viewport
declarations (they’re added back in to govuk_template in 0.17.2).