### PR TITLE
Easier copying of HTML from code snippets

### DIFF
--- a/public/sass/prism.scss
+++ b/public/sass/prism.scss
@@ -53,6 +53,8 @@ pre[class*="language-"] {
   padding: 1em;
   margin: 0 0 30px 0;
   overflow: auto;
+  -webkit-user-select: all;
+  user-select: all;
 }
 
 :not(pre) > code[class*="language-"],


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

## What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## What does it do?
<!--- Describe your changes -->
This PR adds `user-select`:`all` to preformatted code blocks, to make it easier to copy an entire code snippet. Clicking inside the code snippet selects the entire code block.

## Screenshots (if appropriate):

Before:
![before-user-select-all](https://cloud.githubusercontent.com/assets/417754/18637661/10cc5604-7e85-11e6-9a35-b4dd2d2074fa.gif)

After:
![user-select-all](https://cloud.githubusercontent.com/assets/417754/18637658/0dcfddea-7e85-11e6-9907-59ad071f6a46.gif)


## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

