### PR TITLE
Remove the outline from the main content area

### DIFF
--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -4,13 +4,6 @@
 // Elements page styles
 // ==========================================================================
 
-// Pressing enter when focus is on the skiplink sets focus on the #content area
-// Remove the blue outline
-
-#content {
-  outline: none;
-}
-
 // These are example styles, used only for the elements pages
 
 .elements-index {

--- a/public/sass/elements/_layout.scss
+++ b/public/sass/elements/_layout.scss
@@ -14,6 +14,9 @@
   @include media(desktop) {
     padding-bottom: $gutter * 3;
   }
+  // Pressing enter when focus is on the skiplink sets focus on the #content area
+  // Remove the blue outline
+  outline: none;
 }
 
 


### PR DESCRIPTION
Pressing enter when focus is on the skiplink sets focus on the #content
area, remove the blue outline which appears.

This was previously set in the elements-page stylesheet, so it wasn’t
being applied to all pages (this is the stylesheet for styling the page furniture and isn't included in the example pages).

