### PR TITLE
Get Travis to push a latest-release branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,23 +12,23 @@ notifications:
 before_deploy:
 - test $TRAVIS_TEST_RESULT = 0
 deploy:
-  - provider: heroku
-    api_key:
-      secure: nQCOBk2EnuJ0yaC0cO2RabfLlF+3WiZ4MrLLBPt3l+fNQO69KcJZu59Npbt45f/ip6Dv8cEGxdzSqzNsPu/XB+fmyAZd1bml0u7JMKWNQeVLKddoM+A1ETFSyXHoM/Ra3Qw8+2XS/ZJNTAD7BGibSh8SvzYdg9fy9kCN77Sn9Ro=
-    app: govuk-elements
-    on: master
-  - provider: heroku
-    api_key:
-      secure: nQCOBk2EnuJ0yaC0cO2RabfLlF+3WiZ4MrLLBPt3l+fNQO69KcJZu59Npbt45f/ip6Dv8cEGxdzSqzNsPu/XB+fmyAZd1bml0u7JMKWNQeVLKddoM+A1ETFSyXHoM/Ra3Qw8+2XS/ZJNTAD7BGibSh8SvzYdg9fy9kCN77Sn9Ro=
-    app: govuk-elements-sass-release
-    on:
-      tags: true
-      all_branches: true
-  - provider: npm
-    api_key:
-      secure: VAHPK3W0YVWqx03j659FbKjvEwd+UIDfb1x55to9u+PzyVqQp1CXalsYuKQSavxqInaV3gzNJpbANo6SIXlpAUxZPChiTk0rJwUhz7u1fRY0Lshb+aDOMnXSfjSqiIGThNRpjYdxBiJsnrYP1T6unHuo2A1K8mXjwdFtxhadh+w=
-    email: govuk-dev@digital.cabinet-office.gov.uk
-    on:
-      tags: true
-      all_branches: true
+- provider: heroku
+  api_key:
+    secure: nQCOBk2EnuJ0yaC0cO2RabfLlF+3WiZ4MrLLBPt3l+fNQO69KcJZu59Npbt45f/ip6Dv8cEGxdzSqzNsPu/XB+fmyAZd1bml0u7JMKWNQeVLKddoM+A1ETFSyXHoM/Ra3Qw8+2XS/ZJNTAD7BGibSh8SvzYdg9fy9kCN77Sn9Ro=
+  app: govuk-elements
+  on: master
+- provider: heroku
+  api_key:
+    secure: nQCOBk2EnuJ0yaC0cO2RabfLlF+3WiZ4MrLLBPt3l+fNQO69KcJZu59Npbt45f/ip6Dv8cEGxdzSqzNsPu/XB+fmyAZd1bml0u7JMKWNQeVLKddoM+A1ETFSyXHoM/Ra3Qw8+2XS/ZJNTAD7BGibSh8SvzYdg9fy9kCN77Sn9Ro=
+  app: govuk-elements-sass-release
+  on:
+    tags: true
+    all_branches: true
+- provider: npm
+  api_key:
+    secure: VAHPK3W0YVWqx03j659FbKjvEwd+UIDfb1x55to9u+PzyVqQp1CXalsYuKQSavxqInaV3gzNJpbANo6SIXlpAUxZPChiTk0rJwUhz7u1fRY0Lshb+aDOMnXSfjSqiIGThNRpjYdxBiJsnrYP1T6unHuo2A1K8mXjwdFtxhadh+w=
+  email: govuk-dev@digital.cabinet-office.gov.uk
+  on:
+    tags: true
+    all_branches: true
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,6 @@ deploy:
     tags: true
     all_branches: true
 sudo: false
+env:
+  global:
+    secure: eFtS+dlf00c3h4Rpp1FSZw6wOmZPmY4lYbqPV6MQa+VUgh+FRbUYOjDJP3UFaTsWNxMIL4mhEKFYLnkVftBdz1FgPjhIO3jNXleGMgVVedtD+qo5hTu1KI39t68K2YcELx9+kzeccX77WVmv/qJTVg7+f84WP9ebzVOJCQprJuw=

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ deploy:
   on:
     tags: true
     all_branches: true
+- provider: script
+  script: "update-release-branch.sh"
 sudo: false
 env:
   global:

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -16,8 +16,5 @@ if [ "$MASTER_SHA" == "$HEAD_SHA" ]; then
     echo "Creating new tag: $VERSION_TAG"
     git tag $VERSION_TAG
     git push origin $VERSION_TAG
-
-    # Alias branch for the most recently released tag, for easier diffing
-    git push -f origin master:latest-release
   fi
 fi

--- a/update-release-branch.sh
+++ b/update-release-branch.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -ex
+
+# Update the latest-release branch with the most recent tagged release
+
+# we want this to only happen from our repo, not forks
+# check this is not a pull request
+# check we're on the master branch
+
+if [ "$TRAVIS_REPO_SLUG" == "alphagov/govuk_elements" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+  # get the version from the version file
+  VERSION_TAG="$(cat VERSION.txt)"
+  echo "Using the most recent tag: $VERSION_TAG and creating a latest-release branch"
+  git config --global user.email "travis@travis-ci.org"
+  git config --global user.name "Travis CI"
+  set +x
+  git remote add deploy-latest-release https://"${GH_TOKEN}"@github.com/alphagov/govuk_elements.git > /dev/null 2>&1
+  set -x
+  # check the remote has been added
+  git checkout -b latest-release v"$VERSION_TAG"
+  git push --force deploy-latest-release latest-release
+  echo "Pushed latest-release branch to GitHub"
+else
+  echo "Not updating the latest-release branch as we're on a branch..."
+fi


### PR DESCRIPTION
It is useful to have a branch showing the latest-release, get Travis to check the version.txt file and check out the most recent tag and then push a branch called "latest-release".

cc. @robinwhittleton.

This matches the work [already carried out for the govuk_prototype_kit](https://github.com/alphagov/govuk_prototype_kit/commit/000f078c3dbc2b5c8467122f655dc150cd74b618).
