### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (C) 2014 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.4",
   "description": "GOVUK elements Sass files",
   "repository": "alphagov/govuk_elements",
+  "license": "MIT",
   "engines": {
     "node": ">=4.0.0"
   },


### PR DESCRIPTION
This matches the license used by the govuk_frontend_toolkit_npm
package.json file.

https://github.com/alphagov/govuk_frontend_toolkit_npm/blob/master/packa
ge.json#L13

This fixes the following warning: `npm WARN govuk-elements-sass@1.1.4 No license field.`.