### PR TITLE
Remove external link styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can pick and chosoe partials from the govuk-elements-sass package.
     @import "conditionals";                           // Media query mixin
     @import "device-pixels";                          // Retina image mixin
     @import "grid_layout";                            // Basic grid layout mixin
-    @import "typography";                             // Core bold and heading mixins, also external links
+    @import "typography";                             // Core bold and heading mixins
     @import "shims";                                  // Inline block mixin, clearfix placeholder
 
     // Mixins to generate components (chunks of UI)

--- a/public/sass/elements/_govuk-template-base.scss
+++ b/public/sass/elements/_govuk-template-base.scss
@@ -122,25 +122,6 @@ a:active {
   color: $link-active-colour;
 }
 
-// External link styles
-// These are currently deprecated and are liable to be removed in a future release.
-// If your service has user research that indicates that external links are useful
-// (or not) then we’d like to hear from you either on Slack,
-// digital-service-designers or opening an issue.
-a[rel="external"] {
-  @include external-link-default;
-  @include external-link-16;
-
-  @include media(tablet) {
-    @include external-link-19;
-  }
-}
-
-.external-link {
-  @include external-link-12-no-hover;
-  @include external-link-heading;
-}
-
 // Set focus styles
 a {
   // Allow RGBA here, this line has been copied from govuk_template


### PR DESCRIPTION
[govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit) is [potentially removing external link styles](https://github.com/alphagov/govuk_frontend_toolkit/pull/293). If that happens then we’ll want to remove them from govuk_elements as well.