### PR TITLE
Form validation patterns for conditionally revealing content

### DIFF
--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -540,6 +540,11 @@
       </div>
 
       <div class="form-section">
+        <!-- Radio buttons (select one option to reveal content) with error -->
+        {% include "snippets/form_inset_radios_show_errors.html" %}
+      </div>
+
+      <div class="form-section">
         <!-- Checkboxes (select more than option to reveal content) -->
         {% include "snippets/form_inset_checkboxes.html" %}
       </div>

--- a/app/views/snippets/form_inset_radios_show_errors.html
+++ b/app/views/snippets/form_inset_radios_show_errors.html
@@ -1,0 +1,96 @@
+<h1 class="heading-medium" id="example-conditional-errors">
+  Your income
+</h1>
+
+<form>
+  <div class="form-group error">
+
+    <fieldset>
+
+      <legend>
+        <span class="form-label-bold">How often do you get paid?</span>
+        <span class="error-message">Choose an answer</span>
+      </legend>
+
+      <label class="block-label" data-target="paid-weekly" for="example-paid-weekly">
+        <input type="radio" name="radio-income-group" value="Yes" id="example-paid-weekly">
+        Weekly
+      </label>
+      <div class="panel panel-border-narrow js-hidden" id="paid-weekly">
+        <label class="form-label" for="example-paid-weekly-pay">Weekly take home pay after tax</label>
+        <input class="form-control" name="example-paid-weekly-pay" type="text" id="example-paid-weekly-pay">
+      </div>
+
+      <label class="block-label" data-target="paid-fortnightly" for="example-paid-fortnightly">
+        <input type="radio" name="radio-income-group" value="Yes" id="example-paid-fortnightly">
+        Fortnightly
+      </label>
+      <div class="panel panel-border-narrow js-hidden" id="paid-fortnightly">
+        <label class="form-label" for="example-paid-fortnightly-pay">Weekly take home pay after tax</label>
+        <input class="form-control" name="example-paid-fortnightly-pay" type="text" id="example-paid-fortnightly-pay">
+      </div>
+
+      <label class="block-label" data-target="paid-monthly" for="example-paid-monthly">
+        <input type="radio" name="radio-income-group" value="Yes" id="example-paid-monthly">
+        Monthly
+      </label>
+      <div class="panel panel-border-narrow js-hidden" id="paid-monthly">
+        <label class="form-label" for="example-paid-monthly-pay">Monthly take home pay after tax</label>
+        <input class="form-control" name="example-paid-monthly-pay" type="text" id="example-paid-monthly-pay">
+      </div>
+
+    </fieldset>
+  </div>
+</form>
+
+<h1 class="heading-medium" id="example-conditional-errors-2">
+  Your income
+</h1>
+
+<form>
+  <div class="form-group">
+
+    <fieldset>
+
+      <legend>
+        <span class="form-label-bold">How often do you get paid?</span>
+      </legend>
+
+      <label class="block-label" data-target="paid-weekly-2" for="example-paid-weekly-2">
+        <input type="radio" name="radio-income-group-2" value="Yes" id="example-paid-weekly-2">
+        Weekly
+      </label>
+      <div class="panel panel-border-narrow js-hidden" id="paid-weekly-2">
+        <label class="form-label" for="example-paid-weekly-pay-2">Weekly take home pay after tax</label>
+        <input class="form-control" name="example-paid-weekly-pay-2" type="text" id="example-paid-weekly-pay-2">
+      </div>
+
+      <label class="block-label" data-target="paid-fortnightly-2" for="example-paid-fortnightly-2">
+        <input type="radio" name="radio-income-group-2" value="Yes" id="example-paid-fortnightly-2">
+        Fortnightly
+      </label>
+      <div class="panel panel-border-narrow js-hidden" id="paid-fortnightly-2">
+        <label class="form-label" for="example-paid-fortnightly-pay-2">Weekly take home pay after tax</label>
+        <input class="form-control" name="example-paid-fortnightly-pay-2" type="text" id="example-paid-fortnightly-pay-2">
+      </div>
+
+      <label class="block-label" data-target="paid-monthly-2" for="example-paid-monthly-2">
+        <input type="radio" name="radio-income-group-2" value="Yes" id="example-paid-monthly-2" checked="checked">
+        Monthly
+      </label>
+      <div class="panel panel-border-narrow panel-with-error" id="paid-monthly-2">
+        <div class="form-group error">
+          <label class="form-label" for="example-paid-monthly-pay-2">
+            Monthly take home pay (after tax)?
+            <span class="error-message">
+              Error message about monthly pay goes here
+            </span>
+          </label>
+          <input class="form-control" name="example-paid-monthly-pay-2" type="text" id="example-paid-monthly-pay-2">
+        </div>
+      </div>
+
+    </fieldset>
+  </div>
+</form>
+

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -9,7 +9,8 @@
   margin-right: 15px;
 
   // Form inputs should have a red border
-  .form-control {
+  // Add a red border to .form-controls that are direct descendants
+  > .form-control {
     border: 4px solid $error-colour;
   }
 

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -1,30 +1,18 @@
 // Form validation
 // ==========================================================================
 
-// Using the classname .error as it's shorter than .validation and easier to type!
+// Use error to add a red border to the left of a .form-group
 .error {
 
-  // Ensure the .error class is applied to .form-group, otherwide box-sizing(border-box) will need to be used
+  // Ensure the .error class is applied to .form-group, otherwise box-sizing(border-box) will need to be used
   // @include box-sizing(border-box);
   margin-right: 15px;
-
-  // Error messages should be red and bold
-  .error-message {
-    color: $error-colour;
-    font-weight: bold;
-  }
 
   // Form inputs should have a red border
   .form-control {
     border: 4px solid $error-colour;
   }
 
-}
-
-.error,
-.error-summary {
-
-  // Add a red border to the left of the field
   border-left: 4px solid $error-colour;
   padding-left: 10px;
 
@@ -32,10 +20,14 @@
     border-left: 5px solid $error-colour;
     padding-left: $gutter-half;
   }
+
 }
 
+// Error messages should be red and bold
 .error-message {
-  @include core-19;
+  @include bold-19;
+  color: $error-colour;
+
 
   display: block;
   clear: both;


### PR DESCRIPTION
This PR adds two more examples to the form elements example page.

This fixes the issue with inputs using the `.form-control` class inheriting a red border, when a parent `.error` class is used.

Before:

![2 example form elements form elements gov uk elements](https://cloud.githubusercontent.com/assets/417754/17769696/ccf2dc1c-6531-11e6-845e-2575b2fbb3e5.png)

After:

![example form elements form elements gov uk elements](https://cloud.githubusercontent.com/assets/417754/17774205/6075b3ca-654a-11e6-963c-53cd517ec718.png)

There is an example of this working here:
http://govuk-elements-test.herokuapp.com/form-elements/example-form-elements/#example-conditional-errors

cc. @trevorsaint, @gavboulton, @robinwhittleton. 

This fixes #249.