### PR TITLE
Include the shim-links-with-button-role.js script from the frontend toolkit

### DIFF
--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -3,6 +3,7 @@
 <!-- govuk_frontend_toolkit js -->
 <script src="/public/javascripts/vendor/polyfills/bind.js"></script>
 <script src="/public/javascripts/govuk/selection-buttons.js"></script>
+<script src="/public/javascripts/govuk/shim-links-with-button-role.js"></script>
 
 <!-- govuk_elements js -->
 <script src="/public/javascripts/vendor/details.polyfill.js"></script>

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -122,6 +122,10 @@ $(document).ready(function() {
   var $blockLabels = $(".block-label input[type='radio'], .block-label input[type='checkbox']");
   new GOVUK.SelectionButtons($blockLabels);
 
+  // Use GOV.UK shim-links-with-button-role.js to trigger a link styled to look like a button,
+  // with role="button" when the space key is pressed.
+  GOVUK.shimLinksWithButtonRole.init();
+
   // Details/summary polyfill
   // See /javascripts/vendor/details.polyfill.js
 


### PR DESCRIPTION
Include a script from the govuk frontend toolkit to shim anchors with
`role="button"` to be 'clicked' via the space key.

For context, here is the PR adding this script to the govuk_frontend_toolkit.
https://github.com/alphagov/govuk_frontend_toolkit/pull/310