### PR TITLE
Breaking changes to form validation

### DIFF
--- a/app/views/examples/example_date.html
+++ b/app/views/examples/example_date.html
@@ -17,6 +17,83 @@
       <!-- Date of birth -->
       {% include "snippets/form_date.html" %}
 
+      {% include "snippets/form_date_show_errors.html" %}
+
+      <!-- Date of birth -->
+      <div class="form-group form-group-error">
+        <fieldset>
+          <legend>
+            <span class="form-label-bold">Date of birth</span>
+            <span class="form-hint" id="example-dob-hint-1">For example, 31 3 1980</span>
+            <span class="error-message">Error message goes here</span>
+          </legend>
+          <div class="form-date">
+            <div class="form-group form-group-day">
+              <label class="form-label" for="example-dob-day-1">Day</label>
+              <input class="form-control form-control-error" id="example-dob-day-1" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint-1">
+            </div>
+            <div class="form-group form-group-month">
+              <label class="form-label" for="example-dob-month-1">Month</label>
+              <input class="form-control" id="example-dob-month-1" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+            </div>
+            <div class="form-group form-group-year">
+              <label class="form-label" for="example-dob-year-1">Year</label>
+              <input class="form-control" id="example-dob-year-1" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <!-- Date of birth -->
+      <div class="form-group form-group-error">
+        <fieldset>
+          <legend>
+            <span class="form-label-bold">Date of birth</span>
+            <span class="form-hint" id="example-dob-hint-2">For example, 31 3 1980</span>
+            <span class="error-message">Error message goes here</span>
+          </legend>
+          <div class="form-date">
+            <div class="form-group form-group-day">
+              <label class="form-label" for="example-dob-day-2">Day</label>
+              <input class="form-control" id="example-dob-day-2" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint-2">
+            </div>
+            <div class="form-group form-group-month">
+              <label class="form-label" for="example-dob-month-2">Month</label>
+              <input class="form-control form-control-error" id="example-dob-month-2" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+            </div>
+            <div class="form-group form-group-year">
+              <label class="form-label" for="example-dob-year-2">Year</label>
+              <input class="form-control" id="example-dob-year-2" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <!-- Date of birth -->
+      <div class="form-group form-group-error">
+        <fieldset>
+          <legend>
+            <span class="form-label-bold">Date of birth</span>
+            <span class="form-hint" id="example-dob-hint-3">For example, 31 3 1980</span>
+            <span class="error-message">Error message goes here</span>
+          </legend>
+          <div class="form-date">
+            <div class="form-group form-group-day">
+              <label class="form-label" for="example-dob-day-3">Day</label>
+              <input class="form-control" id="example-dob-day-3" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint-3">
+            </div>
+            <div class="form-group form-group-month">
+              <label class="form-label" for="example-dob-month-3">Month</label>
+              <input class="form-control" id="example-dob-month-3" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+            </div>
+            <div class="form-group form-group-year">
+              <label class="form-label" for="example-dob-year-3">Year</label>
+              <input class="form-control form-control-error" id="example-dob-year-3" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
     </div>
   </div>
 

--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -124,7 +124,7 @@
           </p>
 
           <!-- Text inside a label - error -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <label class="form-label-bold" for="example-form-control">
               This is the label text
               <span class="form-hint">
@@ -138,7 +138,7 @@
           </div>
 
           <!-- Hint text outside a label (preference is inside, to be read by AT) - error -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <label class="form-label-bold" for="example-form-control">
               This is the label text
             </label>
@@ -152,7 +152,7 @@
           </div>
 
           <!-- Text inside a legend - error -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <fieldset>
 
               <legend>
@@ -174,7 +174,7 @@
           </div>
 
           <!-- Date of birth -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <fieldset>
               <legend>
                 <span class="form-label-bold">Date of birth</span>
@@ -269,7 +269,7 @@
           </div>
 
           <!-- Input type="text" - error -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <label class="form-label" for="input-text-b">
               This is the label text
               <span class="error-message">
@@ -288,7 +288,7 @@
           </div>
 
           <!-- Input type="text" - error (bold label) -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <label class="form-label-bold" for="input-text-d">
               This is the label text in bold
               <span class="error-message">
@@ -320,7 +320,7 @@
           </div>
 
           <!-- Input type="text" - error (bold label with hint text) -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <label class="form-label-bold" for="input-text-h">
               This is the label text
               <span class="form-hint">
@@ -352,7 +352,7 @@
           </div>
 
           <!-- Textarea - error -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <label class="form-label" for="textarea-b">
               This is the label text
               <span class="error-message">
@@ -371,7 +371,7 @@
           </div>
 
           <!-- Textarea - error (bold label) -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <label class="form-label-bold" for="textarea-d">
               This is the label text in bold
               <span class="error-message">
@@ -391,7 +391,7 @@
           </div>
 
           <!-- Textarea - error (bold label, with hint text) -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <label class="form-label-bold" for="textarea-f">
               This is the label text
               <span class="form-hint">This is hint text</span>
@@ -419,7 +419,7 @@
           </div>
 
           <!-- Select box - error -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <label class="form-label" for="select-box-b">
               This is the label text
               <span class="error-message">
@@ -448,7 +448,7 @@
           </div>
 
           <!-- Select box - error (with bold text) -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <label class="form-label-bold" for="select-box-d">
               This is the label text
               <span class="error-message">
@@ -480,7 +480,7 @@
           </div>
 
           <!-- Select box - error (with bold text and hint text) -->
-          <div class="form-group error">
+          <div class="form-group form-group-error">
             <label class="form-label-bold" for="select-box-h">
               This is the label text
               <span class="form-hint">

--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -178,25 +178,76 @@
             <fieldset>
               <legend>
                 <span class="form-label-bold">Date of birth</span>
-                <span class="form-hint" id="example-dob-hint">For example, 31 3 1980</span>
+                <span class="form-hint" id="example-dob-hint-1">For example, 31 3 1980</span>
                 <span class="error-message">Error message goes here</span>
               </legend>
               <div class="form-date">
                 <div class="form-group form-group-day">
-                  <label class="form-label" for="example-dob-day">Day</label>
-                  <input class="form-control form-control-error" id="example-dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint">
+                  <label class="form-label" for="example-dob-day-1">Day</label>
+                  <input class="form-control form-control-error" id="example-dob-day-1" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint-1">
                 </div>
                 <div class="form-group form-group-month">
-                  <label class="form-label" for="example-dob-month">Month</label>
-                  <input class="form-control" id="example-dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+                  <label class="form-label" for="example-dob-month-1">Month</label>
+                  <input class="form-control" id="example-dob-month-1" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
                 </div>
                 <div class="form-group form-group-year">
-                  <label class="form-label" for="example-dob-year">Year</label>
-                  <input class="form-control" id="example-dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+                  <label class="form-label" for="example-dob-year-1">Year</label>
+                  <input class="form-control" id="example-dob-year-1" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
                 </div>
               </div>
             </fieldset>
           </div>
+
+          <!-- Date of birth -->
+          <div class="form-group form-group-error">
+            <fieldset>
+              <legend>
+                <span class="form-label-bold">Date of birth</span>
+                <span class="form-hint" id="example-dob-hint-2">For example, 31 3 1980</span>
+                <span class="error-message">Error message goes here</span>
+              </legend>
+              <div class="form-date">
+                <div class="form-group form-group-day">
+                  <label class="form-label" for="example-dob-day-2">Day</label>
+                  <input class="form-control" id="example-dob-day-2" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint-2">
+                </div>
+                <div class="form-group form-group-month">
+                  <label class="form-label" for="example-dob-month-2">Month</label>
+                  <input class="form-control form-control-error" id="example-dob-month-2" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+                </div>
+                <div class="form-group form-group-year">
+                  <label class="form-label" for="example-dob-year-2">Year</label>
+                  <input class="form-control" id="example-dob-year-2" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+                </div>
+              </div>
+            </fieldset>
+          </div>
+
+          <!-- Date of birth -->
+          <div class="form-group form-group-error">
+            <fieldset>
+              <legend>
+                <span class="form-label-bold">Date of birth</span>
+                <span class="form-hint" id="example-dob-hint-3">For example, 31 3 1980</span>
+                <span class="error-message">Error message goes here</span>
+              </legend>
+              <div class="form-date">
+                <div class="form-group form-group-day">
+                  <label class="form-label" for="example-dob-day-3">Day</label>
+                  <input class="form-control" id="example-dob-day-3" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint-3">
+                </div>
+                <div class="form-group form-group-month">
+                  <label class="form-label" for="example-dob-month-3">Month</label>
+                  <input class="form-control" id="example-dob-month-3" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+                </div>
+                <div class="form-group form-group-year">
+                  <label class="form-label" for="example-dob-year-3">Year</label>
+                  <input class="form-control form-control-error" id="example-dob-year-3" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+                </div>
+              </div>
+            </fieldset>
+          </div>
+
         </div>
 
         <div class="form-section">

--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -134,7 +134,7 @@
                 Error message goes here
               </span>
             </label>
-            <input class="form-control" id="example-form-control" type="text">
+            <input class="form-control form-control-error" id="example-form-control" type="text">
           </div>
 
           <!-- Hint text outside a label (preference is inside, to be read by AT) - error -->
@@ -148,7 +148,7 @@
             <span class="error-message">
               Error message goes here
             </span>
-            <input class="form-control" id="example-form-control" type="text">
+            <input class="form-control form-control-error" id="example-form-control" type="text">
           </div>
 
           <!-- Text inside a legend - error -->
@@ -184,7 +184,7 @@
               <div class="form-date">
                 <div class="form-group form-group-day">
                   <label class="form-label" for="example-dob-day">Day</label>
-                  <input class="form-control" id="example-dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint">
+                  <input class="form-control form-control-error" id="example-dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint">
                 </div>
                 <div class="form-group form-group-month">
                   <label class="form-label" for="example-dob-month">Month</label>
@@ -276,7 +276,7 @@
                 Error message goes here
               </span>
             </label>
-            <input class="form-control" id="input-text-b" type="text">
+            <input class="form-control form-control-error" id="input-text-b" type="text">
           </div>
 
           <!-- Input type="text" (bold label) -->
@@ -295,7 +295,7 @@
                 Error message goes here
               </span>
             </label>
-            <input class="form-control" id="input-text-d" type="text">
+            <input class="form-control form-control-error" id="input-text-d" type="text">
           </div>
 
           <!-- Input type="text" (bold label with hint text) -->
@@ -330,7 +330,7 @@
                 Error message goes here
               </span>
             </label>
-            <input class="form-control" id="input-text-h" type="text">
+            <input class="form-control form-control-error" id="input-text-h" type="text">
           </div>
         </div>
 
@@ -359,7 +359,7 @@
                 Error message goes here
               </span>
             </label>
-            <textarea class="form-control" id="textarea-b" cols="30" rows="10"></textarea>
+            <textarea class="form-control form-control-error" id="textarea-b" cols="30" rows="10"></textarea>
           </div>
 
           <!-- Textarea (bold label) -->
@@ -378,7 +378,7 @@
                 Error message goes here
               </span>
             </label>
-            <textarea class="form-control" id="textarea-d" cols="30" rows="10"></textarea>
+            <textarea class="form-control form-control-error" id="textarea-d" cols="30" rows="10"></textarea>
           </div>
 
           <!-- Textarea (bold label, with hint text) -->
@@ -399,7 +399,7 @@
                 Error message goes here
               </span>
             </label>
-            <textarea class="form-control" id="textarea-f" cols="30" rows="10"></textarea>
+            <textarea class="form-control form-control-error" id="textarea-f" cols="30" rows="10"></textarea>
           </div>
         </div>
 
@@ -426,7 +426,7 @@
                 Error message goes here
               </span>
             </label>
-            <select class="form-control" id="select-box-b">
+            <select class="form-control form-control-error" id="select-box-b">
               <option>GOV.UK elements option 1</option>
               <option>GOV.UK elements option 2</option>
               <option>GOV.UK elements option 3</option>
@@ -455,7 +455,7 @@
                 Error message goes here
               </span>
             </label>
-            <select class="form-control" id="select-box-d">
+            <select class="form-control form-control-error" id="select-box-d">
               <option>GOV.UK elements option 1</option>
               <option>GOV.UK elements option 2</option>
               <option>GOV.UK elements option 3</option>
@@ -490,7 +490,7 @@
                 Error message goes here
               </span>
             </label>
-            <select class="form-control" id="select-box-h">
+            <select class="form-control form-control-error" id="select-box-h">
               <option>GOV.UK elements option 1</option>
               <option>GOV.UK elements option 2</option>
               <option>GOV.UK elements option 3</option>

--- a/app/views/snippets/form_date_show_errors.html
+++ b/app/views/snippets/form_date_show_errors.html
@@ -1,0 +1,27 @@
+<form>
+  <div class="form-group form-group-error">
+    <fieldset>
+      <legend>
+        <span class="form-label-bold">
+          What is your date of birth?
+        </span>
+        <span class="form-hint" id="dob-hint-example">For example, 31 3 1980</span>
+        <span class="error-message">Error message goes here</span>
+      </legend>
+      <div class="form-date">
+        <div class="form-group form-group-day">
+          <label class="form-label" for="dob-day-example">Day</label>
+          <input class="form-control form-control-error" id="dob-day-example" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="dob-hint-example">
+        </div>
+        <div class="form-group form-group-month">
+          <label class="form-label" for="dob-month-example">Month</label>
+          <input class="form-control form-control-error" id="dob-month-example" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+        </div>
+        <div class="form-group form-group-year">
+          <label class="form-label" for="dob-year-example">Year</label>
+          <input class="form-control form-control-error" id="dob-year-example" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+        </div>
+      </div>
+    </fieldset>
+  </div>
+</form>

--- a/app/views/snippets/form_error_multiple.html
+++ b/app/views/snippets/form_error_multiple.html
@@ -39,7 +39,7 @@
 
   </label>
 
-  <input class="form-control" id="example-full-name" type="text" name="fullName" value="{{fullName}}" {% if error %}{% if not fullName %} aria-describedby="error-message-full-name"{% endif %}{% endif %}>
+  <input class="form-control {% if error %}{% if not fullName %} form-control-error{% endif %}{% endif %}" id="example-full-name" type="text" name="fullName" value="{{fullName}}" {% if error %}{% if not fullName %} aria-describedby="error-message-full-name"{% endif %}{% endif %}>
 </div>
 
 <div class="form-group {% if error %}{% if not niNo %} error{% endif %}{% endif %}">
@@ -61,7 +61,7 @@
     {% endif %}
   </label>
 
-  <input class="form-control" id="example-ni-number" type="text" name="niNo" value="{{niNo}}" {% if error %}{% if not niNo %} aria-describedby="error-message-ni-number"{% endif %}{% endif %}>
+  <input class="form-control {% if error %}{% if not niNo %} form-control-error{% endif %}{% endif %}" id="example-ni-number" type="text" name="niNo" value="{{niNo}}" {% if error %}{% if not niNo %} aria-describedby="error-message-ni-number"{% endif %}{% endif %}>
 
 </div>
 

--- a/app/views/snippets/form_error_multiple.html
+++ b/app/views/snippets/form_error_multiple.html
@@ -25,7 +25,7 @@
   Your personal details
 </h1>
 
-<div class="form-group {% if error %}{% if not fullName %} error{% endif %}{% endif %}">
+<div class="form-group {% if error %}{% if not fullName %} form-group-error{% endif %}{% endif %}">
 
   <label for="example-full-name" {% if error %}{% if not fullName %} id="error-full-name"{% endif %}{% endif %}>
 
@@ -42,7 +42,7 @@
   <input class="form-control {% if error %}{% if not fullName %} form-control-error{% endif %}{% endif %}" id="example-full-name" type="text" name="fullName" value="{{fullName}}" {% if error %}{% if not fullName %} aria-describedby="error-message-full-name"{% endif %}{% endif %}>
 </div>
 
-<div class="form-group {% if error %}{% if not niNo %} error{% endif %}{% endif %}">
+<div class="form-group {% if error %}{% if not niNo %} form-group-error{% endif %}{% endif %}">
 
   <label for="example-ni-number" {% if error %}{% if not niNo %} id="error-full-name"{% endif %}{% endif %}>
 

--- a/app/views/snippets/form_error_multiple_show_errors.html
+++ b/app/views/snippets/form_error_multiple_show_errors.html
@@ -29,7 +29,7 @@
 
   </label>
 
-  <input class="form-control" id="example-full-name" type="text" name="fullName" value="" aria-describedby="error-message-full-name">
+  <input class="form-control form-control-error" id="example-full-name" type="text" name="fullName" value="" aria-describedby="error-message-full-name">
 </div>
 
 <div class="form-group form-group-error">
@@ -48,7 +48,7 @@
 
   </label>
 
-  <input class="form-control" id="example-ni-number" type="text" name="niNo" value="" aria-describedby="error-message-ni-number">
+  <input class="form-control form-control-error" id="example-ni-number" type="text" name="niNo" value="" aria-describedby="error-message-ni-number">
 
 </div>
 

--- a/app/views/snippets/form_error_multiple_show_errors.html
+++ b/app/views/snippets/form_error_multiple_show_errors.html
@@ -19,7 +19,7 @@
   Your personal details
 </h1>
 
-<div class="form-group error">
+<div class="form-group form-group-error">
 
   <label for="example-full-name" id="error-full-name">
 
@@ -32,7 +32,7 @@
   <input class="form-control" id="example-full-name" type="text" name="fullName" value="" aria-describedby="error-message-full-name">
 </div>
 
-<div class="form-group error">
+<div class="form-group form-group-error">
 
   <label for="example-ni-number" id="error-ni-number">
 

--- a/app/views/snippets/form_error_radio.html
+++ b/app/views/snippets/form_error_radio.html
@@ -25,7 +25,7 @@
 </p>
 
 
-<div class="form-group {% if error %} error{% endif %}">
+<div class="form-group {% if error %} form-group-error{% endif %}">
   <fieldset>
 
     <legend {% if error %} id="example-personal-details"{% endif %}>

--- a/app/views/snippets/form_error_radio_show_errors.html
+++ b/app/views/snippets/form_error_radio_show_errors.html
@@ -23,7 +23,7 @@
 </p>
 
 <form>
-  <div class="form-group error">
+  <div class="form-group form-group-error">
     <fieldset>
 
       <legend id="example-personal-details">

--- a/app/views/snippets/form_file_upload_error.html
+++ b/app/views/snippets/form_file_upload_error.html
@@ -1,4 +1,4 @@
-<div class="form-group error">
+<div class="form-group form-group-error">
   <label class="form-label" for="file-input">
     Upload a file
     <span class="error-message">

--- a/app/views/snippets/form_inset_radios_show_errors.html
+++ b/app/views/snippets/form_inset_radios_show_errors.html
@@ -3,7 +3,7 @@
 </h1>
 
 <form>
-  <div class="form-group error">
+  <div class="form-group form-group-error">
 
     <fieldset>
 
@@ -79,7 +79,7 @@
         Monthly
       </label>
       <div class="panel panel-border-narrow panel-with-error" id="paid-monthly-2">
-        <div class="form-group error">
+        <div class="form-group form-group-error">
           <label class="form-label" for="example-paid-monthly-pay-2">
             Monthly take home pay (after tax)?
             <span class="error-message">

--- a/public/sass/elements/forms/_form-validation.scss
+++ b/public/sass/elements/forms/_form-validation.scss
@@ -1,19 +1,9 @@
 // Form validation
 // ==========================================================================
 
-// Use error to add a red border to the left of a .form-group
-.error {
-
-  // Ensure the .error class is applied to .form-group, otherwise box-sizing(border-box) will need to be used
-  // @include box-sizing(border-box);
+// Use .form-group-error to add a red border to the left of a .form-group
+.form-group-error {
   margin-right: 15px;
-
-  // Form inputs should have a red border
-  // Add a red border to .form-controls that are direct descendants
-  > .form-control {
-    border: 4px solid $error-colour;
-  }
-
   border-left: 4px solid $error-colour;
   padding-left: 10px;
 
@@ -21,8 +11,13 @@
     border-left: 5px solid $error-colour;
     padding-left: $gutter-half;
   }
-
 }
+
+// Use .form-control-error to add a red border to .form-control
+.form-control-error {
+  border: 4px solid $error-colour;
+}
+
 
 // Error messages should be red and bold
 .error-message {


### PR DESCRIPTION
#### What problem does the pull request solve?

The styling for form validation is pretty fragile and relies on a parent `.error` selector to apply a red border to the left of a `.form-group` div. This class also sets a red border on any `.form-control` inputs that are direct descendents. 

Rather than relying on a child div sitting inside a parent for this to work - add two new classes `.form-group-error` and `.form-control-error`. One will set the border for form-groups and the other for inputs/textareas with a class of form-control.

This also solves the problem where there may be multiple `.form-control` elements within a parent `.error` - and only one of them needs to have a red border - an example of this is the date of birth pattern.

> This would be a breaking change, but at some point we'll need to make breaking changes, so let's have a discussion  about it here, rather than on Slack where it'll get lost.

#### Screenshots (if appropriate):

I have added the error examples to the date of birth page:

![d2e321d8-1ef7-42b3-5198-6b3114ddef96](https://cloud.githubusercontent.com/assets/417754/22968224/7e14eb62-f361-11e6-8f9d-692f14dffabf.png)

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
- Breaking change (fix or feature that would cause existing functionality to change)

#### Has the documentation been updated?
<!--- Delete the lines below that don't apply -->
- My change requires a change to the documentation.
- I have read the **CONTRIBUTING** document.
