### PR TITLE
Fix invisible input content when changing colours

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -146,9 +146,9 @@ textarea {
   width: 100%;
 
   padding: 5px 4px 4px;
-  color: inherit;
-  background-color: transparent;
-  border: 2px solid;
+  // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
+  // as background-color and color need to always be set together, color should not be set either
+  border: 2px solid $text-colour;
 
   // TODO: Remove 50% width set for tablet and up
   // !! BREAKING CHANGE !!


### PR DESCRIPTION
When overwriting colours via browser settings, Firefox and IE always default to black text in form fields, irrespective of said settings.
When the background of the form fields is transparent and the general background is dark (e.g. black), it results in black text on a black background, i.e. making the text invisible and therefore completely inaccessible.

It seems counterintuitive but due to browser bugs (which I will report) it is necessary to remove the `background-color: transparent`. The only downside I can see is that anyone wanting to use input fields on a non-white background would need to give it a background colour (which would actually re-introduce this bug again in Firefox).

A reduced test case to play around with: http://jsbin.com/sibube
See also alphagov/govuk_frontend_toolkit#377.

<!--- Provide a summary of your changes in the Title above -->

## What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It makes text within form fields accessible to partially sighted users who change their browser's colour settings in IE or Firefox.

## What does it do?
<!--- Describe your changes -->

It removes the transparent background from input fields.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested this in
* Firefox and IE 11 and 8 with default colours, a dark and a light background via their browser settings
* Chrome with default colours, a dark and a light background via the extensions "High Contrast" and "Change Colors"
* Firefox, IE 11 and Edge with default colours, a dark and a light background via the Windows accessibility system settings
* Various browser with different colours via Mac OS, iOS and Android accessibility system settings

## Screenshots (if appropriate):

(Please ignore the buttons in those screenshots, I will open a different PR for that. Also ignore the wrong font.)

This is the page I was testing, showing the default colours:
![firefox-default](https://cloud.githubusercontent.com/assets/108893/22440134/2e2d5618-e72a-11e6-90e0-093238c0f43b.png)

### Before, i.e. showing the bug

Firefox:
![firefox-dark-before](https://cloud.githubusercontent.com/assets/108893/22440220/7aee8260-e72a-11e6-84cd-03d7873b0b7c.png)

IE 11:
<img width="423" alt="ie-dark-before" src="https://cloud.githubusercontent.com/assets/108893/22440243/90efc894-e72a-11e6-9674-91ebef04bf20.png">

### After, i.e. with fix

Firefox:
![firefox-dark-after](https://cloud.githubusercontent.com/assets/108893/22440267/ab0392a6-e72a-11e6-8b85-f3587442dabe.png)

IE 11:
<img width="418" alt="ie-dark-after" src="https://cloud.githubusercontent.com/assets/108893/22440278/b6b148dc-e72a-11e6-859b-44e572ef6be0.png">


## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
