### PR TITLE
Fix default text for global cookie message

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -1,0 +1,10 @@
+// Use this file to change prototype configuration.
+
+// Note: this config can be overridden using environment variables (eg on heroku)
+
+module.exports = {
+
+  // Cookie warning
+  cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies" title="Find out more about cookies">Find out more about cookies</a>'
+
+};

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -7,6 +7,10 @@
   {% include "includes/snippets_scripts.html" %}
 {% endblock %}
 
+{% block cookie_message %}
+  <p>{{cookieText | safe }}</p>
+{% endblock %}
+
 {% block proposition_header %}
   {% include "includes/service_manual_navigation.html" %}
 {% endblock %}

--- a/app/views/layout_example.html
+++ b/app/views/layout_example.html
@@ -32,6 +32,10 @@
   {% include "includes/elements_tracking.html" %}
 {% endblock %}
 
+{% block cookie_message %}
+  <p>{{cookieText | safe }}</p>
+{% endblock %}
+
 {% block proposition_header %}
   {% include "includes/service_manual_navigation.html" %}
 {% endblock %}

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 var bodyParser = require('body-parser'),
+    config = require(__dirname + '/app/config.js'),
     express = require('express'),
     nunjucks = require('express-nunjucks'),
     path = require('path'),
@@ -31,6 +32,12 @@ app.use(bodyParser.urlencoded({
 // send assetPath to all views
 app.use(function (req, res, next) {
   res.locals.asset_path="/public/";
+  next();
+});
+
+// Add variables that are available in all views
+app.use(function (req, res, next) {
+  res.locals.cookieText=config.cookieText;
   next();
 });
 


### PR DESCRIPTION
This pull request is another step towards getting the GOV.UK elements app to work in the same way as the prototype kit. 🎆 

Add a config file, ensure that server.js uses the config file, then define a cookieText variable and pass the cookieText variable to all views. 

Also add the missing blocks for the cookie message in both layout files.

Screenshot before (empty blue cookie banner at the top of the screen):

![gov uk elements - before](https://cloud.githubusercontent.com/assets/417754/16171661/845a327e-356c-11e6-84a9-16ad97fa4d06.png)

Screenshot after (cookie banner with text at the top of the screen):

![gov uk elements - after](https://cloud.githubusercontent.com/assets/417754/16171660/7da7fd58-356c-11e6-9a97-f18b4d4bbe76.png)
