### PR TITLE
Bump govuk frontend toolkit to 4.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=4.4.7"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^4.14.1"
+    "govuk_frontend_toolkit": "^4.15.0"
   },
   "devDependencies": {
     "body-parser": "^1.14.1",


### PR DESCRIPTION
Use version [4.15.0](https://github.com/alphagov/govuk_frontend_toolkit/commit/620c7fdb1eca75
cfb7a8c076cafcf50852a85008) of the GOV.UK frontend toolkit.

- Add support for Google Analytics fieldsObject

- anchor-buttons.js: normalise keyboard behaviour between buttons and
links with a button role 