### PR TITLE
Fix focus outline on form fields in Chrome / Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express": "4.13.3",
     "express-nunjucks": "^0.9.3",
     "express-writer": "0.0.4",
-    "govuk_template_jinja": "0.19.0",
+    "govuk_template_jinja": "0.19.1",
     "grunt": "^0.4.2",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "^0.4.3",

--- a/public/sass/elements/_govuk-template-base.scss
+++ b/public/sass/elements/_govuk-template-base.scss
@@ -139,4 +139,5 @@ textarea:focus,
 select:focus,
 button:focus {
   outline: 3px solid $focus-colour;
+  outline-offset: 0;
 }


### PR DESCRIPTION
## What problem does the pull request solve?
Chrome and Safari’s focus ring differs from everyone else. This was reported in https://github.com/alphagov/govuk_elements/issues/324

## What does it do?
Sets Chrome and Safari’s default `outline-offset: -2px` to be `0` to match other browsers.

## How has this been tested?
Tested in Firefox, Chrome and Safari on elements locally. Original patch went through wider testing in govuk_template.

## Screenshots (if appropriate):
Screenshots in the original PR: https://github.com/alphagov/govuk_template/pull/259

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.