### PR TITLE
Bump govuk_frontend_toolkit to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=4.4.7"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^5.0.0"
+    "govuk_frontend_toolkit": "^5.0.1"
   },
   "devDependencies": {
     "body-parser": "^1.14.1",

--- a/public/sass/elements/_icons.scss
+++ b/public/sass/elements/_icons.scss
@@ -81,9 +81,7 @@
   background: $black;
   color: $white;
 
-  // Allow uppercase letters in font stack variable names
-  // scss-lint:disable NameFormat
-  font-family: $NTA-Light-Tabular;
+  font-family: $toolkit-font-stack-tabular;
   font-size: 12px;
   font-weight: bold;
   text-align: center;


### PR DESCRIPTION
Update govuk_frontend_toolkit to 5.0.1

[# 5.0.1](https://raw.githubusercontent.com/alphagov/govuk_frontend_toolkit/master/CHANGELOG.md)

- Fix role="button" click shim ([PR #347](alphagov/govuk_frontend_toolkit#347))
- Make font variables lowercase ([PR#348](alphagov/govuk_frontend_toolkit#348))