### PR TITLE
[Discuss] Update custom radio and checkbox focus styles

### DIFF
--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -98,11 +98,16 @@
     }
 
     // Focused state
+    &.selection-button-checkbox .focused::before {
+      @include box-shadow(0 0 0 3px $focus-colour);
+    }
+     
+    &.selection-button-radio .focused::before {
+      @include box-shadow(0 0 0 4px $focus-colour);
+    }
+    
     &.selection-button-radio,
     &.selection-button-checkbox {
-      &.focused::before {
-        @include box-shadow(0 0 0 5px $focus-colour);
-      }
       // IE8 focus outline should stay as a border around the entire label
       // Lack of padding doesn’t matter as IE8 won’t resize the inputs.
       @include ie-lte(8) {

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -101,7 +101,7 @@
     &.selection-button-checkbox .focused::before {
       @include box-shadow(0 0 0 3px $focus-colour);
     }
-     
+    
     &.selection-button-radio .focused::before {
       @include box-shadow(0 0 0 4px $focus-colour);
     }


### PR DESCRIPTION
## What problem does the pull request solve?
When comparing the focus styles of checkboxes with the disclosure pattern on http://govuk-elements.herokuapp.com/form-elements/, the focus styles feel inconsistent.

## How has this been tested?
Only in Chrome for now

## Screenshots (if appropriate):


Before

<img width="505" alt="screen shot 2017-02-02 at 18 24 22" src="https://cloud.githubusercontent.com/assets/18534862/22562611/33705754-e975-11e6-99cd-35825ccef4da.png">

After

<img width="551" alt="screen shot 2017-02-02 at 18 24 39" src="https://cloud.githubusercontent.com/assets/18534862/22562613/3374ae30-e975-11e6-851f-59234f42160c.png">

---

Before

<img width="512" alt="screen shot 2017-02-02 at 18 25 46" src="https://cloud.githubusercontent.com/assets/18534862/22562612/3374555c-e975-11e6-9f00-1f46595d66ec.png">

After

<img width="498" alt="screen shot 2017-02-02 at 18 25 58" src="https://cloud.githubusercontent.com/assets/18534862/22562614/3376e16e-e975-11e6-9f9a-36136a0367b8.png">

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

