### PR TITLE
Update advisory node requirement to 6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "alphagov/govuk_elements",
   "license": "MIT",
   "engines": {
-    "node": ">=4.4.7"
+    "node": ">=6.0"
   },
   "dependencies": {
     "govuk_frontend_toolkit": "^5.0.2"


### PR DESCRIPTION
6.0 is the LTS version, update package.json to use this.

