### PR TITLE
Remove rounded corners on form inputs elements and textareas in iOS

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -157,6 +157,8 @@ textarea {
 
 }
 
+// Allow a qualifying element, remove rounded corners from inputs and textareas
+// scss-lint:disable QualifyingElement
 input.form-control,
 textarea.form-control {
   // Remove inner shadow
@@ -164,6 +166,7 @@ textarea.form-control {
   // Remove rounded corners
   border-radius: 0;
 }
+// scss-lint:enable QualifyingElement
 
 // Radio buttons
 .form-radio {

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -157,6 +157,14 @@ textarea {
 
 }
 
+input.form-control,
+textarea.form-control {
+  // Remove inner shadow
+  -webkit-appearance: none;
+  // Remove rounded corners
+  border-radius: 0;
+}
+
 // Radio buttons
 .form-radio {
   display: block;


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->
## What problem does the pull request solve?

<!--- Why is this change required? -->

<!--- If it fixes an open issue, please link to the issue here. -->

This PR removes the rounded corners from form elements in iOS and also the inner shadow from form input elements and textareas.
## What does it do?

<!--- Describe your changes -->

This PR doesn't affect select boxes (drop-down lists) as we'd like to keep native styles for this element.
## Screenshots (if appropriate):

Before:

![realios_iphone_6s_plus](https://cloud.githubusercontent.com/assets/417754/19770208/5808fba0-9c56-11e6-834e-a22e364cffad.jpg)

After:

![realios_iphone_6s_plus 1](https://cloud.githubusercontent.com/assets/417754/19770195/4e3b76de-9c56-11e6-8126-4e92f5034dd1.jpg)
## What type of change is it?

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Put an `x` in all the boxes that apply

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

Remove rounded corners for inputs and textarea elements using the
.form-control class.

Also set -webkit-appearance: none; to remove the inner shadow on these
elements.
