### PR TITLE
Remove abbr underlines in Firefox

### DIFF
--- a/public/sass/elements/_reset.scss
+++ b/public/sass/elements/_reset.scss
@@ -117,3 +117,7 @@ td {
   line-height: inherit;
   font-weight: normal;
 }
+
+abbr[title], acronym[title] {
+  text-decoration: none;
+}


### PR DESCRIPTION
Firefox now supports text-decoration with a dotted underline; consequently (and inline with W3’s recommended default stylesheet) Mozilla updated Firefox’s default stylesheet to style abbrs and acronyms with a dotted text-decoration instead of a dotted border. Our reset stylesheet removes borders from abbr and acronym elements, but doesn’t reset text decoration. The upshot of all this is that every abbr on styled by govuk_elements now has dots underneath it.

This patch simply adds a rule to remove text-decoration from abbr and acronym elements. If text-decoration is being deliberately set anywhere it’ll override this base rule.