### PR TITLE
Move deployment setup to `before_install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: node_js
 node_js:
  - "4.4.7"
 before_install:
+- git config --global user.name "Travis CI"
+- git config --global user.email "travis@travis-ci.org"
+- git remote add origin_ssh git@github.com:alphagov/govuk_elements.git
+- openssl aes-256-cbc -K $encrypted_85ebe8034b89_key -iv $encrypted_85ebe8034b89_iv -in .travis/govuk_elements.enc -out ~/.ssh/id_rsa -d
+  # This openssl command was generated automatically by `travis encrypt-file`, see `.travis/README.md` for more details
+- chmod 600 ~/.ssh/id_rsa
 - npm install -g grunt-cli
 install:
 - npm install
@@ -11,12 +17,6 @@ notifications:
   email: false
 before_deploy:
 - test $TRAVIS_TEST_RESULT = 0
-- git config --global user.name "Travis CI"
-- git config --global user.email "travis@travis-ci.org"
-- git remote add origin_ssh git@github.com:alphagov/govuk_elements.git
-- openssl aes-256-cbc -K $encrypted_85ebe8034b89_key -iv $encrypted_85ebe8034b89_iv -in .travis/govuk_elements.enc -out ~/.ssh/id_rsa -d
-  # This openssl command was generated automatically by `travis encrypt-file`, see `.travis/README.md` for more details
-- chmod 600 ~/.ssh/id_rsa
 deploy:
 - provider: script
   script: './push-version-tag.sh'


### PR DESCRIPTION
The `before_install` section is run before each deployment. As this project has many deployments, the commands will be run multiple times. They're not idempotent so this fails:

```
fatal: remote origin_ssh already exists.
```

We can work around this by doing them as part of the test setup instead.
