### PR TITLE
Amend National Insurance number example to match other examples

### DIFF
--- a/views/snippets/form_hint_text.html
+++ b/views/snippets/form_hint_text.html
@@ -1,5 +1,5 @@
 <label class="form-label" for="ni-number">
   National Insurance number
-  <span class="form-hint">It'll be on your last payslip. For example, JH 21 90 0A.</span>
+  <span class="form-hint">It'll be on your last payslip. For example, VO 12 34 56 D.</span>
 </label>
 <input class="form-control" id="ni-number" type="text">


### PR DESCRIPTION
The example NI number doesn't [match the others used elsewhere](https://github.com/alphagov/govuk_elements/search?utf8=%E2%9C%93&q=VO+12+34+56+D).

Amend this example to be the same as the others.

This fixes #251.