### PR TITLE
Remove wrapping form elements

### DIFF
--- a/app/views/guide_form_elements.html
+++ b/app/views/guide_form_elements.html
@@ -198,9 +198,7 @@
 
   <h4 class="heading-small">Inline radio buttons</h4>
   <div class="example">
-    <form>
-      {% include "snippets/form_radio_buttons_inline.html" %}
-    </form>
+    {% include "snippets/form_radio_buttons_inline.html" %}
   </div>
 
 <pre>
@@ -211,9 +209,7 @@
 
   <h4 class="heading-small">Stacked radio buttons</h4>
   <div class="example">
-    <form>
-      {% include "snippets/form_radio_buttons.html" %}
-    </form>
+    {% include "snippets/form_radio_buttons.html" %}
   </div>
 
 <pre>
@@ -230,9 +226,7 @@
 
   <h4 class="heading-small">Stacked checkboxes</h4>
   <div class="example">
-    <form>
-      {% include "snippets/form_checkboxes.html" %}
-    </form>
+    {% include "snippets/form_checkboxes.html" %}
   </div>
 
 <pre>
@@ -281,9 +275,7 @@
   </div>
 
   <div class="example">
-    <form>
-      {% include "snippets/form_inset_radios.html" %}
-    </form>
+    {% include "snippets/form_inset_radios.html" %}
   </div>
 
   <div class="panel panel-border-wide text">
@@ -321,9 +313,7 @@
     Click on "Citizen of a different country" to see how this works.
   </p>
   <div class="example">
-    <form>
-      {% include "snippets/form_inset_checkboxes.html" %}
-    </form>
+    {% include "snippets/form_inset_checkboxes.html" %}
   </div>
 
 <pre>


### PR DESCRIPTION
## What does it do?
<!--- Describe your changes -->

These were added to each of the examples as the selection-buttons.js
requires a parent form. Since then, the snippets have been modified so
they now show how they would work with a “one question per page” form
and also include a heading, then the parent form with a fieldset and
hidden legend for assistive technology.

The form elements wrapping these examples are no longer required, so
can be removed.

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

