### PR TITLE
Remove the phase banner

### DIFF
--- a/app/views/guide_alpha_beta.html
+++ b/app/views/guide_alpha_beta.html
@@ -6,7 +6,6 @@
 
 <main id="content" role="main" tabindex="-1">
 
-  {% include "includes/phase_banner_survey.html" %}
   {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">

--- a/app/views/guide_buttons.html
+++ b/app/views/guide_buttons.html
@@ -6,7 +6,6 @@
 
 <main id="content" role="main" tabindex="-1">
 
-  {% include "includes/phase_banner_survey.html" %}
   {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">

--- a/app/views/guide_colour.html
+++ b/app/views/guide_colour.html
@@ -6,7 +6,6 @@
 
 <main id="content" role="main" tabindex="-1">
 
-  {% include "includes/phase_banner_survey.html" %}
   {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">

--- a/app/views/guide_data.html
+++ b/app/views/guide_data.html
@@ -6,7 +6,6 @@
 
 <main id="content" role="main" tabindex="-1">
 
-  {% include "includes/phase_banner_survey.html" %}
   {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">

--- a/app/views/guide_errors.html
+++ b/app/views/guide_errors.html
@@ -6,7 +6,6 @@
 
 <main id="content" role="main" tabindex="-1">
 
-  {% include "includes/phase_banner_survey.html" %}
   {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">

--- a/app/views/guide_form_elements.html
+++ b/app/views/guide_form_elements.html
@@ -6,7 +6,6 @@
 
 <main id="content" role="main" tabindex="-1">
 
-  {% include "includes/phase_banner_survey.html" %}
   {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">

--- a/app/views/guide_icons_images.html
+++ b/app/views/guide_icons_images.html
@@ -6,7 +6,6 @@
 
 <main id="content" role="main" tabindex="-1">
 
-  {% include "includes/phase_banner_survey.html" %}
   {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">

--- a/app/views/guide_layout.html
+++ b/app/views/guide_layout.html
@@ -6,7 +6,6 @@
 
 <main id="content" role="main" tabindex="-1">
 
-  {% include "includes/phase_banner_survey.html" %}
   {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">

--- a/app/views/guide_style_guide.html
+++ b/app/views/guide_style_guide.html
@@ -6,7 +6,6 @@
 
 <main id="content" role="main" tabindex="-1">
 
-  {% include "includes/phase_banner_survey.html" %}
   {% include "includes/breadcrumb.html" %}
 
   <div class="grid-row">

--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -6,7 +6,6 @@
 
 <main id="content" role="main" tabindex="-1">
 
-  {% include "includes/phase_banner_survey.html" %}
   {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">

--- a/app/views/includes/phase_banner_survey.html
+++ b/app/views/includes/phase_banner_survey.html
@@ -1,6 +1,0 @@
-<div class="phase-banner-alpha">
-  <p>
-    <strong class="phase-tag">ALPHA</strong>
-    <span>You can help us improve this app by completing our <a href="https://www.surveymonkey.co.uk/r/2MZRS9H">5 minute survey</a>.</span>
-  </p>
-</div>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -8,7 +8,6 @@
 
 <main class="elements-index" id="content" role="main" tabindex="-1">
 
-  {% include "includes/phase_banner_survey.html" %}
   {% include "includes/breadcrumb.html" %}
 
   <div class="grid-row">


### PR DESCRIPTION
Elements definitely isn’t in alpha any more (2.1.0 currently), and the page that the survey link points at was last updated 3 years ago. Let’s just drop it.

Fixes the symptom (but not the underlying problem) of https://github.com/alphagov/govuk_elements/issues/343