### PR TITLE
Fix the spacing underneath the "inline" block label example

### DIFF
--- a/public/sass/elements/_panels.scss
+++ b/public/sass/elements/_panels.scss
@@ -54,7 +54,7 @@
 }
 
 // For inline panels
-.inline .form-group .panel-border-narrow {
+.inline .panel-border-narrow {
   margin-top: 10px;
   margin-bottom: 0;
 }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

## What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes #345.

## What does it do?
<!--- Describe your changes -->

This PR ensures that when two block labels are floated next to each other (using the `.inline` class on a parent fieldset) that any conditionally revealed content - for example a panel revealing an additional question, has a top margin of 10px.

For example, a yes/no question:

```
<fieldset class="inline">
   <label class="block-label" data-target="the-revealed-panel">Yes</label>
   <div class="panel-border-narrow" id="the-revealed-panel">
      Additional content for "Yes" option
   </div>
</fieldset>
```

Ensure that this panel has a top margin of 10px, so the border doesn’t
connect with the block label above it.


## Screenshots (if appropriate):

![fix-yes-no](https://cloud.githubusercontent.com/assets/417754/20269003/48813fd6-aa79-11e6-8258-02e7fd73f91a.gif)

## What type of change is it?

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.