### PR TITLE
Update the govuk_frontend_toolkit to 4.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=4.4.7"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^4.18.1"
+    "govuk_frontend_toolkit": "^4.18.2"
   },
   "devDependencies": {
     "body-parser": "^1.14.1",


### PR DESCRIPTION
- Remove unnecessary print font fallback that causes regression
downstream ([PR
#328](https://github.com/alphagov/govuk_frontend_toolkit/pull/328))