### PR TITLE
add red border to erroneous date inputs

### DIFF
--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -10,7 +10,8 @@
 
   // Form inputs should have a red border
   // Add a red border to .form-controls that are direct descendants
-  > .form-control {
+  > .form-control,
+  > fieldset > .form-date .form-control {
     border: 4px solid $error-colour;
   }
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->
Change to validation sass to target date pattern inputs so when the error class is added to the parent date pattern element the date inputs have a red border applied to them

## What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There isnt an open issue, but if you look at the example on this page, the date pattern with an error is missing the red border - https://govuk-elements.herokuapp.com/form-elements/example-form-elements/ 

## What does it do?
<!--- Describe your changes -->
Restores consistency with error styles

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Looking at the same page after the fix has been applied shows the date pattern input with a red border 

## Screenshots (if appropriate):

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
