### PR TITLE
Only attempt to decrypt encrypted files on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ before_install:
 - git config --global user.name "Travis CI"
 - git config --global user.email "travis@travis-ci.org"
 - git remote add origin_ssh git@github.com:alphagov/govuk_elements.git
-- openssl aes-256-cbc -K $encrypted_85ebe8034b89_key -iv $encrypted_85ebe8034b89_iv -in .travis/govuk_elements.enc -out ~/.ssh/id_rsa -d
+- 'if [ "$TRAVIS_BRANCH" = "master" ]; then openssl aes-256-cbc -K $encrypted_85ebe8034b89_key -iv $encrypted_85ebe8034b89_iv -in .travis/govuk_elements.enc -out ~/.ssh/id_rsa -d && chmod 600 ~/.ssh/id_rsa; fi'
   # This openssl command was generated automatically by `travis encrypt-file`, see `.travis/README.md` for more details
-- chmod 600 ~/.ssh/id_rsa
 - npm install -g grunt-cli
 install:
 - npm install


### PR DESCRIPTION
People can make pull requests from forks, which will try to decrypt
encrypted files using `$encrypted_85ebe8034b89_key` and `$encrypted_85ebe8034b89_iv`.

Travis doesn't make those environment variables available to forks
because then somebody could run `echo $encrypted_85ebe8034b89_key`
to get the value of the variable and get access to our secrets.
