### PR TITLE
Add a .bold helper class

### DIFF
--- a/public/sass/elements/_elements-typography.scss
+++ b/public/sass/elements/_elements-typography.scss
@@ -59,6 +59,11 @@ main {
   @include bold-16();
 }
 
+// Bold, without needing a font size
+.bold {
+  font-weight: 700;
+}
+
 // Common heading sizes
 // Using the bold-xx mixins from the govuk_toolkit _typography.scss file
 // Spacing is set in em, using the px to em function in the elements _helpers.scss file


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

## What does it do?
<!--- Describe your changes -->

The [govuk_template defines the font-weight for `<strong>`](https://github.com/alphagov/govuk_template/blob/b6d4e882d195ed5093beb9fa1396438773c17de3/source/assets/stylesheets/_basic.scss#L141) elements to `font-weight: 600`.

Add a helper class `.bold` to override font-weight to 700.