### PR TITLE
Add a new section on external links

### DIFF
--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -133,14 +133,15 @@
 </code>
 </pre>
 
-  <h3 class="heading-medium" id="typography-external-links">External links</h3>
+  <h4 class="heading-medium" id="typography-external-links">External links</h4>
 
   <div class="panel panel-border-wide text">
-   <p>
-    <strong class="bold-small">
-       External link styles are deprecated and are liable to be removed in a future release. If your service has user research that indicates that external links are useful (or not) then we’d like to hear from you either on Slack, <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/digital-service-designers">digital-service-designers</a> or <a href="https://github.com/alphagov/govuk_elements/issues/new">opening an issue</a>.
-     </strong>
-   </p>
+    <p>
+      <strong class="bold-small">External link styles are deprecated and are liable to be removed in a future release.</strong>
+    </p>
+    <p>
+      If your service has user research that indicates that external links are useful (or not) then we’d like to hear from you either on Slack, <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/digital-service-designers">digital-service-designers</a> or <a href="https://github.com/alphagov/govuk_elements/issues/new">opening an issue</a>.
+    </p>
   </div>
 
   <div class="example">

--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -115,30 +115,43 @@
 
   <h3 class="heading-medium" id="typography-links">Links</h3>
 
-  <p class="notice">
-    <i class="icon icon-important">
-      <span class="visuallyhidden">Warning</span>
-    </i>
-    <strong class="bold-small">
-      External link styles are deprecated and are liable to be removed in a future release. If your service has user research that indicates that external links are useful (or not) then we’d like to hear from you either on Slack, <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/digital-service-designers">digital-service-designers</a> or <a href="https://github.com/alphagov/govuk_elements/issues/new">opening an issue</a>.
-    </strong>
-  </p>
-
   <ul class="list list-bullet text">
     <li>links within body copy should be blue and underlined</li>
     <li>links without surrounding text should not have a full stop at the end</li>
     <li>link colours can be found in the <a href="/colour">colour palette</a></li>
   </ul>
 
-<div class="example">
-  <div class="text">
-    {% include "snippets/typography_links.html" %}
+  <div class="example">
+    <div class="text">
+      {% include "snippets/typography_links.html" %}
+    </div>
   </div>
-</div>
 
 <pre>
 <code class="language-markup">
   {% include "snippets/encoded/typography_links.html" %}
+</code>
+</pre>
+
+  <h3 class="heading-medium" id="typography-external-links">External links</h3>
+
+  <div class="panel panel-border-wide text">
+   <p>
+    <strong class="bold-small">
+       External link styles are deprecated and are liable to be removed in a future release. If your service has user research that indicates that external links are useful (or not) then we’d like to hear from you either on Slack, <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/digital-service-designers">digital-service-designers</a> or <a href="https://github.com/alphagov/govuk_elements/issues/new">opening an issue</a>.
+     </strong>
+   </p>
+  </div>
+
+  <div class="example">
+    <div class="text">
+      {% include "snippets/typography_external_links.html" %}
+    </div>
+  </div>
+
+<pre>
+<code class="language-markup">
+  {% include "snippets/encoded/typography_external_links.html" %}
 </code>
 </pre>
 

--- a/app/views/snippets/typography_external_links.html
+++ b/app/views/snippets/typography_external_links.html
@@ -1,0 +1,3 @@
+<p>
+  <a href="#" rel="external">A 19px body copy external link.</a> Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
+</p>

--- a/app/views/snippets/typography_links.html
+++ b/app/views/snippets/typography_links.html
@@ -6,9 +6,4 @@
   <a href="#">A 19px body copy link</a>. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
 </p>
 
-<p>
-  <a href="#" rel="external">A 19px body copy external link.</a> Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
-</p>
-
-
 <a href="#" class="link-back">Back</a>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

## What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This pull request fixes the layout of the "Links" section (see screenshot).

## What does it do?
<!--- Describe your changes -->

This pull request adds a new section for external links. This is to draw attention to external link styles, which have been deprecated. 

It uses the correct pattern to highlight information on a page and creates a new snippet for external links (so it is clear how these differ from links in body copy).

## Screenshots (if appropriate):

Before:

![typography gov uk elements](https://cloud.githubusercontent.com/assets/417754/17968587/87526788-6ac5-11e6-8f0e-8794c06c5914.png)

After:

![typography gov uk elements](https://cloud.githubusercontent.com/assets/417754/18002242/85b3e91a-6b7e-11e6-8692-bbc2538bbef6.png)



## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.