### PR TITLE
Bump govuk frontend toolkit to 4.14.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
- - "0.10"
- - "4.0"
- - "4"
+ - "4.4.7"
 before_install:
 - npm install -g grunt-cli
 install:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "alphagov/govuk_elements",
   "license": "MIT",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.4.7"
   },
   "dependencies": {
     "govuk_frontend_toolkit": "^4.14.1"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^4.13.0"
+    "govuk_frontend_toolkit": "^4.14.1"
   },
   "devDependencies": {
     "body-parser": "^1.14.1",


### PR DESCRIPTION
# 4.14.1

- Fix tabular number sizing in Firefox ([PR
#301](https://github.com/alphagov/govuk_frontend_toolkit/pull/301))

# 4.14.0

- Allow use of multiple GA customDimensionIndex. See [this
section](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/
docs/javascript.md#using-google-custom-dimensions-with-your-own-statisti
cal-model) of the documentation for more information.
- Configurable duration (in days) for AB Test cookie. See [this
section](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/
docs/javascript.md#multivariate-test-framework) of the documentation
for more information.
- Allow base scripts to run within a module loader. See [this
PR](https://github.com/alphagov/govuk_frontend_toolkit/pull/290) for
more information.