### PR TITLE
Set color:inherit to match text and border colour for form controls

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -146,6 +146,7 @@ textarea {
   width: 100%;
 
   padding: 5px 4px 4px;
+  color: inherit;
   background-color: transparent;
   border: 2px solid;
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

## What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes #358.

Borders on form controls have been inadvertently changed  to`#00000`, this is too dark.
These should remain the same colour as the form label text.

## What does it do?
<!--- Describe your changes -->

As the color property isn't defined for `.form-control`, the user agent is setting this to `color: initial`, which is black #000000.

Setting `color:inherit` ensures the text inside a form control and the border colour become [$text-colour](http://govuk-elements.herokuapp.com/colour/#colour-sass-variables) `#0B0C0C`. 

## Screenshots (if appropriate):

Before:

![before - form elements gov uk elements](https://cloud.githubusercontent.com/assets/417754/20495956/1bd21580-b01b-11e6-882b-e34d6a829950.png)


After:

![after - form elements gov uk elements](https://cloud.githubusercontent.com/assets/417754/20495265/434afb34-b018-11e6-997c-6e4d50dccb32.png)


![colour gov uk elements](https://cloud.githubusercontent.com/assets/417754/20495269/471b377e-b018-11e6-90d8-79f494b42ef4.png)


## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
