### PR TITLE
Bump govuk template to 0.18.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express": "4.13.3",
     "express-nunjucks": "^0.9.3",
     "express-writer": "0.0.4",
-    "govuk_template_jinja": "0.18.2",
+    "govuk_template_jinja": "0.18.3",
     "grunt": "^0.4.2",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "^0.4.3",


### PR DESCRIPTION
Logo fixes: Fix logo breaking layout when increasing font size, fix
invalid or non-standard CSS and remove obsolete CSS around logo, adjust
logo dimensions slightly (PR #237)