### PR TITLE
Update status swatches

### DIFF
--- a/app/views/guide_colour.html
+++ b/app/views/guide_colour.html
@@ -141,35 +141,14 @@
   <div class="example">
 
     <div class="swatch-wrapper">
-      <div class="swatch swatch-alpha"></div>
+      <div class="swatch swatch-govuk-blue"></div>
       <ul>
-        <li><b>#d53880</b></li>
-        <li>$alpha-colour</li>
+        <li><b>#005ea5</b></li>
+        <li>$govuk-blue</li>
       </ul>
-    </div>
-
-    <div class="swatch-wrapper">
-      <div class="swatch swatch-beta"></div>
-      <ul>
-        <li><b>#f47738</b></li>
-        <li>$beta-colour</li>
-      </ul>
-    </div>
-
-    <div class="swatch-wrapper">
-      <div class="swatch swatch-discovery"></div>
-      <ul>
-        <li><b>#912b88</b></li>
-        <li>$discovery-colour</li>
-      </ul>
-    </div>
-
-    <div class="swatch-wrapper">
-      <div class="swatch swatch-live"></div>
-      <ul>
-        <li><b>#85994b</b></li>
-        <li>$live-colour</li>
-      </ul>
+      <p>
+        Use for Alpha and Beta banners
+      </p>
     </div>
 
     <div class="swatch-wrapper">
@@ -178,6 +157,9 @@
         <li><b>#B10E1E</b></li>
         <li>$error-colour</li>
       </ul>
+      <p>
+        Use for error messages
+      </p>
     </div>
 
   </div>


### PR DESCRIPTION
Remove swatches for alpha, beta, discovery and live.

Add context for the two status colour swatches - one is for alpha and
beta banners, the other for error messages.

#### Screenshots

#### Before: 

![colour gov uk elements - before](https://cloud.githubusercontent.com/assets/417754/21937402/40e14d06-d9af-11e6-92ed-ae390d6011db.png)

#### After:

![colour gov uk elements](https://cloud.githubusercontent.com/assets/417754/21937352/0d20636c-d9af-11e6-8080-64ceca07e72f.png)
