### PR TITLE
Update guidance for toggled content

### DIFF
--- a/views/guide_form_elements.html
+++ b/views/guide_form_elements.html
@@ -228,25 +228,38 @@
   </h3>
   <ul class="list list-bullet text">
     <li>reveal additional questions, depending on the context</li>
-    <li>insets are used to emphasise this supporting information</li>
+    <li>a left border is used to emphasise this supporting information</li>
   </ul>
-
-  <p>
-    <a href="https://designpatterns.hackpad.com/Conditional-form-fields-powy4GQmLIx" rel="external">
-      Discuss conditional form fields on the design patterns Hackpad
-    </a>
-  </p>
 
   <h4 class="heading-small" id="form-toggle-content-radios">
     Radio buttons
   </h4>
-  <p>
-    Click on "Yes" to see how this works.
-  </p>
+  <div class="text">
+    <p>Choose an option below to see how this works.</p>
+  </div>
+
   <div class="example">
     <form>
       {{> form_inset_radios }}
     </form>
+  </div>
+
+  <div class="panel panel-border-wide text">
+    <p>
+      A grey left hand border is used to visually connect the revealed content with the question above.
+    </p>
+  </div>
+
+<pre>
+<code class="language-markup">
+  <div class="panel panel-border-narrow"></div>
+</code>
+</pre>
+
+  <div class="text">
+    <p>
+      The <a href="/typography/#typography-inset-text">inset text section</a> has more information on where and how to use panels (content with a grey left hand border).
+    </p>
   </div>
 
 <pre>
@@ -254,6 +267,10 @@
   {{> form_inset_radios }}
 </code>
 </pre>
+
+  <p class="text">
+     In the code snippet above, the <code class="language-markup">data-target=""</code> attribute is present on every label, as each option reveals an extra field.
+  </p>
 
   <h4 class="heading-small" id="form-toggle-content-checkboxes">
     Checkboxes
@@ -272,6 +289,12 @@
   {{> form_inset_checkboxes }}
 </code>
 </pre>
+
+  <p>
+    <a href="https://designpatterns.hackpad.com/Conditional-form-fields-powy4GQmLIx" rel="external">
+      Discuss conditional form fields on the design patterns Hackpad
+    </a>
+  </p>
 
   <h3 class="heading-medium" id="examples">Examples</h3>
   <ul class="list list-bullet">

--- a/views/snippets/form_inset_radios.html
+++ b/views/snippets/form_inset_radios.html
@@ -1,27 +1,39 @@
 <h1 class="heading-medium">
-  Do you know their National Insurance number?
+  How do you want to be contacted?
 </h1>
 
 <form>
-  <fieldset class="inline">
+  <fieldset>
 
-    <legend class="visuallyhidden">Do you know their National Insurance number?</legend>
+    <legend class="visuallyhidden">How do you want to be contacted?</legend>
 
     <div class="form-group">
 
-      <label class="block-label" data-target="example-ni-no" for="radio-indent-1">
-        <input id="radio-indent-1" type="radio" name="radio-indent-group" value="Yes">
-        Yes
+      <label class="block-label" data-target="contact-by-email" for="example-contact-by-email">
+        <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Yes">
+        Email
       </label>
+      <div class="panel panel-border-narrow js-hidden" id="contact-by-email">
+        <label class="form-label" for="contact-email">Email address</label>
+        <input class="form-control" name="contact-email" type="text" id="contact-email">
+      </div>
 
-      <label class="block-label" for="radio-indent-2">
-        <input id="radio-indent-2" type="radio" name="radio-indent-group" value="No">
-        No
+      <label class="block-label" data-target="contact-by-phone" for="example-contact-by-phone">
+        <input id="example-contact-by-phone" type="radio" name="radio-contact-group" value="No">
+        Phone
       </label>
+      <div class="panel panel-border-narrow js-hidden" id="contact-by-phone">
+        <label class="form-label" for="contact-phone">Phone number</label>
+        <input class="form-control" name="contact-phone" type="text" id="contact-phone">
+      </div>
 
-      <div class="panel panel-border-narrow js-hidden" id="example-ni-no">
-        <label class="form-label" for="national-insurance">National Insurance number</label>
-        <input class="form-control" name="national-insurance" type="text" id="national-insurance">
+      <label class="block-label" data-target="contact-by-text" for="example-contact-by-text">
+        <input id="example-contact-by-text" type="radio" name="radio-contact-group" value="No">
+        Text message
+      </label>
+      <div class="panel panel-border-narrow js-hidden" id="contact-by-text">
+        <label class="form-label" for="contact-text-message">Mobile phone number</label>
+        <input class="form-control" name="contact-text-message" type="text" id="contact-text-message">
       </div>
 
     </div>


### PR DESCRIPTION
This PR adds more information on how panels can be used and links the "toggled content" section (Conditionally revealing content), to the section in Typography, "Inset text".

1. panels can be used within forms to connect toggled or revealed
content with the question above (in form elements)

2. wide panels can be used to draw attention to important content on
the page (in typograpghy)

![inset text](https://cloud.githubusercontent.com/assets/417754/15743293/462fe280-28bc-11e6-8fb4-ac476b8a8662.png)

3. add a link from the toggled content section, to the inset text
section.

4. update the conditionally revealed content example to show the "how would you like to be contacted?" example.

![how do you want to be contacted](https://cloud.githubusercontent.com/assets/417754/15532368/4b688cb8-2257-11e6-9fdb-abc9b1dd68f8.png)

This fixes #211 and #179.
