### PR TITLE
Amend data visualisation examples

### DIFF
--- a/app/views/snippets/data_48px_16px.html
+++ b/app/views/snippets/data_48px_16px.html
@@ -1,4 +1,4 @@
 <div class="data">
-  <h2 class="bold-xlarge">48px</h2>
-  <p class="bold-xsmall">16px</p>
+  <span class="data-item bold-xlarge">48px</span>
+  <span class="data-item bold-xsmall">16px</span>
 </div>

--- a/app/views/snippets/data_48px_16px_example.html
+++ b/app/views/snippets/data_48px_16px_example.html
@@ -1,4 +1,4 @@
 <div class="data">
-  <h2 class="bold-xlarge">56/154</h2>
-  <p class="bold-xsmall">on GOV.UK</p>
+  <span class="data-item bold-xlarge">56/154</span>
+  <span class="data-item bold-xsmall">on GOV.UK</span>
 </div>

--- a/app/views/snippets/data_80px_16px.html
+++ b/app/views/snippets/data_80px_16px.html
@@ -1,4 +1,4 @@
 <div class="data">
-  <h2 class="bold-xxlarge">80px</h2>
-  <p class="bold-xsmall">16px</p>
+  <span class="data-item bold-xxlarge">80px</span>
+  <span class="data-item bold-xsmall">16px</span>
 </div>

--- a/app/views/snippets/data_80px_16px_example.html
+++ b/app/views/snippets/data_80px_16px_example.html
@@ -1,4 +1,4 @@
 <div class="data">
-  <h2 class="bold-xxlarge">24</h2>
-  <p class="bold-xsmall">Ministerial departments</p>
+  <span class="data-item bold-xxlarge">24</span>
+  <span class="data-item bold-xsmall">Ministerial departments</span>
 </div>

--- a/public/sass/elements-page.scss
+++ b/public/sass/elements-page.scss
@@ -357,12 +357,7 @@ $palette: (
 // 5. Data
 // ==========================================================================
 
-.data .bold-xlarge,
-.data .bold-xxlarge {
-  line-height: 0.8;
-}
-
-.example .data p {
+.example .data {
   margin-bottom: 0;
 }
 

--- a/public/sass/elements/_elements-typography.scss
+++ b/public/sass/elements/_elements-typography.scss
@@ -291,3 +291,19 @@ hr {
     margin-left: -$gutter-half;
   }
 }
+
+// Data
+.data {
+  margin-top: em(5, 16);
+  margin-bottom: em(20, 16);
+
+  @include media(tablet) {
+    margin-top: em(5, 19);
+    margin-bottom: em(20, 19);
+  }
+}
+
+.data-item {
+  display: block;
+  line-height: 1;
+}


### PR DESCRIPTION
Amend [the data visualisation examples](http://govuk-elements.herokuapp.com/data/#data-visualisation), the styles for these were in the elements "style guide" stylesheets. Move the data styles to elements-typography.

Remove the headings and paragraphs within data examples, instead use `<span>`.

After screenshot:

![data gov uk elements](https://cloud.githubusercontent.com/assets/417754/20300326/a02be784-ab16-11e6-9ad8-1f5234bd2425.png)

