### PR TITLE
Correct guidance: numbered lists should be written as full sentences

### DIFF
--- a/views/guide_typography.html
+++ b/views/guide_typography.html
@@ -134,7 +134,7 @@
 
   <h3 class="heading-medium" id="typography-lists">Lists</h3>
   <p class="text">
-    List items start with a lowercase letter and have no full stop at the end.
+    Bulleted list items start with a lowercase letter and have no full stop at the end. Numbered list items are written as full sentences, so they start with an uppercase letter and have a full stop at the end.
   </p>
 
 <div class="example">

--- a/views/snippets/typography_lists.html
+++ b/views/snippets/typography_lists.html
@@ -1,15 +1,15 @@
+<p>Here is a bulleted list:</p>
 <ul class="list list-bullet">
-  <li>here is a bulleted list</li>
   <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
   <li>vestibulum id ligula porta felis euismod semper</li>
   <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
 </ul>
 
+<p>Here is a numbered list.</p>
 <ol class="list list-number">
-  <li>here is a numbered list</li>
-  <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
-  <li>vestibulum id ligula porta felis euismod semper</li>
-  <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
+  <li>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</li>
+  <li>Vestibulum id ligula porta felis euismod semper.</li>
+  <li>Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</li>
 </ol>
 
 <ul class="list">


### PR DESCRIPTION
What we currently say about lists isn't quite right: numbered lists are written as full sentences. See the style guide: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#bullet-points-steps

... and, for example, this page: https://www.gov.uk/guardians-allowance/how-to-claim

Apologies for any errors in the html.

@gemmaleigh 
