### PR TITLE
Force push latest release tracking branch

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -18,6 +18,6 @@ if [ "$MASTER_SHA" == "$HEAD_SHA" ]; then
     git push origin $VERSION_TAG
 
     # Alias branch for the most recently released tag, for easier diffing
-    git push origin master:latest-release
+    git push -f origin master:latest-release
   fi
 fi


### PR DESCRIPTION
Added in https://github.com/alphagov/govuk_elements/pull/232

The push failed in the most recent release/build:

```
To git@github.com:alphagov/govuk_elements.git
 ! [rejected]        master -> latest-release (non-fast-forward)
error: failed to push some refs to 'git@github.com:alphagov/govuk_elements.git'
hint: Updates were rejected because a pushed branch tip is behind its remote
hint: counterpart. Check out this branch and integrate the remote changes
hint: (e.g. 'git pull ...') before pushing again.
```

Given it's just for tracking, we can safely force push.