### PR TITLE
Centre text on full width buttons

### DIFF
--- a/public/sass/elements/_buttons.scss
+++ b/public/sass/elements/_buttons.scss
@@ -8,6 +8,7 @@
 
   @include media (mobile) {
     width: 100%;
+    text-align: center;
   }
 }
 


### PR DESCRIPTION
Text on native input button/submit inputs is normally centred. When links are dressed as buttons the text is left aligned. This is okay on tablet views and above as buttons are only as wide as they need to be but on mobile views, buttons are full width. Centre the text for full width buttons for consistency.

Before:
![rsz_button-left](https://cloud.githubusercontent.com/assets/3900826/17852875/738414c4-6861-11e6-91d4-5348bd4d887f.png)

After:
![rsz_button-centre](https://cloud.githubusercontent.com/assets/3900826/17852887/7c998710-6861-11e6-9bb3-f93708cf1fed.png)
