### PR TITLE
Add `!default` flag to image `$path`

### DIFF
--- a/public/sass/elements/_helpers.scss
+++ b/public/sass/elements/_helpers.scss
@@ -4,7 +4,7 @@
 // If image-url is not defined (if we are not in a Rails environment)
 // Set a path to /public/images
 @if not(function-exists(image-url)) {
-  $path: "/public/images/";
+  $path: "/public/images/" !default;
 }
 
 // Return ems from a pixel value


### PR DESCRIPTION
The `!default` flag will only update the value of the variable when it has not been set. Adding this flag makes it easier to set when including elements modules in project specific files.