### PR TITLE
Fix scss lint errors

### DIFF
--- a/public/sass/elements/_shame.scss
+++ b/public/sass/elements/_shame.scss
@@ -8,6 +8,8 @@
 // If Mozilla add display: revert and remove list-item from summary then this will fall through.
 @-moz-document regexp('.*') {
   details summary:not([tabindex]) {
+    // Allow duplicate properties, override the summary display property
+    // scss-lint:disable DuplicateProperty
     display: list-item;
     display: revert;
   }


### PR DESCRIPTION
Disable the DuplicateProperty property linter in `_shame.scss`, to allow
the second property fall back to the first if not supported.

cc. @robinwhittleton.