### PR TITLE
Add basic styling for typographic elements

### DIFF
--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -21,13 +21,13 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <ul class="list list-contents">
-        <li><a href="#typography-class">Style elements automatically</a></li>
         <li><a href="#typography-font">Font</a></li>
         <li><a href="#typography-headings">Headings</a></li>
         <li><a href="#typography-lead-paragraph">Lead paragraph</a></li>
         <li><a href="#typography-body-copy">Body copy</a></li>
         <li><a href="#typography-links">Links</a></li>
         <li><a href="#typography-lists">Lists</a></li>
+        <li><a href="#typography-scope">Scoped typographic styles</a></li>
         <li><a href="#typography-inset-text">Inset text</a></li>
         <li><a href="#typography-legal-text">Legal text</a></li>
         <li><a href="#typography-hidden-text">Hidden text (progressive disclosure)</a></li>
@@ -35,23 +35,6 @@
       </ul>
     </div>
   </div>
-
-  <h3 class="heading-medium" id="typography-class">Style elements automatically</h3>
-  <div class="text">
-    <p>You can use the <code class="code">govuk-prose</code> class around a body of prose. Then certain elements inside will be styled automatically without the need to add specific classes to each of them.</p>
-    <p>That will apply to most typographic elements: headings, lists, links, strong and code. Some elements are already always styled without that class: Tables, paragraphs, details and horizontal rules. (Links and strong are only automatically styled without that class when using govuk_template or govuk-template-base.scss.)</p>
-    <p>Please note, adding this class to anything as generic as the <code class="code">body</code> is not supported and can have unintended consequences.</p>
-  </div>
-
-<div class="example">
-  {% include "snippets/typography_class.html" %}
-</div>
-
-<pre>
-<code class="language-markup">
-  {% filter escape %}{% include "snippets/typography_class.html" %}{% endfilter %}
-</code>
-</pre>
 
   <h3 class="heading-medium" id="typography-font">Font</h3>
   <div class="text">
@@ -172,6 +155,32 @@
   {% filter escape %}
     {% include "snippets/typography_lists.html" %}
   {% endfilter %}
+</code>
+</pre>
+
+  <h3 class="heading-medium" id="typography-scope">Scoped typographic styles</h3>
+  <div class="text">
+    <p>
+      You can use the class <code class="code">govuk-prose</code> around a body of prose.
+    </p>
+    <p>
+      This will style headings, links, lists, strong and code elements without the need to add a class to them.
+    </p>
+    <p>
+      The following html elements are already styled without requiring a class to be added - tables, paragraphs, details and horizontal rules.
+    </p>
+    <p>
+      Don't add this class to the <code class="code">body</code>, it is intended to wrap areas of text-based content.
+    </p>
+  </div>
+
+<div class="example">
+  {% include "snippets/typography_scope.html" %}
+</div>
+
+<pre>
+<code class="language-markup">
+  {% filter escape %}{% include "snippets/typography_scope.html" %}{% endfilter %}
 </code>
 </pre>
 

--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -21,6 +21,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <ul class="list list-contents">
+        <li><a href="#typography-class">Style elements automatically</a></li>
         <li><a href="#typography-font">Font</a></li>
         <li><a href="#typography-headings">Headings</a></li>
         <li><a href="#typography-lead-paragraph">Lead paragraph</a></li>
@@ -34,6 +35,23 @@
       </ul>
     </div>
   </div>
+
+  <h3 class="heading-medium" id="typography-class">Style elements automatically</h3>
+  <div class="text">
+    <p>You can use the <code class="code">govuk-prose</code> class around a body of prose. Then certain elements inside will be styled automatically without the need to add specific classes to each of them.</p>
+    <p>That will apply to most typographic elements: headings, lists, links, strong and code. Some elements are already always styled without that class: Tables, paragraphs, details and horizontal rules. (Links and strong are only automatically styled without that class when using govuk_template or govuk-template-base.scss.)</p>
+    <p>Please note, adding this class to anything as generic as the <code class="code">body</code> is not supported and can have unintended consequences.</p>
+  </div>
+
+<div class="example">
+  {% include "snippets/typography_class.html" %}
+</div>
+
+<pre>
+<code class="language-markup">
+  {% filter escape %}{% include "snippets/typography_class.html" %}{% endfilter %}
+</code>
+</pre>
 
   <h3 class="heading-medium" id="typography-font">Font</h3>
   <div class="text">
@@ -228,7 +246,6 @@
       <a href="/typography/example-details-summary/">Take a look at example page</a> which demonstrates conditionally revealing information, using the HTML5 details and summary elements.
     </p>
   </div>
-
 
   <h3 class="heading-medium" id="examples">Examples</h3>
   <ul class="list list-bullet">

--- a/app/views/snippets/typography_class.html
+++ b/app/views/snippets/typography_class.html
@@ -1,0 +1,15 @@
+<div class="govuk-prose">
+  <h3>Heading</h3>
+
+  <ul>
+    <li>Unordered list</li>
+    <li>With some <strong>bold</strong></li>
+  </ul>
+
+  <ol>
+    <li>Ordered list</li>
+    <li>With some <code>code</code></li>
+  </ol>
+
+  <p>And a <a href="#">link</a> within a paragraph.</p>
+</div>

--- a/app/views/snippets/typography_scope.html
+++ b/app/views/snippets/typography_scope.html
@@ -1,5 +1,7 @@
 <div class="govuk-prose">
-  <h3>Heading</h3>
+  <h1>Heading level 1</h1>
+  <h2>Heading level 2</h2>
+  <h3>Heading level 3</h3>
 
   <ul>
     <li>Unordered list</li>

--- a/assets/sass/elements/_elements-typography.scss
+++ b/assets/sass/elements/_elements-typography.scss
@@ -60,6 +60,7 @@ main {
 }
 
 // Bold, without needing a font size
+.govuk-prose strong,
 .bold {
   font-weight: 700;
 }
@@ -69,6 +70,7 @@ main {
 // Spacing is set in em, using the px to em function in the elements _helpers.scss file
 
 // Headings
+.govuk-prose h1,
 .heading-xlarge {
   @include bold-48();
 
@@ -89,6 +91,7 @@ main {
 
 }
 
+.govuk-prose h2,
 .heading-large {
   @include bold-36();
 
@@ -109,6 +112,7 @@ main {
 
 }
 
+.govuk-prose h3,
 .heading-medium {
   @include bold-24();
 
@@ -122,6 +126,7 @@ main {
 
 }
 
+.govuk-prose h4,
 .heading-small {
   @include bold-19();
 
@@ -167,19 +172,23 @@ p,
 }
 
 // Link styles
+.govuk-prose a,
 .link {
   color: $link-colour;
   text-decoration: underline;
 }
 
+.govuk-prose a:visited,
 .link:visited {
   color: $link-visited-colour;
 }
 
+.govuk-prose a:hover,
 .link:hover {
   color: $link-hover-colour;
 }
 
+.govuk-prose a:active,
 .link:active {
   color: $link-colour;
 }
@@ -236,6 +245,7 @@ p,
 }
 
 // Code styles
+.govuk-prose code,
 .code {
   color: $text-colour;
   background-color: $highlight-colour;

--- a/assets/sass/elements/_lists.scss
+++ b/assets/sass/elements/_lists.scss
@@ -6,23 +6,28 @@ ol {
   list-style-type: none;
 }
 
+.govuk-prose ul,
+.govuk-prose ol,
 .list {
   padding: 0;
   margin-top: 5px;
   margin-bottom: 20px;
 }
 
+.govuk-prose li,
 .list li {
   margin-bottom: 5px;
 }
 
 // Bulleted lists
+.govuk-prose ul,
 .list-bullet {
   list-style-type: disc;
   padding-left: 20px;
 }
 
 // Numbered lists
+.govuk-prose ol,
 .list-number {
   list-style-type: decimal;
   padding-left: 20px;


### PR DESCRIPTION
This adds styling to standard typographic elements without the need to use classes directly on the elements.
<del>Please discuss.</del>

<!--- Provide a summary of your changes in the Title above -->

## What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I find having all HTML elements styled in a sensible way really important. I call that "basic styles".
It is important because it makes it easier for non-frontend developers to use the correct markup. It makes the general look and feel more consistent. It reduced the amount of markup and CSS necessary. And it saves time by making simple markup look good by default.

It is similar to what the `govuk-govspeak` class from GOV.UK Components provides, although that had a different intention.

When I set up my first project with Elements [I overcame this restriction in a way which some people didn't like](https://github.com/alphagov/content-performance-manager/blob/master/app/assets/stylesheets/_base.scss). This PR would make that unnecessary (unless we're using slimmer/static and can use `govuk-govspeak`).

## What does it do?
<!--- Describe your changes -->

This adds styling to standard typographic elements (i.e. headings, lists, links, code, strong) without the need to use classes directly on the elements.
This is done scoped under the <del>`govuk-basic-styles`</del> `govuk-prose` class which can be added to the `body` or `main` or just a single component. That makes it backwards-compatible and people can opt in to use them.

Inconsistently, some basic (but non-scoped) styles already exist for:
* tables
* paragraphs (spacing)
* details/summary
* links (although links are styled via govuk_template not via Elements)

After this change, it would stay inconsistent that one type of styles are scoped and others are not. To change that would be a breaking change whether you chose all of them to be opt in or opt out.

<del>This is not a full PR as it is meant to start a discussion.</del> What would be necessary to complete this PR:
* [x] testing
* [x] documentation

Later other missing elements could also be styled (e.g. definition lists or quotes) which you would expect to be styled.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<del>This has not been tested yet as this PR was created to have a discussion about the basic idea first. I will test properly and write documentation if people are happy with the basic idea.</del>

I have tested all the relevant elements inside a div with the new class in the styleguide that comes with Elements. I have only tested in one browser as I don't believe there will be any browser-related issues. Please let me know if I should test anything more.

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
