### PR TITLE
Fix the grey left hand border example for Radios and checkboxes

### DIFF
--- a/app/views/guide_form_elements.html
+++ b/app/views/guide_form_elements.html
@@ -277,15 +277,29 @@
     {% include "snippets/form_inset_radios.html" %}
   </div>
 
-  <div class="panel panel-border-wide text">
+  <pre>
+  <code class="language-markup">
+    {% include "snippets/encoded/form_inset_radios.html" %}
+  </code>
+  </pre>
+
+  <p class="text">
+    In the code snippet above, the <code class="language-markup">data-target=""</code> attribute is present on every label, as each option reveals an extra field.
+  </p>
+
+  <div class="text">
     <p>
       A grey left hand border is used to visually connect the revealed content with the question above.
     </p>
   </div>
 
+<div class="example">
+  {% include "snippets/form_inset_panel.html" %}
+</div>
+
 <pre>
 <code class="language-markup">
-  <div class="panel panel-border-narrow"></div>
+  {% include "snippets/encoded/form_inset_panel.html" %}
 </code>
 </pre>
 
@@ -294,16 +308,6 @@
       The <a href="/typography/#typography-inset-text">inset text section</a> has more information on where and how to use panels (content with a grey left hand border).
     </p>
   </div>
-
-<pre>
-<code class="language-markup">
-  {% include "snippets/encoded/form_inset_radios.html" %}
-</code>
-</pre>
-
-  <p class="text">
-     In the code snippet above, the <code class="language-markup">data-target=""</code> attribute is present on every label, as each option reveals an extra field.
-  </p>
 
   <h4 class="heading-small" id="form-toggle-content-checkboxes">
     Checkboxes

--- a/app/views/snippets/form_inset_panel.html
+++ b/app/views/snippets/form_inset_panel.html
@@ -1,0 +1,6 @@
+<div class="form-group">
+  <div class="panel panel-border-narrow" id="contact-by-text">
+    <label class="form-label" for="contact-text-message">Mobile phone number</label>
+    <input class="form-control" name="contact-text-message" type="text" id="contact-text-message">
+  </div>
+</div>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

## What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes the example in the [Radios and checkboxes section](http://govuk-elements.herokuapp.com/form-elements/#form-toggle-content), showing a grey left hand border on a conditionally revealed form field, the bug is that this example is empty.

## Screenshots (if appropriate):
Before:
![before - form elements gov uk elements](https://cloud.githubusercontent.com/assets/417754/20276042/93af856c-aa92-11e6-9c3b-7d249376ce94.png)

After:
![form elements gov uk elements - updated](https://cloud.githubusercontent.com/assets/417754/20276032/8e2fddd0-aa92-11e6-8bbe-7ccf7ccc96ce.png)

This PR:
- moves the code snippet for inset radios underneath the example
- adds a new snippet to show the inset panel example

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.