### PR TITLE
Make sure the test task fails if scss lint fails

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -157,13 +157,49 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask(
-    'test',
-    'default',
-    function () {
-      grunt.log.writeln('Test that the app runs');
+    'test_default',
+    'Test that the default task runs the app',
+    [
+      'copy:govuk_template',
+      'copy:govuk_assets',
+      'convert_template',
+      'copy:govuk_frontend_toolkit_scss',
+      'copy:govuk_frontend_toolkit_js',
+      'copy:govuk_frontend_toolkit_img',
+      'replace',
+      'sass'
+    ]
+  );
+
+  grunt.registerTask(
+    'lint',
+    'Use govuk-scss-lint to lint the sass files',
+    function() {
+      grunt.task.run('shell', 'lint_message');
     }
   );
 
-  grunt.registerTask('lint', 'shell');
+   grunt.registerTask(
+    'lint_message',
+    'Output a message once linting is complete',
+    function() {
+      grunt.log.write("scss lint is complete, without errors.");
+    }
+  );
 
+  grunt.registerTask(
+    'test',
+    'Lint the Sass files, then check the app runs',
+    function() {
+      grunt.task.run('lint', 'test_default', 'test_message');
+    }
+  );
+
+  grunt.registerTask(
+    'test_message',
+    'Output a message once the tests are complete',
+    function() {
+      grunt.log.write("scss lint is complete and the app runs, without errors.");
+    }
+  );
 };

--- a/public/sass/elements/_reset.scss
+++ b/public/sass/elements/_reset.scss
@@ -118,6 +118,7 @@ td {
   font-weight: normal;
 }
 
-abbr[title], acronym[title] {
+abbr[title],
+acronym[title] {
   text-decoration: none;
 }


### PR DESCRIPTION
When `grunt test` is run, run the lint task first to lint the sass
files.

Then test that the default task works.

This should fail and then pass once #243  is merged.