### PR TITLE
Clear floats on details elements

### DIFF
--- a/public/sass/elements/_details.scss
+++ b/public/sass/elements/_details.scss
@@ -3,6 +3,7 @@
 
 details {
   display: block;
+  clear: both;
 
   summary {
     display: inline-block;


### PR DESCRIPTION
# What problem does the pull request solve?
When a details element follows a floated element its height consumes the height of the floated element. 

## What does it do?
Clear floats for details elements so that details element height does not cover the previous floated element  (which matches panel styling).

## How has this been tested?
Manual browser testing

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
