### PR TITLE
Fix legend text wrapping in IE.

### DIFF
--- a/public/sass/elements/_reset.scss
+++ b/public/sass/elements/_reset.scss
@@ -122,3 +122,15 @@ abbr[title],
 acronym[title] {
   text-decoration: none;
 }
+
+// Legend --------------------------------
+// Fix legend text wrapping in Edge and IE
+// ---------------------------------------
+// 1. IE9-11 & Edge 12-13
+// 2. IE8-11
+
+legend {
+  box-sizing: border-box; // [1]
+  max-width: 100%;        // [1]
+  display: table;         // [2]
+}


### PR DESCRIPTION
IE9-11 and Edge 12-13 can be completely fixed using box-sizing: border-box; max-width: 100%, but IE8 will still experience some issues as “the min-width property applies to content-box even if box-sizing is set to border-box” cite.
IE8-11 can be fixed using the 456 Berea St fix display: table; white-space: normal, but this fix will not work at all for Edge 12-13.