### PR TITLE
Remove external links: bump govuk_frontend_toolkit to 5.0.0 and govuk_template to 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express": "4.13.3",
     "express-nunjucks": "^0.9.3",
     "express-writer": "0.0.4",
-    "govuk_template_jinja": "0.18.3",
+    "govuk_template_jinja": "0.19.0",
     "grunt": "^0.4.2",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=4.4.7"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^4.18.4"
+    "govuk_frontend_toolkit": "^5.0.0"
   },
   "devDependencies": {
     "body-parser": "^1.14.1",


### PR DESCRIPTION
Bump govuk_frontend_toolkit to 5.0.0 
https://github.com/alphagov/govuk_frontend_toolkit/blob/master/CHANGELOG.md

This release includes two breaking changes:

- Removal of external link styles and icons, if you are using the external-link-* mixins you will need to remove them from your codebase  ([PR #293](https://github.com/alphagov/govuk_frontend_toolkit/pull/293))
- Correct spelling of the 'accordion' icon, you will need to check for the incorrect spelling 'accordian' and update if you are using this icon ([PR #345](https://github.com/alphagov/govuk_frontend_toolkit/pull/345))

And two minor changes:

- Amend GOVUK.StickAtTopWhenScrolling to resize the sticky element and shim when the .js-sticky-resize class is set ([PR #343](https://github.com/alphagov/govuk_frontend_toolkit/pull/343))
- Allow custom options in GOVUK.analytics.trackPageview ([#332](https://github.com/alphagov/govuk_frontend_toolkit/pull/332))

----

Bump govuk_template_jinja to 0.19.0
https://github.com/alphagov/govuk_template/blob/master/CHANGELOG.md

- Remove external link styles (PR #231)
- Remove extraneous copy of HTML5shiv that wasn’t being used (PR #254)
- Update govuk_frontend_toolkit to latest version (PR #256)
