### PR TITLE
Update Procile to use npm start

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node start.js
+web: npm start


### PR DESCRIPTION
start.js was removed in #306, instead use `npm start` to start the app.