### PR TITLE
Custom radios / checkboxes

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -145,9 +145,14 @@ textarea {
   @include core-19;
   width: 100%;
 
-  padding: 4px;
-  background-color: $white;
-  border: 2px solid $grey-1;
+  padding: 5px 4px 4px;
+  background-color: transparent;
+  border: 2px solid;
+  border-color: currentColor;
+
+  @include ie-lte(8) {
+    border-color: $text-colour;
+  }
 
   // TODO: Remove 50% width set for tablet and up
   // !! BREAKING CHANGE !!

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -148,11 +148,6 @@ textarea {
   padding: 5px 4px 4px;
   background-color: transparent;
   border: 2px solid;
-  border-color: currentColor;
-
-  @include ie-lte(8) {
-    border-color: $text-colour;
-  }
 
   // TODO: Remove 50% width set for tablet and up
   // !! BREAKING CHANGE !!

--- a/public/sass/elements/_helpers.scss
+++ b/public/sass/elements/_helpers.scss
@@ -22,8 +22,7 @@
 }
 
 // Hide, but not for screenreaders
-.visually-hidden,
-.visuallyhidden {
+@mixin visually-hidden {
   position: absolute;
   overflow: hidden;
   clip: rect(0 0 0 0);
@@ -32,4 +31,9 @@
   margin: -1px;
   padding: 0;
   border: 0;
+}
+
+.visually-hidden,
+.visuallyhidden {
+  @include visually-hidden;
 }

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -84,6 +84,8 @@
       position: absolute;
       top: 10px;
       left: 8px;
+      -moz-transform: rotate(-45deg); // Firefox 15 compatibility
+      -o-transform: rotate(-45deg); // Opera 12.0 compatibility
       -webkit-transform: rotate(-45deg); // Safari 8 compatibility
       -ms-transform: rotate(-45deg); // IE9 compatibility
       transform: rotate(-45deg);

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -96,6 +96,12 @@
       &:hover::after {
         @include opacity(.15);
       }
+      // hide the hover state in iOS / mobile Chrome
+      @media (hover: none) {
+        &:hover::after {
+          opacity: 0;
+        }
+      }
     }
 
     // Focused state

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -9,13 +9,15 @@
   clear: left;
   position: relative;
 
-  padding: (7px $gutter-one-third 7px $gutter * 1.5);
-  margin-bottom: $gutter-half;
+  padding: (8px $gutter-one-third 9px 50px);
+  margin-bottom: $gutter-one-third;
 
   cursor: pointer; // Encourage clicking on block labels
 
   @include media(tablet) {
     float: left;
+    padding-top: 7px;
+    padding-bottom: 7px;
     // width: 25%; - Test : check that text within labels will wrap
   }
 
@@ -25,8 +27,8 @@
     cursor: pointer;
     left: 0;
     top: 0;
-    width: 37px;
-    height: 37px;
+    width: 38px;
+    height: 38px;
 
     // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements.
     @if ($is-ie == false) or ($ie-version == 9) {
@@ -42,8 +44,8 @@
       border: 2px solid currentColor;
       border-radius: 50%;
       background: transparent;
-      width: 33px;
-      height: 33px;
+      width: 34px;
+      height: 34px;
       position: absolute;
       top: 0;
       left: 0;
@@ -53,11 +55,11 @@
       content: "";
       border-radius: 50%;
       background: transparent;
-      width: 23px;
-      height: 23px;
+      width: 20px;
+      height: 20px;
       position: absolute;
-      top: 7px;
-      left: 7px;
+      top: 9px;
+      left: 9px;
     }
 
     &.selection-button-radio.selected::after {
@@ -68,8 +70,8 @@
       content: "";
       border: 2px solid currentColor;
       background: transparent;
-      width: 33px;
-      height: 33px;
+      width: 34px;
+      height: 34px;
       position: absolute;
       top: 0;
       left: 0;
@@ -78,13 +80,13 @@
     &.selection-button-checkbox::after {
       content: "";
       border: solid transparent;
-      border-width: 0 0 4px 4px;
+      border-width: 0 0 5px 5px;
       background: transparent;
-      width: 15px;
-      height: 9px;
+      width: 17px;
+      height: 7px;
       position: absolute;
-      top: 9px;
-      left: 9px;
+      top: 10px;
+      left: 8px;
       -webkit-transform: rotate(-45deg); // Safari 8 compatibility
       -ms-transform: rotate(-45deg); // IE9 compatibility
       transform: rotate(-45deg);
@@ -107,7 +109,7 @@
 
   @include media (tablet) {
     margin-bottom: 0;
-    margin-right: $gutter-half;
+    margin-right: $gutter;
   }
 }
 
@@ -118,7 +120,7 @@
 
 // Add focus to block labels inputs
 .js-enabled label.focused::before {
-  @include box-shadow(0 0 0 3px $focus-colour);
+  @include box-shadow(0 0 0 5px $focus-colour);
 }
 
 @include ie-lte(8) {

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -54,16 +54,13 @@
     &.selection-button-radio::after {
       content: "";
       border-radius: 50%;
-      background: transparent;
+      background: currentColor;
       width: 20px;
       height: 20px;
       position: absolute;
       top: 9px;
       left: 9px;
-    }
-
-    &.selection-button-radio.selected::after {
-      background: currentColor;
+      @include opacity(0);
     }
 
     &.selection-button-checkbox::before {
@@ -79,7 +76,7 @@
 
     &.selection-button-checkbox::after {
       content: "";
-      border: solid transparent;
+      border: solid currentColor;
       border-width: 0 0 5px 5px;
       background: transparent;
       width: 17px;
@@ -90,10 +87,23 @@
       -webkit-transform: rotate(-45deg); // Safari 8 compatibility
       -ms-transform: rotate(-45deg); // IE9 compatibility
       transform: rotate(-45deg);
+      @include opacity(0);
     }
 
-    &.selection-button-checkbox.selected::after {
-      border-color: currentColor;
+    // Hover state
+    &.selection-button-radio,
+    &.selection-button-checkbox {
+      &:hover::after {
+        @include opacity(.15);
+      }
+    }
+
+    // Selected state
+    &.selection-button-radio,
+    &.selection-button-checkbox {
+      &.selected::after {
+        @include opacity(1);
+      }
     }
   }
 

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -49,16 +49,19 @@
       left: 0;
     }
 
-    &.selection-button-radio.selected::after {
+    &.selection-button-radio::after {
       content: "";
-      border: 2px solid currentColor;
       border-radius: 50%;
-      background: currentColor;
-      width: 19px;
-      height: 19px;
+      background: transparent;
+      width: 23px;
+      height: 23px;
       position: absolute;
       top: 7px;
       left: 7px;
+    }
+
+    &.selection-button-radio.selected::after {
+      background: currentColor;
     }
 
     &.selection-button-checkbox::before {
@@ -72,9 +75,9 @@
       left: 0;
     }
 
-    &.selection-button-checkbox.selected::after {
+    &.selection-button-checkbox::after {
       content: "";
-      border: solid currentColor;
+      border: solid transparent;
       border-width: 0 0 4px 4px;
       background: transparent;
       width: 15px;
@@ -85,6 +88,10 @@
       -webkit-transform: rotate(-45deg); // Safari 8 compatibility
       -ms-transform: rotate(-45deg); // IE9 compatibility
       transform: rotate(-45deg);
+    }
+
+    &.selection-button-checkbox.selected::after {
+      border-color: currentColor;
     }
   }
 

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -41,7 +41,7 @@
   .js-enabled & {
     &.selection-button-radio::before {
       content: "";
-      border: 2px solid currentColor;
+      border: 2px solid;
       border-radius: 50%;
       background: transparent;
       width: 34px;
@@ -65,7 +65,7 @@
 
     &.selection-button-checkbox::before {
       content: "";
-      border: 2px solid currentColor;
+      border: 2px solid;
       background: transparent;
       width: 34px;
       height: 34px;
@@ -76,7 +76,7 @@
 
     &.selection-button-checkbox::after {
       content: "";
-      border: solid currentColor;
+      border: solid;
       border-width: 0 0 5px 5px;
       background: transparent;
       width: 17px;

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -92,20 +92,6 @@
       @include opacity(0);
     }
 
-    // Hover state
-    &.selection-button-radio,
-    &.selection-button-checkbox {
-      &:hover::after {
-        @include opacity(.15);
-      }
-      // hide the hover state in iOS / mobile Chrome
-      @media (hover: none) {
-        &:hover::after {
-          opacity: 0;
-        }
-      }
-    }
-
     // Focused state
     &.selection-button-radio,
     &.selection-button-checkbox {

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -28,15 +28,10 @@
     width: 37px;
     height: 37px;
 
-    .js-enabled & {
-      // hide off-sceeen, as visibility: hidden removes inputs from tab order
-      left: -9999px;
-    }
-
-    @include ie-lte(8) {
-      &,
+    // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements.
+    @if ($is-ie == false) or ($ie-version == 9) {
       .js-enabled & {
-        left: 0;
+        @include visually-hidden;
       }
     }
   }

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -9,11 +9,9 @@
   clear: left;
   position: relative;
 
-  background: $panel-colour;
-  border: 1px solid $panel-colour;
-  padding: (18px $gutter $gutter-half $gutter * 1.8);
+  padding: (7px $gutter-one-third 7px $gutter * 1.5);
+  margin-bottom: $gutter-half;
 
-  margin-bottom: 10px;
   cursor: pointer; // Encourage clicking on block labels
 
   @include media(tablet) {
@@ -24,21 +22,74 @@
   // Absolutely position inputs within label, to allow text to wrap
   input {
     position: absolute;
-    top: 15px;
-    left: $gutter-half;
     cursor: pointer;
-    margin: 0;
-    width: 29px;
-    height: 29px;
+    left: 0;
+    top: 0;
+    width: 37px;
+    height: 37px;
 
-    @include ie(8) {
-      top: 12px;
+    .js-enabled & {
+      // hide off-sceeen, as visibility: hidden removes inputs from tab order
+      left: -9999px;
+    }
+
+    @include ie-lte(8) {
+      &,
+      .js-enabled & {
+        left: 0;
+      }
     }
   }
 
-  // Change border on hover
-  &:hover {
-    border-color: $black;
+  .js-enabled & {
+    &.selection-button-radio::before {
+      content: "";
+      border: 2px solid $black;
+      border-radius: 50%;
+      background: $white;
+      width: 33px;
+      height: 33px;
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+
+    &.selection-button-radio.selected::after {
+      content: "";
+      border: 2px solid $black;
+      border-radius: 50%;
+      background: $black;
+      width: 19px;
+      height: 19px;
+      position: absolute;
+      top: 7px;
+      left: 7px;
+    }
+
+    &.selection-button-checkbox::before {
+      content: "";
+      border: 2px solid $black;
+      background: $white;
+      width: 33px;
+      height: 33px;
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+
+    &.selection-button-checkbox.selected::after {
+      content: "";
+      border: solid $black;
+      border-width: 0 0 4px 4px;
+      width: 15px;
+      height: 9px;
+      position: absolute;
+      top: 9px;
+      left: 9px;
+      -webkit-transform: rotate(-45deg); // Safari 8 compatibility
+      -ms-transform: rotate(-45deg); // IE9 compatibility
+      transform: rotate(-45deg);
+    }
   }
 
   &:last-child,
@@ -53,7 +104,7 @@
 
   @include media (tablet) {
     margin-bottom: 0;
-    margin-right: 10px;
+    margin-right: $gutter-half;
   }
 }
 
@@ -62,15 +113,15 @@
 // Allow a qualifying element for the selected state
 // scss-lint:disable QualifyingElement
 
-// Add selected state
-.js-enabled label.selected {
-  background: $white;
-  border-color: $black;
+// Add focus to block labels inputs
+.js-enabled label.focused::before {
+  @include box-shadow(0 0 0 3px $focus-colour);
 }
 
-// Add focus to block labels
-.js-enabled label.focused {
-  outline: 3px solid $focus-colour;
+@include ie-lte(8) {
+  .js-enabled label.focused {
+    outline: 3px solid $focus-colour;
+  }
 }
 
 // scss-lint:enable QualifyingElement

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -39,9 +39,9 @@
   .js-enabled & {
     &.selection-button-radio::before {
       content: "";
-      border: 2px solid $black;
+      border: 2px solid currentColor;
       border-radius: 50%;
-      background: $white;
+      background: transparent;
       width: 33px;
       height: 33px;
       position: absolute;
@@ -51,9 +51,9 @@
 
     &.selection-button-radio.selected::after {
       content: "";
-      border: 2px solid $black;
+      border: 2px solid currentColor;
       border-radius: 50%;
-      background: $black;
+      background: currentColor;
       width: 19px;
       height: 19px;
       position: absolute;
@@ -63,8 +63,8 @@
 
     &.selection-button-checkbox::before {
       content: "";
-      border: 2px solid $black;
-      background: $white;
+      border: 2px solid currentColor;
+      background: transparent;
       width: 33px;
       height: 33px;
       position: absolute;
@@ -74,8 +74,9 @@
 
     &.selection-button-checkbox.selected::after {
       content: "";
-      border: solid $black;
+      border: solid currentColor;
       border-width: 0 0 4px 4px;
+      background: transparent;
       width: 15px;
       height: 9px;
       position: absolute;

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -33,7 +33,8 @@
     // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there.
     @if ($is-ie == false) or ($ie-version == 9) {
       .js-enabled & {
-        @include visually-hidden;
+        margin: 0;
+        @include opacity(0);
       }
     }
   }

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -30,7 +30,7 @@
     width: 38px;
     height: 38px;
 
-    // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements.
+    // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there.
     @if ($is-ie == false) or ($ie-version == 9) {
       .js-enabled & {
         @include visually-hidden;
@@ -98,6 +98,25 @@
       }
     }
 
+    // Focused state
+    &.selection-button-radio,
+    &.selection-button-checkbox {
+      &.focused::before {
+        @include box-shadow(0 0 0 5px $focus-colour);
+      }
+      // IE8 focus outline should stay as a border around the entire label
+      // Lack of padding doesn’t matter as IE8 won’t resize the inputs.
+      @include ie-lte(8) {
+        &.focused {
+          outline: 3px solid $focus-colour;
+
+          input:focus {
+            outline: none;
+          }
+        }
+      }
+    }
+
     // Selected state
     &.selection-button-radio,
     &.selection-button-checkbox {
@@ -121,27 +140,4 @@
     margin-bottom: 0;
     margin-right: $gutter;
   }
-}
-
-// Selected and focused states
-
-// Allow a qualifying element for the selected state
-// scss-lint:disable QualifyingElement
-
-// Add focus to block labels inputs
-.js-enabled label.focused::before {
-  @include box-shadow(0 0 0 5px $focus-colour);
-}
-
-@include ie-lte(8) {
-  .js-enabled label.focused {
-    outline: 3px solid $focus-colour;
-  }
-}
-
-// scss-lint:enable QualifyingElement
-
-// Remove focus from radio/checkboxes
-.js-enabled .focused input:focus {
-  outline: none;
 }

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -42,24 +42,24 @@
     &.selection-button-radio::before {
       content: "";
       border: 2px solid;
-      border-radius: 50%;
       background: transparent;
       width: 34px;
       height: 34px;
       position: absolute;
       top: 0;
       left: 0;
+      @include border-radius(50%);
     }
 
     &.selection-button-radio::after {
       content: "";
-      border-radius: 50%;
       background: currentColor;
       width: 20px;
       height: 20px;
       position: absolute;
       top: 9px;
       left: 9px;
+      @include border-radius(50%);
       @include opacity(0);
     }
 

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -54,9 +54,9 @@
 
     &.selection-button-radio::after {
       content: "";
-      background: currentColor;
-      width: 20px;
-      height: 20px;
+      border: 10px solid;
+      width: 0;
+      height: 0;
       position: absolute;
       top: 9px;
       left: 9px;


### PR DESCRIPTION
This requires no change to the existing HTML: the custom inputs are built using pseudoelements. In a no-JS / no-CSS / IE8 scenario it falls back to standard inputs. To style the radio and checkboxes differently a class is needed on the label - this is automatically added by the new SelectionButton JS.

This is partially based on Verify’s styles, and updates a design by @timpaul and @joelanman inspired by observations from user research and lots of requests from @cjforms. The inputs are sized to match the height of text inputs.

![Image showing the design of the new radio buttons and checkboxes](https://cloud.githubusercontent.com/assets/7414/18244567/a357ddbe-7358-11e6-820e-58d582231442.png)

Tested on:
- IE 7-11
- Edge 14
- OS X Firefox 48
- OS X Chrome 51
- OS X Safari 9
- iOS Safari 5.0 - 9.1  
- Android 4.4+ Chrome

Android Browser on BrowserStack’s Nexus 4 (4.2) is massively unresponsive and doesn’t seem to let you click on the radios most of the time. It will need to be tested on a real device.

Would absolutely love any feedback.
- [x] Base implementation + testing
- [x] Check that this works with click events in Selenium (testing in verify indicated possible problems)
- [x] Make it use `currentColor` for compatibility with custom colour themes
- [x] Make the pseudo-elements permanent and just repaint the background colour on state change
- [x] Add a translucent hover state
- [x] Test in old Android devices
- [x] Fix general problems with Dragon Naturally Speaking 13 on IE11 (Dragon 12.5 is fine)
- [x] Padding no longer exists after legends - investigate recommended changes