### PR TITLE
Update custom radio and checkbox focus styles

### DIFF
--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -98,11 +98,11 @@
     }
 
     // Focused state
-    &.selection-button-checkbox .focused::before {
+    &.selection-button-checkbox.focused::before {
       @include box-shadow(0 0 0 3px $focus-colour);
     }
 
-    &.selection-button-radio .focused::before {
+    &.selection-button-radio.focused::before {
       @include box-shadow(0 0 0 4px $focus-colour);
     }
 

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -106,17 +106,15 @@
       @include box-shadow(0 0 0 4px $focus-colour);
     }
 
-    &.selection-button-radio,
-    &.selection-button-checkbox {
-      // IE8 focus outline should stay as a border around the entire label
-      // Lack of padding doesn’t matter as IE8 won’t resize the inputs.
-      @include ie-lte(8) {
-        &.focused {
-          outline: 3px solid $focus-colour;
+    // IE8 focus outline should stay as a border around the entire label
+    // Lack of padding doesn’t matter as IE8 won’t resize the inputs.
+    @include ie-lte(8) {
+      &.selection-button-radio.focused,
+      &.selection-button-checkbox.focused {
+        outline: 3px solid $focus-colour;
 
-          input:focus {
-            outline: none;
-          }
+        input:focus {
+          outline: none;
         }
       }
     }

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -98,11 +98,16 @@
     }
 
     // Focused state
+    &.selection-button-checkbox .focused::before {
+      @include box-shadow(0 0 0 3px $focus-colour);
+    }
+
+    &.selection-button-radio .focused::before {
+      @include box-shadow(0 0 0 4px $focus-colour);
+    }
+
     &.selection-button-radio,
     &.selection-button-checkbox {
-      &.focused::before {
-        @include box-shadow(0 0 0 5px $focus-colour);
-      }
       // IE8 focus outline should stay as a border around the entire label
       // Lack of padding doesn’t matter as IE8 won’t resize the inputs.
       @include ie-lte(8) {


### PR DESCRIPTION
#### What problem does the pull request solve?

This PR is copied from #399 by @miaallers.

It makes checkbox and radio focused styles visually consistent with the input focus style.

Closing #399 in favour of this PR, this one fixes the whitespace issues I wasn't able to update on Mia's fork.

#### Screenshots (if appropriate):

![feb-09-2017 18-38-16](https://cloud.githubusercontent.com/assets/417754/22797660/0281f922-eef7-11e6-8974-36b4ab49cb00.gif)

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)


#### Put an `x` in all the boxes that apply
- I have read the **CONTRIBUTING** document.
