### PR TITLE
Fix the service manual link in the header

### DIFF
--- a/app/views/includes/propositional_navigation.html
+++ b/app/views/includes/propositional_navigation.html
@@ -5,7 +5,7 @@
       <a href="https://www.gov.uk/service-manual" id="proposition-name">Government Service Design Manual</a>
       <ul id="proposition-links">
         <li><a href="https://www.gov.uk/service-manual/digital-by-default">Digital by Default Service Standard</a></li>
-        <li><a href="https://www.gov.uk/service-manual/start">Start using the manual</a></li>
+        <li><a href="https://www.gov.uk/service-manual">Start using the manual</a></li>
         <li><a href="https://www.gov.uk/contact/govuk">Feedback</a></li>
       </ul>
     </nav>

--- a/app/views/includes/service_manual_navigation.html
+++ b/app/views/includes/service_manual_navigation.html
@@ -5,7 +5,7 @@
       <a href="https://www.gov.uk/service-manual" id="proposition-name">Government Service Design Manual</a>
       <ul id="proposition-links">
         <li><a href="https://www.gov.uk/service-manual/digital-by-default">Digital by Default Service Standard</a></li>
-        <li><a href="https://www.gov.uk/service-manual/start">Start using the manual</a></li>
+        <li><a href="https://www.gov.uk/service-manual">Start using the manual</a></li>
         <li><a href="https://www.gov.uk/contact/govuk">Feedback</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
Now that the new service manual is live, this page doesn’t exist any more.

Fixes https://github.com/alphagov/govuk_elements/issues/378