### PR TITLE
added example of input sizes using form-control classes

### DIFF
--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -332,13 +332,11 @@
             </label>
             <input class="form-control" id="input-text-h" type="text">
           </div>
-
-
-          <!-- Input type="text" - size modifiers -->
-          {% include "snippets/form_input_sizes.html" %}
-
-
         </div>
+
+        <!-- Input type="text" - size modifiers -->
+        {% include "snippets/form_input_sizes.html" %}
+
 
         <div class="form-section">
           <h2 class="heading-medium">

--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -332,6 +332,12 @@
             </label>
             <input class="form-control" id="input-text-h" type="text">
           </div>
+
+
+          <!-- Input type="text" - size modifiers -->
+          {% include "snippets/form_input_sizes.html" %}
+
+
         </div>
 
         <div class="form-section">

--- a/app/views/snippets/form_input_sizes.html
+++ b/app/views/snippets/form_input_sizes.html
@@ -1,0 +1,47 @@
+<div class="form-section">
+  <h2 class="heading-medium">
+              Example: input text with form-control classes
+  </h2>
+
+  <div class="form-group">
+    <label class="form-label-bold" for="form-control-1-8">
+      Input with class form-control-1-8 (12.5% width)
+    </label>
+    <input class="form-control form-control-1-8" id="form-control-1-8" type="text">
+  </div>
+
+  <div class="form-group">
+    <label class="form-label-bold" for="form-control-1-4">
+      Input with class form-control-1-4 (25% width)
+    </label>
+    <input class="form-control form-control-1-4" id="form-control-1-4" type="text">
+  </div>
+
+  <div class="form-group">
+    <label class="form-label-bold" for="form-control-1-3">
+      Input with class form-control-1-3 (33% width)
+    </label>
+    <input class="form-control form-control-1-3" id="form-control-1-3" type="text">
+  </div>
+
+  <div class="form-group">
+    <label class="form-label-bold" for="form-control-1-2">
+      Input with class form-control-1-2 (50% width - default form-control size)
+    </label>
+    <input class="form-control form-control-1-2" id="form-control-1-2" type="text">
+  </div>
+
+  <div class="form-group">
+    <label class="form-label-bold" for="form-label-bold">
+      Input with class form-control-2-3 (66% width)
+    </label>
+    <input class="form-control form-control-2-3" id="form-control-2-3" type="text">
+  </div>
+
+  <div class="form-group">
+    <label class="form-label-bold" for="form-control-3-4">
+      Input with class form-control-3-4 (75% width)
+    </label>
+    <input class="form-control form-control-3-4" id="form-control-3-4" type="text">
+  </div>
+</div>

--- a/app/views/snippets/form_input_sizes.html
+++ b/app/views/snippets/form_input_sizes.html
@@ -4,42 +4,42 @@
   </h2>
 
   <div class="form-group">
-    <label class="form-label-bold" for="form-control-1-8">
+    <label class="form-label" for="form-control-1-8">
       Input with class form-control-1-8 (12.5% width)
     </label>
     <input class="form-control form-control-1-8" id="form-control-1-8" type="text">
   </div>
 
   <div class="form-group">
-    <label class="form-label-bold" for="form-control-1-4">
+    <label class="form-label" for="form-control-1-4">
       Input with class form-control-1-4 (25% width)
     </label>
     <input class="form-control form-control-1-4" id="form-control-1-4" type="text">
   </div>
 
   <div class="form-group">
-    <label class="form-label-bold" for="form-control-1-3">
+    <label class="form-label" for="form-control-1-3">
       Input with class form-control-1-3 (33% width)
     </label>
     <input class="form-control form-control-1-3" id="form-control-1-3" type="text">
   </div>
 
   <div class="form-group">
-    <label class="form-label-bold" for="form-control-1-2">
+    <label class="form-label" for="form-control-1-2">
       Input with class form-control-1-2 (50% width - default form-control size)
     </label>
     <input class="form-control form-control-1-2" id="form-control-1-2" type="text">
   </div>
 
   <div class="form-group">
-    <label class="form-label-bold" for="form-label-bold">
+    <label class="form-label" for="form-label">
       Input with class form-control-2-3 (66% width)
     </label>
     <input class="form-control form-control-2-3" id="form-control-2-3" type="text">
   </div>
 
   <div class="form-group">
-    <label class="form-label-bold" for="form-control-3-4">
+    <label class="form-label" for="form-control-3-4">
       Input with class form-control-3-4 (75% width)
     </label>
     <input class="form-control form-control-3-4" id="form-control-3-4" type="text">


### PR DESCRIPTION
A designer was asking me about  different size lengths of an input box, and I couldn't find them shown as examples.

## What problem does the pull request solve?
This pull requests add various examples using form-control classes

## What does it do?
Added new html include snippets, I put them in order of % width

## How has this been tested?
Manual browser testing

## Screenshots (if appropriate):

<img width="684" alt="screen shot 2016-10-25 at 15 02 32" src="https://cloud.githubusercontent.com/assets/4334015/19689088/1caeb844-9ac4-11e6-8627-04022d17f35d.png">


## What type of change is it?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

