### PR TITLE
Remove guidance on external link icons

### DIFF
--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -133,29 +133,6 @@
 </code>
 </pre>
 
-  <h4 class="heading-medium" id="typography-external-links">External links</h4>
-
-  <div class="panel panel-border-wide text">
-    <p>
-      <strong class="bold-small">External link styles are deprecated and are liable to be removed in a future release.</strong>
-    </p>
-    <p>
-      If your service has user research that indicates that external links are useful (or not) then we’d like to hear from you either on Slack, <a href="https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/digital-service-designers">digital-service-designers</a> or <a href="https://github.com/alphagov/govuk_elements/issues/new">opening an issue</a>.
-    </p>
-  </div>
-
-  <div class="example">
-    <div class="text">
-      {% include "snippets/typography_external_links.html" %}
-    </div>
-  </div>
-
-<pre>
-<code class="language-markup">
-  {% include "snippets/encoded/typography_external_links.html" %}
-</code>
-</pre>
-
   <h3 class="heading-medium" id="typography-lists">Lists</h3>
   <p class="text">
     List items start with a lowercase letter and have no full stop at the end.

--- a/app/views/snippets/typography_external_links.html
+++ b/app/views/snippets/typography_external_links.html
@@ -1,3 +1,0 @@
-<p>
-  <a href="#" rel="external">A 19px body copy external link.</a> Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
-</p>


### PR DESCRIPTION
As we’re removing these from frontend toolkit we can remove the guidance around their use.