### PR TITLE
Update the phase banner examples, the phase tag is now $govuk-blue

### DIFF
--- a/app/views/guide_alpha_beta.html
+++ b/app/views/guide_alpha_beta.html
@@ -55,6 +55,10 @@
     Use the GOV.UK Sass phase banner mixin &ndash; find this in the GOV.UK frontend toolkit <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/design-patterns/_alpha-beta.scss">alpha-beta.scss</a> file.
   </p>
 
+  <p class="text">
+    If you’ve previously used <code>phase-banner-alpha</code> or <code>phase-banner-beta</code> classes in your markup you should change them to <code>phase-banner</code>.
+  </p>
+
   <p>
     <a href="https://designpatterns.hackpad.com/Alpha-and-beta-banners-HpbaBjaYRSJ" rel="external">
       Discuss alpha and beta banners on the design patterns Hackpad

--- a/app/views/includes/phase_banner.html
+++ b/app/views/includes/phase_banner.html
@@ -1,4 +1,4 @@
-<div class="phase-banner-alpha">
+<div class="phase-banner">
   <p>
     <strong class="phase-tag">ALPHA</strong>
     <span>This is a new service – your <a href="https://designpatterns.hackpad.com/GOV.UK-elements-feedback-sKrDyQxcfA2">feedback</a> will help us to improve it.</span>

--- a/app/views/snippets/phase_banner_alpha.html
+++ b/app/views/snippets/phase_banner_alpha.html
@@ -1,4 +1,4 @@
-<div class="phase-banner-alpha">
+<div class="phase-banner">
   <p>
     <strong class="phase-tag">ALPHA</strong>
     <span>This is a new service – your <a href="#">feedback</a> will help us to improve it.</span>

--- a/app/views/snippets/phase_banner_beta.html
+++ b/app/views/snippets/phase_banner_beta.html
@@ -1,4 +1,4 @@
-<div class="phase-banner-beta">
+<div class="phase-banner">
   <p>
     <strong class="phase-tag">BETA</strong>
     <span>This is a new service – your <a href="#">feedback</a> will help us to improve it.</span>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=4.4.7"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^5.0.1"
+    "govuk_frontend_toolkit": "^5.0.2"
   },
   "devDependencies": {
     "body-parser": "^1.14.1",

--- a/public/sass/elements/_phase-banner.scss
+++ b/public/sass/elements/_phase-banner.scss
@@ -1,10 +1,13 @@
 // Phase banners
 // ==========================================================================
 
-.phase-banner-alpha {
+.phase-banner {
   @include phase-banner();
 }
 
+// These classnames are deprecated,
+// they will be removed in a future version of GOV.UK elements
+.phase-banner-alpha,
 .phase-banner-beta {
   @include phase-banner();
 }

--- a/public/sass/elements/_phase-banner.scss
+++ b/public/sass/elements/_phase-banner.scss
@@ -2,9 +2,9 @@
 // ==========================================================================
 
 .phase-banner-alpha {
-  @include phase-banner($state: alpha);
+  @include phase-banner();
 }
 
 .phase-banner-beta {
-  @include phase-banner($state: beta);
+  @include phase-banner();
 }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->
This PR anticipates the changes to the [govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit/pull/353), by removing the state passed to the phase banner mixin.  This is no longer required, as the phase tag has a $govuk-blue background.

Once the govuk_frontend_toolkit has been updated, govuk_elements can be updated to use the latest version.

## Screenshots (if appropriate):

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
