### PR TITLE
Get Travis to check if the version number matches the tag number

### DIFF
--- a/update-release-branch.sh
+++ b/update-release-branch.sh
@@ -10,16 +10,21 @@ set -ex
 if [ "$TRAVIS_REPO_SLUG" == "alphagov/govuk_elements" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
   # get the version from the version file
   VERSION_TAG="$(cat VERSION.txt)"
-  echo "Using the most recent tag: $VERSION_TAG and creating a latest-release branch"
-  git config --global user.email "travis@travis-ci.org"
-  git config --global user.name "Travis CI"
-  set +x
-  git remote add deploy-latest-release https://"${GH_TOKEN}"@github.com/alphagov/govuk_elements.git > /dev/null 2>&1
-  set -x
-  # check the remote has been added
-  git checkout -b latest-release v"$VERSION_TAG"
-  git push --force deploy-latest-release latest-release
-  echo "Pushed latest-release branch to GitHub"
+  # check to make sure the tag doesn't already exist
+  if ! git rev-parse $VERSION_TAG >/dev/null 2>&1; then
+    echo "Using the most recent tag: $VERSION_TAG and creating a latest-release branch"
+    git config --global user.email "travis@travis-ci.org"
+    git config --global user.name "Travis CI"
+    set +x
+    git remote add deploy-latest-release https://"${GH_TOKEN}"@github.com/alphagov/govuk_elements.git > /dev/null 2>&1
+    set -x
+    # check the remote has been added
+    git checkout -b latest-release v"$VERSION_TAG"
+    git push --force deploy-latest-release latest-release
+    echo "Pushed latest-release branch to GitHub"
+  else
+    echo "Not updating the latest-release branch as the tag already exists..."
+  fi
 else
   echo "Not updating the latest-release branch as we're on a branch..."
 fi


### PR DESCRIPTION
If it does, don't update the latest-release branch.
Otherwise, if the version number has changed - update the latest release branch.

This work was done for the [govuk_prototype_kit repo](https://github.com/alphagov/govuk_prototype_kit/pull/296), but hadn't been updated here.