### PR TITLE
Remove the title from the cookie message link

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -5,6 +5,6 @@
 module.exports = {
 
   // Cookie warning
-  cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies" title="Find out more about cookies">Find out more about cookies</a>'
+  cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'
 
 }


### PR DESCRIPTION
It’s unnecessary and doesn’t give an accessibility benefit. Thanks to @trevorsaint for catching this.