### PR TITLE
Update code example colours to improve contrast and readability

### DIFF
--- a/public/sass/vendor/prism.scss
+++ b/public/sass/vendor/prism.scss
@@ -32,7 +32,6 @@ pre[class*="language-"] {
   -moz-hyphens: none;
   -ms-hyphens: none;
   hyphens: none;
-  background-color: $code-background; // light grey
   word-spacing: normal;
   word-break: normal;
   // Wrap lines of code rather than overflowing
@@ -133,6 +132,11 @@ pre[class*="language-"] {
 .token.string,
 .token.variable {
   color: $code-blue;
+}
+
+// Color numbers the same as un-detected text for css - so 'core-16' and similar is coloured correctly.
+.language-scss .token.number, .language-css .token.number {
+  color: $code-text;
 }
 
 // Other styling

--- a/public/sass/vendor/prism.scss
+++ b/public/sass/vendor/prism.scss
@@ -19,7 +19,7 @@ $code-green: #1E8400;
 code[class*="language-"],
 pre[class*="language-"] {
   color: $code-text;
-  text-shadow: 0 1px white;
+  text-shadow: 0 1px $white;
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
   font-size: 14px;
   direction: ltr;
@@ -35,21 +35,25 @@ pre[class*="language-"] {
   word-spacing: normal;
   word-break: normal;
   // Wrap lines of code rather than overflowing
-  white-space: pre-wrap;       /* css-3 */
-  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
-  white-space: -pre-wrap;      /* Opera 4-6 */
-  white-space: -o-pre-wrap;    /* Opera 7 */
-  word-wrap: break-word;       /* Internet Explorer 5.5+ */
+  white-space: pre-wrap;       // css-3
+  white-space: -moz-pre-wrap;  // Mozilla, since 1999
+  white-space: -pre-wrap;      // Opera 4-6
+  white-space: -o-pre-wrap;    // Opera 7
+  word-wrap: break-word;       // Internet Explorer 5.5+
 }
 
-pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
-code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+pre[class*="language-"]::-moz-selection,
+pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection,
+code[class*="language-"] ::-moz-selection {
   text-shadow: none;
   background: #b3d4fc;
 }
 
-pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
-code[class*="language-"]::selection, code[class*="language-"] ::selection {
+pre[class*="language-"]::selection,
+pre[class*="language-"] ::selection,
+code[class*="language-"]::selection,
+code[class*="language-"] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -61,7 +65,7 @@ code[class*="language-"]::selection, code[class*="language-"] ::selection {
   }
 }
 
-/* Code blocks */
+// Code blocks
 pre[class*="language-"] {
   border: 1px solid $grey-2;
   padding: 1em;
@@ -74,7 +78,7 @@ pre[class*="language-"] {
   background: $code-background;
 }
 
-/* Inline code */
+// Inline code
 :not(pre) > code[class*="language-"] {
   padding: .1em;
   border-radius: .3em;
@@ -135,7 +139,8 @@ pre[class*="language-"] {
 }
 
 // Color numbers the same as un-detected text for css - so 'core-16' and similar is coloured correctly.
-.language-scss .token.number, .language-css .token.number {
+.language-scss .token.number,
+.language-css .token.number {
   color: $code-text;
 }
 
@@ -144,6 +149,7 @@ pre[class*="language-"] {
 .token.bold {
   font-weight: bold;
 }
+
 .token.italic {
   font-style: italic;
 }

--- a/public/sass/vendor/prism.scss
+++ b/public/sass/vendor/prism.scss
@@ -1,32 +1,46 @@
+
 //  http://prismjs.com/download.html?themes=prism&languages=markup+css+scss
 //
-//  prism.js default theme for JavaScript, CSS and HTML
+//  prism.js theme by Edward Horsford for GOV.UK
+//  based on prism default theme
 //  Based on dabblet (http://dabblet.com)
-//  @author Lea Verou
-//
 
+@import "colours";
+
+// Use GOV.UK colour palette where possible, or tints thereof to meet contrast rules
+$code-text: $text-colour;
+$code-grey: darken($secondary-text-colour, 2%); // grey #6a7276 4.62:1
+$code-background: scale-color($highlight-colour, $lightness:50%); // light grey
+$code-light-red: darken($mellow-red, 2%);
+$code-dark-red: darken($red, 7%);
+$code-blue: $govuk-blue;
+$code-green: #1E8400;
 
 code[class*="language-"],
 pre[class*="language-"] {
-  color: black;
+  color: $code-text;
   text-shadow: 0 1px white;
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
   font-size: 14px;
   direction: ltr;
   text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
   line-height: 1.5;
-
   -moz-tab-size: 4;
   -o-tab-size: 4;
   tab-size: 4;
-
   -webkit-hyphens: none;
   -moz-hyphens: none;
   -ms-hyphens: none;
   hyphens: none;
+  background-color: $code-background; // light grey
+  word-spacing: normal;
+  word-break: normal;
+  // Wrap lines of code rather than overflowing
+  white-space: pre-wrap;       /* css-3 */
+  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+  white-space: -pre-wrap;      /* Opera 4-6 */
+  white-space: -o-pre-wrap;    /* Opera 7 */
+  word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
@@ -50,6 +64,7 @@ code[class*="language-"]::selection, code[class*="language-"] ::selection {
 
 /* Code blocks */
 pre[class*="language-"] {
+  border: 1px solid $grey-2;
   padding: 1em;
   margin: 0 0 30px 0;
   overflow: auto;
@@ -57,7 +72,7 @@ pre[class*="language-"] {
 
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
-  background: #f5f2f0;
+  background: $code-background;
 }
 
 /* Inline code */
@@ -66,65 +81,61 @@ pre[class*="language-"] {
   border-radius: .3em;
 }
 
+// Comments
 .token.comment,
 .token.prolog,
 .token.doctype,
-.token.cdata {
-  color: slategray;
-}
-
+.token.cdata,
 .token.punctuation {
-  color: #999;
+  color: $code-grey;
 }
 
 .namespace {
   opacity: .7;
 }
 
-.token.property,
+// Tags / elements
 .token.tag,
 .token.boolean,
 .token.number,
 .token.constant,
 .token.symbol,
-.token.deleted {
-  color: #905;
+.token.deleted,
+.token.selector,
+.token.keyword {
+  color: $code-dark-red;
 }
 
-.token.selector,
+// Attribute names
 .token.attr-name,
-.token.string,
 .token.char,
 .token.builtin,
-.token.inserted {
-  color: #690;
+.token.inserted,
+.token.function,
+.token.property {
+  color: $code-green;
 }
 
+.token.regex,
+.token.important,
+.token.atrule,
+.language-scss .token.keyword,
 .token.operator,
 .token.entity,
 .token.url,
 .language-css .token.string,
 .style .token.string {
-  color: #a67f59;
-  background: hsla(0, 0%, 100%, .5);
+  color: $code-light-red;
 }
 
-.token.atrule,
+// Attribute values
 .token.attr-value,
-.token.keyword {
-  color: #07a;
-}
-
-.token.function {
-  color: #DD4A68;
-}
-
-.token.regex,
-.token.important,
+.token.string,
 .token.variable {
-  color: #e90;
+  color: $code-blue;
 }
 
+// Other styling
 .token.important,
 .token.bold {
   font-weight: bold;


### PR DESCRIPTION
## What problem does the pull request solve?
This PR adjusts the colours used in example code blocks so that they are each 4.5:1 or greater contrast against the background. This will improve the readability for those who struggle with low contrast.

[Demo page](https://govuk-syntax-prototype.herokuapp.com/syntax2) with highlighting on many languages. username: syntax password: highlighting

## What does it do?
* Adjust colours used for code elements to contrast compliant colours, using GOV.UK palette where possible (or tints thereof).
* Prioritises distinctive colours so that different elements can be distinguished.
* Makes the background lighter and adds a grey border to code examples. This matches other example styles used by elements, and helps distinguish the block now that the background is lighter.
* Lines of code wrap rather than overflowing.
* Adjusts which colours are used for different languages to make highlighting more consistent across other languages (other languages not used by elements).

## How has this been tested?
* Has been tested on Chrome 54 and Safari 10 on Mac OS X 10.11.6.
* Primarily tested with: HTML, SCSS, Javascript.
* Some testing with: Apache, Bash, C++, Dockerfile, ERB, Handlebars, Java, JSON, Markdown, Nginx, Perl, PHP, Puppet, Python, Ruby, Scala, SQL, Yaml

## Screenshots (if appropriate):

HTML Before:
![screen shot 2016-10-26 at 17 06 46](https://cloud.githubusercontent.com/assets/2204224/19734218/a440b9ee-9b9e-11e6-9f2b-c9ac29401d8f.png)

HTML After:
![screen shot 2016-10-26 at 17 06 55](https://cloud.githubusercontent.com/assets/2204224/19734230/af513372-9b9e-11e6-9eba-785d8b448a34.png)

CSS / SCSS isn't currently used in any examples on Elements, but likely will in future GOV.UK Frontend work.

CSS Before:
![screen shot 2016-10-26 at 17 04 38](https://cloud.githubusercontent.com/assets/2204224/19734179/7a3da04e-9b9e-11e6-8f11-8871c1be58a5.png)

CSS After:
![screen shot 2016-10-26 at 17 52 41](https://cloud.githubusercontent.com/assets/2204224/19735898/547a1188-9ba5-11e6-8d98-76f51eb7f939.png)

## What type of change is it?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

## Not done
Highlighting for markdown snippets isn't great - I don't think we have any current cases where it's needed, so haven't done anything to adjust it specifically yet.
