### PR TITLE
Reorder grunt tasks, remove the Procfile, remove grunt-shell dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,16 +111,6 @@ module.exports = function (grunt) {
           logConcurrentOutput: true
         }
       }
-    },
-
-    // Lint scss files
-    shell: {
-      multiple: {
-        command: [
-          'bundle',
-          'bundle exec govuk-lint-sass public/sass/elements/'
-        ].join('&&')
-      }
     }
 
   })
@@ -132,7 +122,6 @@ module.exports = function (grunt) {
     'grunt-sass',
     'grunt-nodemon',
     'grunt-concurrent',
-    'grunt-shell',
     'grunt-htmlentities'
   ].forEach(function (task) {
     grunt.loadNpmTasks(task)
@@ -153,7 +142,7 @@ module.exports = function (grunt) {
   })
 
   // 1. Use govuk-scss-lint to lint the sass files
-  grunt.registerTask('lint', ['shell', 'lint-success'])
+  grunt.registerTask('lint', ['lint-success'])
   grunt.registerTask('lint-success', function () {
     grunt.log.writeln('Scss lint is complete, without errors.'['yellow'].bold)
   })

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,12 +48,12 @@ module.exports = function (grunt) {
           src: '**',
           dest: 'govuk_modules/govuk_frontend_toolkit/'
         },
-        {
-          expand: true,
-          cwd: 'node_modules/govuk_template_jinja/',
-          src: '**',
-          dest: 'govuk_modules/govuk_template/'
-        }]
+          {
+            expand: true,
+            cwd: 'node_modules/govuk_template_jinja/',
+            src: '**',
+            dest: 'govuk_modules/govuk_template/'
+          }]
       },
       govuk_template_jinja: {
         files: [{
@@ -138,60 +138,26 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks(task)
   })
 
-  grunt.registerTask('default', [
-    'clean',
-    'copy',
-    'encode_snippets',
-    'sass',
-    'concurrent:target'
-  ])
+  grunt.registerTask('default', ['clean', 'copy', 'encode-snippets', 'sass', 'concurrent:target'])
 
-  grunt.registerTask(
-    'test_default',
-    'Test that the default task runs the app',
-    [
-      'copy',
-      'sass'
-    ]
-  )
+  // Encode HTML snippets
+  grunt.registerTask('encode-snippets', ['htmlentities', 'encode-snippets-success'])
+  grunt.registerTask('encode-snippets-success', function () {
+    grunt.log.writeln('HTML snippets encoded.'['yellow'].bold)
+  })
 
-  grunt.registerTask(
-    'encode_snippets',
-    'Encode HTML snippets',
-    function () {
-      grunt.task.run('htmlentities')
-    }
-  )
+  // Tests
+  grunt.registerTask('test', ['lint', 'test-default', 'test-success'])
+  grunt.registerTask('test-success', function () {
+    grunt.log.writeln('The tests are complete and the app runs, without errors.'['yellow'].bold)
+  })
 
-  grunt.registerTask(
-    'lint',
-    'Use govuk-scss-lint to lint the sass files',
-    function () {
-      grunt.task.run('shell', 'lint_message')
-    }
-  )
+  // 1. Use govuk-scss-lint to lint the sass files
+  grunt.registerTask('lint', ['shell', 'lint-success'])
+  grunt.registerTask('lint-success', function () {
+    grunt.log.writeln('Scss lint is complete, without errors.'['yellow'].bold)
+  })
 
-  grunt.registerTask(
-    'lint_message',
-    'Output a message once linting is complete',
-    function () {
-      grunt.log.write('scss lint is complete, without errors.')
-    }
-  )
-
-  grunt.registerTask(
-    'test',
-    'Lint the Sass files, then check the app runs',
-    function () {
-      grunt.task.run('lint', 'test_default', 'test_message')
-    }
-  )
-
-  grunt.registerTask(
-    'test_message',
-    'Output a message once the tests are complete',
-    function () {
-      grunt.log.write('scss lint is complete and the app runs, without errors.')
-    }
-  )
+  // 2. Test that the default grunt task runs the app
+  grunt.registerTask('test-default', ['clean', 'copy', 'encode-snippets', 'sass'])
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,12 +48,12 @@ module.exports = function (grunt) {
           src: '**',
           dest: 'govuk_modules/govuk_frontend_toolkit/'
         },
-          {
-            expand: true,
-            cwd: 'node_modules/govuk_template_jinja/',
-            src: '**',
-            dest: 'govuk_modules/govuk_template/'
-          }]
+        {
+          expand: true,
+          cwd: 'node_modules/govuk_template_jinja/',
+          src: '**',
+          dest: 'govuk_modules/govuk_template/'
+        }]
       },
       govuk_template_jinja: {
         files: [{

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: npm start

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "standard": "^7.1.2"
   },
   "scripts": {
-    "test": "standard && grunt test",
+    "test": "standard && grunt test && npm run lint",
+    "lint": "bundle && bundle exec govuk-lint-sass public/sass/elements/",
     "start": "grunt"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "standard": "^7.1.2"
   },
   "scripts": {
-    "test": "standard && grunt test && npm run lint",
+    "test": "standard && grunt test && npm run lint --silent",
     "lint": "bundle && bundle exec govuk-lint-sass public/sass/elements/",
     "start": "grunt"
   },


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

## What does it do?
<!--- Describe your changes -->

This PR:

1. makes the grunt tasks less verbose and reorders them, to make them easier to read

2. removes the [Procfile](https://devcenter.heroku.com/articles/nodejs-support#default-web-process-type) [*]

3. removes the dependency on grunt-shell and instead uses npm scripts

[*] _If no Procfile is present in the root directory of your app during the build process, your web process will be started by running `npm start`, specified in package.json._

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
