### PR TITLE
Fix conditional match to use typeof

### DIFF
--- a/public/javascripts/redirect.js
+++ b/public/javascripts/redirect.js
@@ -51,7 +51,7 @@
       '#alpha-beta-creating-banners': '/alpha-beta-banners/#creating-phase-banners'
     }
 
-    if (newRoutes[fragment] !== 'undefined') {
+    if (typeof newRoutes[fragment] !== 'undefined') {
       return baseURL + newRoutes[fragment]
     }
 


### PR DESCRIPTION
We're missing a typeof in our conditional to check if something needs to be redirected.
