### PR TITLE
Use the same example NI number throughout

### DIFF
--- a/app/views/snippets/form_error_multiple.html
+++ b/app/views/snippets/form_error_multiple.html
@@ -50,7 +50,7 @@
     <span class="form-hint">
       It's on your National Insurance card, benefit letter, payslip or P60.
       <br>
-      For example, 'VO 12 34 56 D'.
+      For example, 'QQ 12 34 56 C'.
     </span>
     {% if error %}
       {% if not niNo %}

--- a/app/views/snippets/form_error_multiple_show_errors.html
+++ b/app/views/snippets/form_error_multiple_show_errors.html
@@ -40,7 +40,7 @@
     <span class="form-hint">
       It's on your National Insurance card, benefit letter, payslip or P60.
       <br>
-      For example, 'VO 12 34 56 D'.
+      For example, 'QQ 12 34 56 C'.
     </span>
     <span class="error-message" id="error-message-ni-number">
       Error message about National Insurance number goes here

--- a/app/views/snippets/form_hint_text.html
+++ b/app/views/snippets/form_hint_text.html
@@ -1,5 +1,9 @@
 <label class="form-label" for="ni-number">
   National Insurance number
-  <span class="form-hint">It'll be on your last payslip. For example, VO 12 34 56 D.</span>
+  <span class="form-hint">
+    It's on your National Insurance card, benefit letter, payslip or P60.
+    <br>
+    For example, 'QQ 12 34 56 C'.
+  </span>
 </label>
 <input class="form-control" id="ni-number" type="text">


### PR DESCRIPTION
Use the [example National Insurance number recommended by the service manual](
https://www.gov.uk/service-manual/user-centred-design/resources/patterns/national-insurance-number.html).

Also update the hint text when asking for a national insurance number so
the examples are consistent.

cc. @edwardhorsford.
