### PR TITLE
[WIP] Remove bold form labels

### DIFF
--- a/app/views/examples/example_details_summary.html
+++ b/app/views/examples/example_details_summary.html
@@ -30,7 +30,7 @@
       <h2 class="heading-medium">Example 1: Summary content is visible, details content is hidden</h2>
 
       <div class="form-group">
-        <label class="form-label-bold" for="driving-licence">
+        <label class="form-label" for="driving-licence">
           Driving licence number
           <span class="form-hint">For example, NORGA657054SM91J</span>
         </label>

--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -25,19 +25,21 @@
           <p>
             There should be 10px under the label or legend and the input
           </p>
+
           <!-- Text inside a label -->
           <div class="form-group">
-            <label class="form-label-bold" for="example-form-label">
-              This is the label text in bold
+            <label class="form-label" for="example-form-label">
+              This is the label text
             </label>
             <input class="form-control" id="example-form-label" type="text">
           </div>
+
           <!-- Text inside a legend -->
           <div class="form-group">
             <fieldset>
               <legend>
-                <span class="form-label-bold">
-                  This is the label text in bold
+                <span class="form-label">
+                  This is the legend text, styled to look like a label
                 </span>
               </legend>
               <label class="block-label" for="example-radio-yes-no-yes">
@@ -55,32 +57,21 @@
 
           <!-- Hint text inside a label -->
           <div class="form-group">
-            <label class="form-label-bold" for="example-form-label-bold">
-              This is the label text in bold
+            <label class="form-label" for="example-form-label">
+              This is the label text
               <span class="form-hint">
                 This is hint text
               </span>
             </label>
-            <input class="form-control" id="example-form-label-bold" type="text">
-          </div>
-
-          <!-- Hint text outside a label (preference is inside, to be read by AT) -->
-          <div class="form-group">
-            <label class="form-label-bold" for="example-form-label-bold">
-              This is the label text in bold
-            </label>
-            <span class="form-hint">
-              This is hint text
-            </span>
-            <input class="form-control" id="example-form-label-bold" type="text">
+            <input class="form-control" id="example-form-label" type="text">
           </div>
 
           <!-- Text inside a legend -->
           <div class="form-group">
             <fieldset>
               <legend>
-                <span class="form-label-bold">
-                  This is the label text in bold
+                <span class="form-label">
+                  This is the legend text, styled to look like a label
                 </span>
                 <span class="form-hint">
                   This is hint text
@@ -97,7 +88,7 @@
           <div class="form-group">
             <fieldset>
               <legend>
-                <span class="form-label-bold">This is the label text in bold</span>
+                <span class="form-label">This is the label text</span>
                 <span class="form-hint" id="dob-hint">This is hint text</span>
               </legend>
               <div class="form-date">
@@ -125,7 +116,7 @@
 
           <!-- Text inside a label - error -->
           <div class="form-group error">
-            <label class="form-label-bold" for="example-form-control">
+            <label class="form-label" for="example-form-control">
               This is the label text
               <span class="form-hint">
                 This is hint text
@@ -137,27 +128,13 @@
             <input class="form-control" id="example-form-control" type="text">
           </div>
 
-          <!-- Hint text outside a label (preference is inside, to be read by AT) - error -->
-          <div class="form-group error">
-            <label class="form-label-bold" for="example-form-control">
-              This is the label text
-            </label>
-            <span class="form-hint">
-              This is hint text
-            </span>
-            <span class="error-message">
-              Error message goes here
-            </span>
-            <input class="form-control" id="example-form-control" type="text">
-          </div>
-
           <!-- Text inside a legend - error -->
           <div class="form-group error">
             <fieldset>
 
               <legend>
-                <span class="form-label-bold">
-                  Do you have a National Insurance number?
+                <span class="form-label">
+                  This is the legend text, styled to look like a label
                 </span>
                 <span class="form-hint">
                   This is hint text
@@ -177,7 +154,7 @@
           <div class="form-group error">
             <fieldset>
               <legend>
-                <span class="form-label-bold">Date of birth</span>
+                <span class="form-label">Date of birth</span>
                 <span class="form-hint" id="example-dob-hint">For example, 31 3 1980</span>
                 <span class="error-message">Error message goes here</span>
               </legend>
@@ -207,8 +184,8 @@
           <!-- Yes or No question (without revealed content ) -->
           <fieldset class="inline">
             <legend>
-              <span class="form-label-bold">
-                Do you already have a personal user account?
+              <span class="form-label">
+                This is the legend text, styled to look like a label
               </span>
             </legend>
             <label class="block-label" for="radio-inline-1a">
@@ -226,8 +203,8 @@
           <!-- Yes or No question (select one option to reveal content) -->
           <fieldset class="inline">
             <legend>
-              <span class="form-label-bold">
-                This is the label text
+              <span class="form-label">
+                This is the legend text, styled to look like a label
               </span>
               <span class="form-hint">
                 This is the hint text
@@ -279,38 +256,10 @@
             <input class="form-control" id="input-text-b" type="text">
           </div>
 
-          <!-- Input type="text" (bold label) -->
-          <div class="form-group">
-            <label class="form-label-bold" for="input-text-c">
-              This is the label text in bold
-            </label>
-            <input class="form-control" id="input-text-c" type="text">
-          </div>
-
-          <!-- Input type="text" - error (bold label) -->
-          <div class="form-group error">
-            <label class="form-label-bold" for="input-text-d">
-              This is the label text in bold
-              <span class="error-message">
-                Error message goes here
-              </span>
-            </label>
-            <input class="form-control" id="input-text-d" type="text">
-          </div>
-
-          <!-- Input type="text" (bold label with hint text) -->
-          <div class="form-group">
-            <label class="form-label-bold" for="input-text-g">
-              This is the label text
-              <span class="form-hint">
-                This is hint text
-              </span>
-            </label>
-            <input class="form-control" id="input-text-g" type="text">
-          </div>
+          <!-- Input type="text" (label with hint text) -->
 
           <div class="form-group">
-            <label class="form-label-bold" for="input-text-g">
+            <label class="form-label" for="input-text-g">
               This is the label text
             </label>
             <span class="form-hint">
@@ -321,7 +270,7 @@
 
           <!-- Input type="text" - error (bold label with hint text) -->
           <div class="form-group error">
-            <label class="form-label-bold" for="input-text-h">
+            <label class="form-label" for="input-text-h">
               This is the label text
               <span class="form-hint">
                 This is hint text
@@ -358,45 +307,6 @@
             <textarea class="form-control" id="textarea-b" cols="30" rows="10"></textarea>
           </div>
 
-          <!-- Textarea (bold label) -->
-          <div class="form-group">
-            <label class="form-label-bold" for="textarea-c">
-              This is the label text in bold
-            </label>
-            <textarea class="form-control" id="textarea-c" cols="30" rows="10"></textarea>
-          </div>
-
-          <!-- Textarea - error (bold label) -->
-          <div class="form-group error">
-            <label class="form-label-bold" for="textarea-d">
-              This is the label text in bold
-              <span class="error-message">
-                Error message goes here
-              </span>
-            </label>
-            <textarea class="form-control" id="textarea-d" cols="30" rows="10"></textarea>
-          </div>
-
-          <!-- Textarea (bold label, with hint text) -->
-          <div class="form-group">
-            <label class="form-label-bold" for="textarea-e">
-              This is the label text
-              <span class="form-hint">This is hint text</span>
-            </label>
-            <textarea class="form-control" id="textarea-e" cols="30" rows="10"></textarea>
-          </div>
-
-          <!-- Textarea - error (bold label, with hint text) -->
-          <div class="form-group error">
-            <label class="form-label-bold" for="textarea-f">
-              This is the label text
-              <span class="form-hint">This is hint text</span>
-              <span class="error-message">
-                Error message goes here
-              </span>
-            </label>
-            <textarea class="form-control" id="textarea-f" cols="30" rows="10"></textarea>
-          </div>
         </div>
 
         <div class="form-section">
@@ -405,14 +315,7 @@
           </h2>
 
           <!-- Select box -->
-          <div class="form-group">
-            <label class="form-label" for="select-box-a">This is the label text</label>
-            <select class="form-control" id="select-box-a">
-              <option>GOV.UK elements option 1</option>
-              <option>GOV.UK elements option 2</option>
-              <option>GOV.UK elements option 3</option>
-            </select>
-          </div>
+          {% include "snippets/form_select_boxes.html" %}
 
           <!-- Select box - error -->
           <div class="form-group error">
@@ -423,70 +326,6 @@
               </span>
             </label>
             <select class="form-control" id="select-box-b">
-              <option>GOV.UK elements option 1</option>
-              <option>GOV.UK elements option 2</option>
-              <option>GOV.UK elements option 3</option>
-            </select>
-          </div>
-        </div>
-
-        <div class="form-section">
-          <!-- Select box (with bold text) -->
-          <div class="form-group">
-            <label class="form-label-bold" for="select-box-c">
-              This is the label text
-            </label>
-            <select class="form-control" id="select-box-c">
-              <option>GOV.UK elements option 1</option>
-              <option>GOV.UK elements option 2</option>
-              <option>GOV.UK elements option 3</option>
-            </select>
-          </div>
-
-          <!-- Select box - error (with bold text) -->
-          <div class="form-group error">
-            <label class="form-label-bold" for="select-box-d">
-              This is the label text
-              <span class="error-message">
-                Error message goes here
-              </span>
-            </label>
-            <select class="form-control" id="select-box-d">
-              <option>GOV.UK elements option 1</option>
-              <option>GOV.UK elements option 2</option>
-              <option>GOV.UK elements option 3</option>
-            </select>
-          </div>
-        </div>
-
-        <div class="form-section">
-          <!-- Select box (with bold text and hint text) -->
-          <div class="form-group">
-            <label class="form-label-bold" for="select-box-g">
-              This is the label text
-              <span class="form-hint">
-                This the hint text
-              </span>
-            </label>
-            <select class="form-control" id="select-box-g">
-              <option>GOV.UK elements option 1</option>
-              <option>GOV.UK elements option 2</option>
-              <option>GOV.UK elements option 3</option>
-            </select>
-          </div>
-
-          <!-- Select box - error (with bold text and hint text) -->
-          <div class="form-group error">
-            <label class="form-label-bold" for="select-box-h">
-              This is the label text
-              <span class="form-hint">
-                This is the hint text
-              </span>
-              <span class="error-message">
-                Error message goes here
-              </span>
-            </label>
-            <select class="form-control" id="select-box-h">
               <option>GOV.UK elements option 1</option>
               <option>GOV.UK elements option 2</option>
               <option>GOV.UK elements option 3</option>

--- a/app/views/snippets/form_date.html
+++ b/app/views/snippets/form_date.html
@@ -2,7 +2,7 @@
   <div class="form-group">
     <fieldset>
       <legend>
-        <span class="form-label-bold">
+        <span class="form-label">
           What is your date of birth?
         </span>
         <span class="form-hint" id="dob-hint">For example, 31 3 1980</span>

--- a/app/views/snippets/form_error_multiple.html
+++ b/app/views/snippets/form_error_multiple.html
@@ -29,7 +29,7 @@
 
   <label for="example-full-name" {% if error %}{% if not fullName %} id="error-full-name"{% endif %}{% endif %}>
 
-    <span class="form-label-bold">Full name</span>
+    <span class="form-label">Full name</span>
     <span class="form-hint">As shown on your birth certificate or passport</span>
     {% if error %}
       {% if not fullName %}
@@ -46,7 +46,7 @@
 
   <label for="example-ni-number" {% if error %}{% if not niNo %} id="error-full-name"{% endif %}{% endif %}>
 
-    <span class="form-label-bold">National Insurance number</span>
+    <span class="form-label">National Insurance number</span>
     <span class="form-hint">
       It's on your National Insurance card, benefit letter, payslip or P60.
       <br>

--- a/app/views/snippets/form_error_multiple_show_errors.html
+++ b/app/views/snippets/form_error_multiple_show_errors.html
@@ -23,7 +23,7 @@
 
   <label for="example-full-name" id="error-full-name">
 
-    <span class="form-label-bold">Full name</span>
+    <span class="form-label">Full name</span>
     <span class="form-hint">As shown on your birth certificate or passport</span>
     <span class="error-message" id="error-message-full-name">Error message about full name goes here</span>
 
@@ -36,7 +36,7 @@
 
   <label for="example-ni-number" id="error-ni-number">
 
-    <span class="form-label-bold">National Insurance number</span>
+    <span class="form-label">National Insurance number</span>
     <span class="form-hint">
       It's on your National Insurance card, benefit letter, payslip or P60.
       <br>

--- a/app/views/snippets/form_error_radio.html
+++ b/app/views/snippets/form_error_radio.html
@@ -30,7 +30,7 @@
 
     <legend {% if error %} id="example-personal-details"{% endif %}>
 
-      <span class="form-label-bold">
+      <span class="form-label">
         Are your personal details correct and up-to-date?
       </span>
       {% if error %}

--- a/app/views/snippets/form_error_radio_show_errors.html
+++ b/app/views/snippets/form_error_radio_show_errors.html
@@ -28,7 +28,7 @@
 
       <legend id="example-personal-details">
 
-        <span class="form-label-bold">
+        <span class="form-label">
           Are your personal details correct and up-to-date?
         </span>
         <span class="error-message">

--- a/app/views/snippets/form_inset_radios_show_errors.html
+++ b/app/views/snippets/form_inset_radios_show_errors.html
@@ -8,7 +8,7 @@
     <fieldset>
 
       <legend>
-        <span class="form-label-bold">How often do you get paid?</span>
+        <span class="form-label">How often do you get paid?</span>
         <span class="error-message">Choose an answer</span>
       </legend>
 
@@ -53,7 +53,7 @@
     <fieldset>
 
       <legend>
-        <span class="form-label-bold">How often do you get paid?</span>
+        <span class="form-label">How often do you get paid?</span>
       </legend>
 
       <label class="block-label" data-target="paid-weekly-2" for="example-paid-weekly-2">


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

Form labels should be normal weight. Bold examples crept into gouvk_elements and have been used often for legend text, to increase the distinction between a the legend text and a group of radio buttons or checkboxes. 

This will require a change to the documentation and a solution for the legend text styling.
At present legends use a nested span, with the form label styling. 

## Screenshots (if appropriate):

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.