### PR TITLE
Inherit font stack from toolkit

### DIFF
--- a/public/sass/elements/_govuk-template-base.scss
+++ b/public/sass/elements/_govuk-template-base.scss
@@ -5,9 +5,7 @@ input,
 table,
 td,
 th {
-  // Allow uppercase letters in font stack variable names
-  // scss-lint:disable NameFormat
-  font-family: $NTA-Light;
+  font-family: $toolkit-font-stack;
 }
 
 // basic styles for HTML5 and other elements


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

## What problem does the pull request solve?
It was not previously possible to fully override the font stack used with the GOV.UK template base.
It almost worked, as the font stack is usually pulled from the frontend toolkit, which [allows](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/mixins.md#changing-font) one to override it using a variable. However, the GOV.UK template base hardcodes the font used for unclassed elements to MTA Light, so if one sets the `$toolkit-font-stack` one ends up with a disconcerting mix of fonts.
<!--- If it fixes an open issue, please link to the issue here. -->

## What does it do?
<!--- Describe your changes -->
This commit replaces the MTA Light reference to `$toolkit-font-stack`. Because GOV.UK Elements depends on the frontend toolkit, the latter variable is usually already initialised to MTA Light, so there shouldn't be any incompatibility issues. It also removes the now unused linter exception comment.

This allows people that don't have access to the New Transport font stack to select their own font in a more reliable fashion.
## How has this been tested?
This commit was tested manually using a personal project on my laptop. `npm test` was run on a remote server and exited successfully.

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

This commit removes the hard-coded reference to New Transport in
the GOV.UK template base, and replaces it with a mostly equivalent
variable used within the Frontend Toolkit, which can be overridden.

Because the Frontend Toolkit is a dependency of GOV.UK elements, the
new variable is usually initialised to MTA Light anyway, but in a way
that eases the process of reusing the template if one is unable to use
the New Transport font.