### PR TITLE
Move the Google Tag manager script

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -2,9 +2,12 @@
 
 {% block head %}
   {% include "includes/elements_head.html" %}
-  {% include "includes/elements_tracking.html" %}
   {% include "includes/snippets_head.html" %}
   {% include "includes/snippets_scripts.html" %}
+{% endblock %}
+
+{% block body_start %}
+  {% include "includes/elements_tracking.html" %}
 {% endblock %}
 
 {% block cookie_message %}

--- a/app/views/layout_example.html
+++ b/app/views/layout_example.html
@@ -29,6 +29,9 @@
      /* End: Styles for this example page */
 
   </style>
+{% endblock %}
+
+{% block body_start %}
   {% include "includes/elements_tracking.html" %}
 {% endblock %}
 


### PR DESCRIPTION
Create a new `body_start` block to insert the Google Tag Manager script
inside the body of the page.

This also fixes the validation errors caused by the Google Tag Manager
script being inserted in the head of the page, rather than in the body.
