### PR TITLE
Add new section for file upload, with examples

### DIFF
--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -496,17 +496,10 @@
 
         <div class="form-section">
           <!--File upload -->
-          <div class="form-group">
-            {% include "snippets/form_file_upload.html" %}
-          </div>
+          {% include "snippets/form_file_upload.html" %}
 
           <!--File upload with error -->
-          <div class="form-group error">
-            <span class="error-message">
-              Error message goes here
-            </span>
-            {% include "snippets/form_file_upload.html" %}
-          </div>
+          {% include "snippets/form_file_upload_error.html" %}
         </div>
 
       </form>

--- a/app/views/guide_form_elements.html
+++ b/app/views/guide_form_elements.html
@@ -145,6 +145,23 @@
 </code>
 </pre>
 
+  <div class="text">
+    <p>
+      We recommend using a native input using <code class="code">type="file"</code>, rather than a custom implementation.
+    </p>
+    <p class="lead-in">
+      This is so:
+    </p>
+    <ul class="list list-bullet">
+      <li>the control gains focus when tabbing through the page</li>
+      <li>the control functions using a keyboard</li>
+      <li>the control functions using assistive technology</li>
+      <li>the control functions when javascript is disabled</li>
+    </ul>
+    <p>
+      A custom implementation of this control would need to meet the criteria above.
+    </p>
+  </div>
 
   <h3 class="heading-medium" id="form-fieldsets">Fieldsets and legends</h3>
   <p class="text">

--- a/app/views/guide_form_elements.html
+++ b/app/views/guide_form_elements.html
@@ -28,6 +28,7 @@
         <li><a href="#form-focus-states">Form focus states</a></li>
         <li><a href="#form-hint-text">Hint text</a></li>
         <li><a href="#form-spacing">Spacing</a></li>
+        <li><a href="#form-file-upload">File upload</a></li>
         <li><a href="#form-fieldsets">Fieldsets</a></li>
         <li><a href="#form-select-boxes">Select boxes</a></li>
         <li><a href="#form-radio-buttons">Radio buttons</a></li>
@@ -130,6 +131,20 @@
   {% include "snippets/encoded/form_spacing.html" %}
 </code>
 </pre>
+
+  <h3 class="heading-medium" id="form-file-upload">File upload</h3>
+  <p>A control that lets the user select a file.</p>
+
+  <div class="example">
+    {% include "snippets/form_file_upload.html" %}
+  </div>
+
+<pre>
+<code class="language-markup">
+  {% include "snippets/encoded/form_file_upload.html" %}
+</code>
+</pre>
+
 
   <h3 class="heading-medium" id="form-fieldsets">Fieldsets and legends</h3>
   <p class="text">

--- a/app/views/snippets/form_file_upload_error.html
+++ b/app/views/snippets/form_file_upload_error.html
@@ -1,6 +1,9 @@
-<div class="form-group">
+<div class="form-group error">
   <label class="form-label" for="file-input">
     Upload a file
+    <span class="error-message">
+      Error message goes here
+    </span>
   </label>
   <input type="file" id="file-input">
 </div>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

## What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes #298, by reverting the custom file upload style. 

## What does it do?
<!--- Describe your changes -->
The button style currently used prevents the button from gaining focus. 
This a bug, for now it is better to revert to the native file upload and in future find a custom solution which is accessible.

## Screenshots (if appropriate):

Before:
![screen shot 2016-09-08 at 11 40 55](https://cloud.githubusercontent.com/assets/417754/18346673/7a6d93ea-75b9-11e6-825d-795c330f8c21.png)

After:

![screen shot 2016-09-08 at 11 39 43](https://cloud.githubusercontent.com/assets/417754/18346679/80b91062-75b9-11e6-8707-46f375103e3d.png)

After (focussed by tabbing through form examples page):

![screen shot 2016-09-08 at 11 40 03](https://cloud.githubusercontent.com/assets/417754/18346685/8cc7d12c-75b9-11e6-83c5-06a904ec52de.png)

New section added to the "Form elements" guide:

![screen shot 2016-09-08 at 11 40 19](https://cloud.githubusercontent.com/assets/417754/18346690/913d6b4a-75b9-11e6-8ffa-b8249fa23f79.png)


## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
