### PR TITLE
Add a deprecation warning for external links

### DIFF
--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -114,6 +114,16 @@
 </pre>
 
   <h3 class="heading-medium" id="typography-links">Links</h3>
+
+  <p class="notice">
+    <i class="icon icon-important">
+      <span class="visuallyhidden">Warning</span>
+    </i>
+    <strong class="bold-small">
+      External link styles are deprecated and are liable to be removed in a future release. If your service has user research that indicates that external links are useful (or not) then we’d like to hear from you either on Slack, <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/digital-service-designers">digital-service-designers</a> or <a href="https://github.com/alphagov/govuk_elements/issues/new">opening an issue</a>.
+    </strong>
+  </p>
+
   <ul class="list list-bullet text">
     <li>links within body copy should be blue and underlined</li>
     <li>links without surrounding text should not have a full stop at the end</li>

--- a/public/sass/elements/_govuk-template-base.scss
+++ b/public/sass/elements/_govuk-template-base.scss
@@ -125,6 +125,10 @@ a:active {
 }
 
 // External link styles
+// These are currently deprecated and are liable to be removed in a future release.
+// If your service has user research that indicates that external links are useful
+// (or not) then we’d like to hear from you either on Slack,
+// digital-service-designers or opening an issue.
 a[rel="external"] {
   @include external-link-default;
   @include external-link-16;


### PR DESCRIPTION
We’d potentially like to remove external link styling, but first we want to see if anyone else has any input into whether they are useful or not. This adds a deprecation warning. I’ll also add a note to the changelog when we release the next version, and publicise it at that point.