### PR TITLE
Bump govuk frontend toolkit to 4.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^4.12.0"
+    "govuk_frontend_toolkit": "^4.13.0"
   },
   "devDependencies": {
     "body-parser": "^1.14.1",


### PR DESCRIPTION
# 4.13.0

- Make headings block-level by default (PR #200). If you are styling
elements you want to be inline with heading includes, you’ll need to
explicitly make them inline in your CSS.