### PR TITLE
Remove button role from start link

### DIFF
--- a/app/views/snippets/buttons_button_start_now.html
+++ b/app/views/snippets/buttons_button_start_now.html
@@ -1,1 +1,1 @@
-<a class="button button-start" href="#" role="button">Start now</a>
+<a class="button button-start" href="#">Start now</a>


### PR DESCRIPTION
By keeping `role="button"` on start-button links:

1. JAWS announces "*Continue. Button. To activate press space bar*".
2. VoiceOver (Mac) via Chrome announces "*You are currently on a button. To click this button, press Control-Option-Space*".

Unfortunately:

* Pressing space does nothing in older versions of JAWS.
* Pressing Control-Option-Space does nothing in Chrome.

Why? A `keyup` event listener is still required to handle the space key. This will prevent some assistive-device users from starting the service.

I'd advise removing the `role` as this is probably a mistake.

Thanks