### PR TITLE
Update visuallyhidden to be hyphenated

### DIFF
--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -35,7 +35,7 @@
         <div class="form-group">
           <fieldset>
 
-            <legend class="visuallyhidden">What is your nationality?</legend>
+            <legend class="visually-hidden">What is your nationality?</legend>
 
             <label for="nationality_british" class="block-label">
               <input type="checkbox" name="nationality_british" value="British" id="nationality_british">
@@ -69,7 +69,7 @@
         <div class="form-group">
           <fieldset>
 
-            <legend class="visuallyhidden">
+            <legend class="visually-hidden">
               Where should we send your new passport?
             </legend>
 
@@ -91,7 +91,7 @@
 
               <fieldset>
 
-                <legend class="visuallyhidden">
+                <legend class="visually-hidden">
                   Your other address
                 </legend>
 
@@ -101,7 +101,7 @@
                 </div>
 
                 <div class="form-group">
-                  <label class="form-label visuallyhidden" for="address-line-2">Street</label>
+                  <label class="form-label visually-hidden" for="address-line-2">Street</label>
                   <input type="text" class="form-control" id="address-line-2">
                 </div>
 
@@ -132,7 +132,7 @@
         <div class="form-group">
           <fieldset>
 
-            <legend class="visuallyhidden">
+            <legend class="visually-hidden">
               Which part of the Housing Act was your licence isued under?
             </legend>
 

--- a/app/views/snippets/form_checkboxes.html
+++ b/app/views/snippets/form_checkboxes.html
@@ -4,7 +4,7 @@
 <form>
   <fieldset>
 
-    <legend class="visuallyhidden">Which types of waste do you transport regularly?</legend>
+    <legend class="visually-hidden">Which types of waste do you transport regularly?</legend>
 
     <label class="block-label" for="waste-type-1">
       <input id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal">

--- a/app/views/snippets/form_inset_checkboxes.html
+++ b/app/views/snippets/form_inset_checkboxes.html
@@ -9,7 +9,7 @@
   <div class="form-group">
     <fieldset>
 
-      <legend class="visuallyhidden">What is your nationality?</legend>
+      <legend class="visually-hidden">What is your nationality?</legend>
 
       <label class="block-label" for="nationalities-british">
         <input id="nationalities-british" name="nationalities" type="checkbox" value="British">

--- a/app/views/snippets/form_inset_radios.html
+++ b/app/views/snippets/form_inset_radios.html
@@ -6,7 +6,7 @@
   <div class="form-group">
     <fieldset>
 
-      <legend class="visuallyhidden">How do you want to be contacted?</legend>
+      <legend class="visually-hidden">How do you want to be contacted?</legend>
 
       <label class="block-label" data-target="contact-by-email" for="example-contact-by-email">
         <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Yes">

--- a/app/views/snippets/form_radio_buttons.html
+++ b/app/views/snippets/form_radio_buttons.html
@@ -4,7 +4,7 @@
   <div class="form-group">
     <fieldset>
 
-      <legend class="visuallyhidden">Where do you live?</legend>
+      <legend class="visually-hidden">Where do you live?</legend>
 
       <label class="block-label" for="radio-1">
         <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">

--- a/app/views/snippets/form_radio_buttons_inline.html
+++ b/app/views/snippets/form_radio_buttons_inline.html
@@ -6,7 +6,7 @@
   <div class="form-group">
     <fieldset class="inline">
 
-      <legend class="visuallyhidden">Do you already have a personal user account?</legend>
+      <legend class="visually-hidden">Do you already have a personal user account?</legend>
 
       <label class="block-label" for="radio-inline-1">
         <input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes">

--- a/app/views/snippets/form_radio_inline_yes_no.html
+++ b/app/views/snippets/form_radio_inline_yes_no.html
@@ -6,7 +6,7 @@
   <div class="form-group">
     <fieldset class="inline">
 
-      <legend class="visuallyhidden">Do you yes/no?</legend>
+      <legend class="visually-hidden">Do you yes/no?</legend>
 
       <label class="block-label" data-target="yes-and-do-next" for="radio-yes-no-yes">
         <input id="radio-yes-no-yes" type="radio" name="yes-no-group" value="Yes">

--- a/app/views/snippets/typography_legal_text.html
+++ b/app/views/snippets/typography_legal_text.html
@@ -1,6 +1,6 @@
 <div class="notice">
   <i class="icon icon-important">
-    <span class="visuallyhidden">Warning</span>
+    <span class="visually-hidden">Warning</span>
   </i>
   <strong class="bold-small">
     You can be fined up to £5,000 if you don’t register.


### PR DESCRIPTION
For consistency, update the `visuallyhidden` class to be hyphenated `visually-hidden` where it is used in code snippets.

## Screenshots (if appropriate):

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

We use hyphens between classnames everywhere else, let’s update the
examples to follow the same conventions.