### PR TITLE
Update GOV.UK elements to use Express 4

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 var express = require('express'),
+    bodyParser = require('body-parser'),
     routes = require(__dirname + '/routes.js'),
     app = express(),
     port = (process.env.PORT || 3000);
@@ -12,8 +13,12 @@ app.set('views', __dirname + '/views');
 // Middleware to serve static assets
 app.use('/public', express.static(__dirname + '/public'));
 app.use('/public', express.static(__dirname + '/govuk_modules/public'));
-app.use(express.json());       // to support JSON-encoded bodies
-app.use(express.urlencoded()); // to support URL-encoded bodies
+
+// Support for parsing data in POSTs
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({
+	extended: true
+}));
 
 // routes (found in routes.js)
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "govuk_frontend_toolkit": "^4.12.0"
   },
   "devDependencies": {
+    "body-parser": "^1.14.1",
     "consolidate": "^0.10.0",
     "express": "^3.18.4",
     "express-writer": "0.0.4",


### PR DESCRIPTION
This was [updated for the prototype kit in October 2015](https://github.com/alphagov/govuk_prototype_kit/pull/32).

This one is to be merged first. cc. @joelanman, @robinwhittleton.

