### PR TITLE
Radios and checkboxes without JS

### DIFF
--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -40,7 +40,7 @@
                   This is the label text in bold
                 </span>
               </legend>
-              <div class="block-label">
+              <div class="multiple-choice">
                 <input id="example-radio-yes-no-yes" type="radio" name="example-yes-no-group" value="Yes">
                 <label for="example-radio-yes-no-yes">Yes</label>
               </div>
@@ -86,7 +86,7 @@
                   This is hint text
                 </span>
               </legend>
-              <div class="block-label">
+              <div class="multiple-choice">
                 <input id="radio-yes-no-yes-b" type="radio" name="yes-no-group-b" value="Yes">
                 <label for="radio-yes-no-yes-b">Yes</label>
               </div>
@@ -166,7 +166,7 @@
                   Error message goes here
                 </span>
               </legend>
-              <div class="block-label">
+              <div class="multiple-choice">
                 <input id="radio-yes-no-yes-c" type="radio" name="yes-no-group-c" value="Yes">
                 <label for="radio-yes-no-yes-c">Yes</label>
               </div>
@@ -211,11 +211,11 @@
                 Do you already have a personal user account?
               </span>
             </legend>
-            <div class="block-label">
+            <div class="multiple-choice">
               <input id="radio-inline-1a" type="radio" name="radio-inline-group" value="Yes">
               <label for="radio-inline-1a">Yes</label>
             </div>
-            <div class="block-label">
+            <div class="multiple-choice">
               <input id="radio-inline-2a" type="radio" name="radio-inline-group" value="No">
               <label for="radio-inline-2a">No</label>
             </div>
@@ -234,11 +234,11 @@
               </span>
             </legend>
             <div class="form-group">
-              <div class="block-label">
+              <div class="multiple-choice">
                 <input id="radio-yes-no-yes-a" type="radio" name="yes-no-group-a" value="Yes">
                 <label data-target="yes-and-do-next" for="radio-yes-no-yes-a">Yes</label>
               </div>
-              <div class="block-label">
+              <div class="multiple-choice">
                 <input id="radio-yes-no-no-a" type="radio" name="yes-no-group-a" value="No">
                 <label data-target="no-and-do-next" for="radio-yes-no-no-a">No</label>
               </div>

--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -40,10 +40,10 @@
                   This is the label text in bold
                 </span>
               </legend>
-              <label class="block-label selection-button-radio" for="example-radio-yes-no-yes">
+              <div class="block-label">
                 <input id="example-radio-yes-no-yes" type="radio" name="example-yes-no-group" value="Yes">
-                  Yes
-              </label>
+                <label for="example-radio-yes-no-yes">Yes</label>
+              </div>
             </fieldset>
           </div>
         </div>
@@ -86,10 +86,10 @@
                   This is hint text
                 </span>
               </legend>
-              <label class="block-label selection-button-radio" for="radio-yes-no-yes-b">
+              <div class="block-label">
                 <input id="radio-yes-no-yes-b" type="radio" name="yes-no-group-b" value="Yes">
-                  Yes
-              </label>
+                <label for="radio-yes-no-yes-b">Yes</label>
+              </div>
             </fieldset>
           </div>
 
@@ -166,10 +166,10 @@
                   Error message goes here
                 </span>
               </legend>
-              <label class="block-label selection-button-radio" for="radio-yes-no-yes-c">
+              <div class="block-label">
                 <input id="radio-yes-no-yes-c" type="radio" name="yes-no-group-c" value="Yes">
-                  Yes
-              </label>
+                <label for="radio-yes-no-yes-c">Yes</label>
+              </div>
             </fieldset>
           </div>
 
@@ -211,14 +211,14 @@
                 Do you already have a personal user account?
               </span>
             </legend>
-            <label class="block-label selection-button-radio" for="radio-inline-1a">
+            <div class="block-label">
               <input id="radio-inline-1a" type="radio" name="radio-inline-group" value="Yes">
-              Yes
-            </label>
-            <label class="block-label selection-button-radio" for="radio-inline-2a">
+              <label for="radio-inline-1a">Yes</label>
+            </div>
+            <div class="block-label">
               <input id="radio-inline-2a" type="radio" name="radio-inline-group" value="No">
-              No
-            </label>
+              <label for="radio-inline-2a">No</label>
+            </div>
           </fieldset>
         </div>
 
@@ -234,14 +234,14 @@
               </span>
             </legend>
             <div class="form-group">
-              <label class="block-label selection-button-radio" data-target="yes-and-do-next" for="radio-yes-no-yes-a">
+              <div class="block-label">
                 <input id="radio-yes-no-yes-a" type="radio" name="yes-no-group-a" value="Yes">
-                Yes
-              </label>
-              <label class="block-label selection-button-radio" data-target="no-and-do-next" for="radio-yes-no-no-a">
+                <label data-target="yes-and-do-next" for="radio-yes-no-yes-a">Yes</label>
+              </div>
+              <div class="block-label">
                 <input id="radio-yes-no-no-a" type="radio" name="yes-no-group-a" value="No">
-                No
-              </label>
+                <label data-target="no-and-do-next" for="radio-yes-no-no-a">No</label>
+              </div>
               <div class="panel panel-border-narrow js-hidden" id="yes-and-do-next-a">
                 <label class="form-label" for="yes-next-a">Yes, this next</label>
                 <input class="form-control" name="yes-next" type="text" id="yes-next-a">

--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -37,17 +37,17 @@
 
             <legend class="visually-hidden">What is your nationality?</legend>
 
-            <div class="block-label">
+            <div class="multiple-choice">
               <input type="checkbox" name="nationality_british" value="British" id="nationality_british">
               <label for="nationality_british">British</label>
             </div>
 
-            <div class="block-label">
+            <div class="multiple-choice">
               <input type="checkbox" name="nationality_irish" value="Irish" id="nationality_irish">
               <label for="nationality_irish">Irish</label>
             </div>
 
-            <div class="block-label" data-target="example_nationality_other">
+            <div class="multiple-choice" data-target="example_nationality_other">
               <input type="checkbox" name="nationality_other" value="Wales" id="nationality_other">
               <label for="nationality_other">Citizen of another country</label>
             </div>
@@ -73,12 +73,12 @@
               Where should we send your new passport?
             </legend>
 
-            <div class="block-label">
+            <div class="multiple-choice">
               <input id="radio-home-address" type="radio" name="radio-indent-group" value="Yes">
               <label for="radio-home-address">Home address</label>
             </div>
 
-            <div class="block-label" data-target="example-other-address">
+            <div class="multiple-choice" data-target="example-other-address">
               <input id="radio-other-address" type="radio" name="radio-indent-group" value="No">
               <label for="radio-other-address">Other address</label>
             </div>
@@ -136,13 +136,13 @@
               Which part of the Housing Act was your licence isued under?
             </legend>
 
-            <div class="block-label">
+            <div class="multiple-choice">
               <input id="radio-part-2" type="radio" name="housing-act" value="Part 2">
               <label for="radio-part-2"><span class="heading-small">Part 2 of the Housing Act 2004</span><br></label>
               For divroperties that are 3 or more stories high and occupied by 5 or more people
             </label>
 
-            <div class="block-label">
+            <div class="multiple-choice">
               <input id="radio-part-3" type="radio" name="housing-act" value="Part 3">
               <label for="radio-part-3"><span class="heading-small">Part 3 of the Housing Act 2004</span><br></label>
               For divroperties that are within a geographical area defined by a local council

--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -37,20 +37,20 @@
 
             <legend class="visually-hidden">What is your nationality?</legend>
 
-            <label for="nationality_british" class="block-label selection-button-checkbox">
+            <div class="block-label">
               <input type="checkbox" name="nationality_british" value="British" id="nationality_british">
-              British
-            </label>
+              <label for="nationality_british">British</label>
+            </div>
 
-            <label for="nationality_irish" class="block-label selection-button-checkbox">
+            <div class="block-label">
               <input type="checkbox" name="nationality_irish" value="Irish" id="nationality_irish">
-              Irish
-            </label>
+              <label for="nationality_irish">Irish</label>
+            </div>
 
-            <label for="nationality_other" class="block-label selection-button-checkbox" data-target="example_nationality_other">
+            <div class="block-label" data-target="example_nationality_other">
               <input type="checkbox" name="nationality_other" value="Wales" id="nationality_other">
-              Citizen of another country
-            </label>
+              <label for="nationality_other">Citizen of another country</label>
+            </div>
 
             <div class="panel panel-border-narrow js-hidden" id="example_nationality_other">
               <label for="nationality_other_countries" class="form-label">
@@ -73,15 +73,15 @@
               Where should we send your new passport?
             </legend>
 
-            <label for="radio-home-address" class="block-label selection-button-radio">
+            <div class="block-label">
               <input id="radio-home-address" type="radio" name="radio-indent-group" value="Yes">
-              Home address
-            </label>
+              <label for="radio-home-address">Home address</label>
+            </div>
 
-            <label for="radio-other-address" class="block-label selection-button-radio" data-target="example-other-address">
+            <div class="block-label" data-target="example-other-address">
               <input id="radio-other-address" type="radio" name="radio-indent-group" value="No">
-              Other address
-            </label>
+              <label for="radio-other-address">Other address</label>
+            </div>
 
             <div class="panel panel-border-narrow js-hidden" id="example-other-address">
 
@@ -136,33 +136,22 @@
               Which part of the Housing Act was your licence isued under?
             </legend>
 
-            <label for="radio-part-2" class="block-label selection-button-radio">
+            <div class="block-label">
               <input id="radio-part-2" type="radio" name="housing-act" value="Part 2">
-              <span class="heading-small">Part 2 of the Housing Act 2004</span><br>
-              For properties that are 3 or more stories high and occupied by 5 or more people
+              <label for="radio-part-2"><span class="heading-small">Part 2 of the Housing Act 2004</span><br></label>
+              For divroperties that are 3 or more stories high and occupied by 5 or more people
             </label>
 
-            <label for="radio-part-3" class="block-label selection-button-radio">
+            <div class="block-label">
               <input id="radio-part-3" type="radio" name="housing-act" value="Part 3">
-              <span class="heading-small">Part 3 of the Housing Act 2004</span><br>
-              For properties that are within a geographical area defined by a local council
+              <label for="radio-part-3"><span class="heading-small">Part 3 of the Housing Act 2004</span><br></label>
+              For divroperties that are within a geographical area defined by a local council
             </label>
 
           </fieldset>
         </div>
 
       </form>
-
-      <h2 class="heading-medium implementation-advice">Implementation advice</h2>
-      <ul class="list list-bullet text">
-        <li>
-          Add a class to your labels for quicker initialisation.
-          <span class="panel panel-border-narrow">
-            for radio buttons use <code>class="block-label selection-button-radio"</code> and for checkboxes use <code>class="block-label selection-button-checkbox"</code>
-          </span>
-          If you don’t add this class it’ll still work, but will be slower for users.
-        </li>
-      </ul>
 
     </div>
   </div>

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -2,7 +2,6 @@
 
 <!-- govuk_frontend_toolkit js -->
 <script src="/public/javascripts/vendor/polyfills/bind.js"></script>
-<script src="/public/javascripts/govuk/selection-buttons.js"></script>
 <script src="/public/javascripts/govuk/shim-links-with-button-role.js"></script>
 <script src="/public/javascripts/govuk/show-hide-content.js"></script>
 

--- a/app/views/snippets/form_checkbox.html
+++ b/app/views/snippets/form_checkbox.html
@@ -2,7 +2,7 @@
   <label class="form-label" for="telephone-number">Enter your telephone number</label>
   <input class="form-control" id="telephone-number" name="telephone-number" type="text">
 </div>
-<label class="block-label selection-button-checkbox" for="checkbox-telephone-number">
+<div class="multiple-choice">
   <input id="checkbox-telephone-number" name="contact-by-text-phone" type="checkbox" value="true">
-  I need to be contacted using a text phone
-</label>
+  <label for="checkbox-telephone-number">I need to be contacted using a text phone</label>
+</div>

--- a/app/views/snippets/form_checkboxes.html
+++ b/app/views/snippets/form_checkboxes.html
@@ -6,15 +6,15 @@
 
     <legend class="visually-hidden">Which types of waste do you transport regularly?</legend>
 
-    <div class="block-label">
+    <div class="multiple-choice">
       <input id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal">
       <label for="waste-type-1">Waste from animal carcasses</label>
     </div>
-    <div class="block-label">
+    <div class="multiple-choice">
       <input id="waste-type-2" name="waste-types" type="checkbox" value="waste-mines">
       <label for="waste-type-2">Waste from mines or quarries</label>
     </div>
-    <div class="block-label">
+    <div class="multiple-choice">
       <input id="waste-type-3" name="waste-types" type="checkbox" value="waste-farm-agricultural">
       <label for="waste-type-3">Farm or agricultural waste</label>
     </div>

--- a/app/views/snippets/form_checkboxes.html
+++ b/app/views/snippets/form_checkboxes.html
@@ -6,18 +6,18 @@
 
     <legend class="visually-hidden">Which types of waste do you transport regularly?</legend>
 
-    <label class="block-label selection-button-checkbox" for="waste-type-1">
+    <div class="block-label">
       <input id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal">
-      Waste from animal carcasses
-    </label>
-    <label class="block-label selection-button-checkbox" for="waste-type-2">
+      <label for="waste-type-1">Waste from animal carcasses</label>
+    </div>
+    <div class="block-label">
       <input id="waste-type-2" name="waste-types" type="checkbox" value="waste-mines">
-      Waste from mines or quarries
-    </label>
-    <label class="block-label selection-button-checkbox" for="waste-type-3">
+      <label for="waste-type-2">Waste from mines or quarries</label>
+    </div>
+    <div class="block-label">
       <input id="waste-type-3" name="waste-types" type="checkbox" value="waste-farm-agricultural">
-      Farm or agricultural waste
-    </label>
+      <label for="waste-type-3">Farm or agricultural waste</label>
+    </div>
 
   </fieldset>
 </form>

--- a/app/views/snippets/form_error_radio.html
+++ b/app/views/snippets/form_error_radio.html
@@ -41,12 +41,12 @@
 
     </legend>
 
-    <div class="block-label">
+    <div class="multiple-choice">
       <input id="personal_details_yes" type="radio" name="personalDetails" value="Yes">
       <label for="personal_details_yes">Yes, my personal details are correct</label>
     </div>
 
-    <div class="block-label">
+    <div class="multiple-choice">
       <input id="personal_details_no" type="radio" name="personalDetails" value="No">
       <label for="personal_details_no">No, some details are wrong or have changed</label>
     </div>

--- a/app/views/snippets/form_error_radio.html
+++ b/app/views/snippets/form_error_radio.html
@@ -41,15 +41,15 @@
 
     </legend>
 
-    <label class="block-label selection-button-radio" for="personal_details_yes">
+    <div class="block-label">
       <input id="personal_details_yes" type="radio" name="personalDetails" value="Yes">
-      Yes, my personal details are correct
-    </label>
+      <label for="personal_details_yes">Yes, my personal details are correct</label>
+    </div>
 
-    <label class="block-label selection-button-radio" for="personal_details_no">
+    <div class="block-label">
       <input id="personal_details_no" type="radio" name="personalDetails" value="No">
-      No, some details are wrong or have changed
-    </label>
+      <label for="personal_details_no">No, some details are wrong or have changed</label>
+    </div>
 
   </fieldset>
 </div>

--- a/app/views/snippets/form_error_radio_show_errors.html
+++ b/app/views/snippets/form_error_radio_show_errors.html
@@ -37,12 +37,12 @@
 
       </legend>
 
-      <div class="block-label">
+      <div class="multiple-choice">
         <input id="personal_details_yes" type="radio" name="personalDetails" value="Yes">
         <label for="personal_details_yes">Yes, my personal details are correct</label>
       </div>
 
-      <div class="block-label">
+      <div class="multiple-choice">
         <input id="personal_details_no" type="radio" name="personalDetails" value="No">
         <label for="personal_details_no">No, some details are wrong or have changed</label>
       </div>

--- a/app/views/snippets/form_error_radio_show_errors.html
+++ b/app/views/snippets/form_error_radio_show_errors.html
@@ -37,15 +37,15 @@
 
       </legend>
 
-      <label class="block-label selection-button-radio" for="personal_details_yes">
+      <div class="block-label">
         <input id="personal_details_yes" type="radio" name="personalDetails" value="Yes">
-        Yes, my personal details are correct
-      </label>
+        <label for="personal_details_yes">Yes, my personal details are correct</label>
+      </div>
 
-      <label class="block-label selection-button-radio" for="personal_details_no">
+      <div class="block-label">
         <input id="personal_details_no" type="radio" name="personalDetails" value="No">
-        No, some details are wrong or have changed
-      </label>
+        <label for="personal_details_no">No, some details are wrong or have changed</label>
+      </div>
 
     </fieldset>
   </div>

--- a/app/views/snippets/form_inset_checkboxes.html
+++ b/app/views/snippets/form_inset_checkboxes.html
@@ -11,18 +11,18 @@
 
       <legend class="visually-hidden">What is your nationality?</legend>
 
-      <label class="block-label selection-button-checkbox" for="nationalities-british">
+      <div class="block-label">
         <input id="nationalities-british" name="nationalities" type="checkbox" value="British">
-        British (including English, Scottish, Welsh and Northern Irish)
-      </label>
-      <label class="block-label selection-button-checkbox" for="nationalities-irish">
+        <label for="nationalities-british">British (including English, Scottish, Welsh and Northern Irish)</label>
+      </div>
+      <div class="block-label">
         <input id="nationalities-irish" name="nationalities" type="checkbox" value="Irish">
-        Irish
-      </label>
-      <label class="block-label selection-button-checkbox" for="nationalities-other" data-target="example-different-country">
+        <label for="nationalities-irish">Irish</label>
+      </div>
+      <div class="block-label" data-target="example-different-country">
         <input id="nationalities-other" name="nationalities" type="checkbox" value="Citizen of a different country">
-        Citizen of a different country
-      </label>
+        <label for="nationalities-other">Citizen of a different country</label>
+      </div>
       <div class="panel panel-border-narrow js-hidden" id="example-different-country">
         <label class="form-label" for="nationalities-other-country">Country name</label>
         <input class="form-control" type="text" id="nationalities-other-country" name="nationalities-other-country">

--- a/app/views/snippets/form_inset_checkboxes.html
+++ b/app/views/snippets/form_inset_checkboxes.html
@@ -11,15 +11,15 @@
 
       <legend class="visually-hidden">What is your nationality?</legend>
 
-      <div class="block-label">
+      <div class="multiple-choice">
         <input id="nationalities-british" name="nationalities" type="checkbox" value="British">
         <label for="nationalities-british">British (including English, Scottish, Welsh and Northern Irish)</label>
       </div>
-      <div class="block-label">
+      <div class="multiple-choice">
         <input id="nationalities-irish" name="nationalities" type="checkbox" value="Irish">
         <label for="nationalities-irish">Irish</label>
       </div>
-      <div class="block-label" data-target="example-different-country">
+      <div class="multiple-choice" data-target="example-different-country">
         <input id="nationalities-other" name="nationalities" type="checkbox" value="Citizen of a different country">
         <label for="nationalities-other">Citizen of a different country</label>
       </div>

--- a/app/views/snippets/form_inset_radios.html
+++ b/app/views/snippets/form_inset_radios.html
@@ -8,28 +8,28 @@
 
       <legend class="visually-hidden">How do you want to be contacted?</legend>
 
-      <label class="block-label selection-button-radio" data-target="contact-by-email" for="example-contact-by-email">
+      <div class="block-label" data-target="contact-by-email">
         <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Yes">
-        Email
-      </label>
+        <label for="example-contact-by-email">Email</label>
+      </div>
       <div class="panel panel-border-narrow js-hidden" id="contact-by-email">
         <label class="form-label" for="contact-email">Email address</label>
         <input class="form-control" name="contact-email" type="text" id="contact-email">
       </div>
 
-      <label class="block-label selection-button-radio" data-target="contact-by-phone" for="example-contact-by-phone">
+      <div class="block-label" data-target="contact-by-phone">
         <input id="example-contact-by-phone" type="radio" name="radio-contact-group" value="No">
-        Phone
-      </label>
+        <label for="example-contact-by-phone">Phone</label>
+      </div>
       <div class="panel panel-border-narrow js-hidden" id="contact-by-phone">
         <label class="form-label" for="contact-phone">Phone number</label>
         <input class="form-control" name="contact-phone" type="text" id="contact-phone">
       </div>
 
-      <label class="block-label selection-button-radio" data-target="contact-by-text" for="example-contact-by-text">
+      <div class="block-label" data-target="contact-by-text">
         <input id="example-contact-by-text" type="radio" name="radio-contact-group" value="No">
-        Text message
-      </label>
+        <label for="example-contact-by-text">Text message</label>
+      </div>
       <div class="panel panel-border-narrow js-hidden" id="contact-by-text">
         <label class="form-label" for="contact-text-message">Mobile phone number</label>
         <input class="form-control" name="contact-text-message" type="text" id="contact-text-message">

--- a/app/views/snippets/form_inset_radios.html
+++ b/app/views/snippets/form_inset_radios.html
@@ -8,7 +8,7 @@
 
       <legend class="visually-hidden">How do you want to be contacted?</legend>
 
-      <div class="block-label" data-target="contact-by-email">
+      <div class="multiple-choice" data-target="contact-by-email">
         <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Yes">
         <label for="example-contact-by-email">Email</label>
       </div>
@@ -17,7 +17,7 @@
         <input class="form-control" name="contact-email" type="text" id="contact-email">
       </div>
 
-      <div class="block-label" data-target="contact-by-phone">
+      <div class="multiple-choice" data-target="contact-by-phone">
         <input id="example-contact-by-phone" type="radio" name="radio-contact-group" value="No">
         <label for="example-contact-by-phone">Phone</label>
       </div>
@@ -26,7 +26,7 @@
         <input class="form-control" name="contact-phone" type="text" id="contact-phone">
       </div>
 
-      <div class="block-label" data-target="contact-by-text">
+      <div class="multiple-choice" data-target="contact-by-text">
         <input id="example-contact-by-text" type="radio" name="radio-contact-group" value="No">
         <label for="example-contact-by-text">Text message</label>
       </div>

--- a/app/views/snippets/form_inset_radios_show_errors.html
+++ b/app/views/snippets/form_inset_radios_show_errors.html
@@ -12,28 +12,28 @@
         <span class="error-message">Choose an answer</span>
       </legend>
 
-      <label class="block-label selection-button-radio" data-target="paid-weekly" for="example-paid-weekly">
+      <div class="block-label" data-target="paid-weekly">
         <input type="radio" name="radio-income-group" value="Yes" id="example-paid-weekly">
-        Weekly
-      </label>
+        <label for="example-paid-weekly">Weekly</label>
+      </div>
       <div class="panel panel-border-narrow js-hidden" id="paid-weekly">
         <label class="form-label" for="example-paid-weekly-pay">Weekly take home pay after tax</label>
         <input class="form-control" name="example-paid-weekly-pay" type="text" id="example-paid-weekly-pay">
       </div>
 
-      <label class="block-label selection-button-radio" data-target="paid-fortnightly" for="example-paid-fortnightly">
+      <div class="block-label" data-target="paid-fortnightly">
         <input type="radio" name="radio-income-group" value="Yes" id="example-paid-fortnightly">
-        Fortnightly
-      </label>
+        <label for="example-paid-fortnightly">Fortnightly</label>
+      </div>
       <div class="panel panel-border-narrow js-hidden" id="paid-fortnightly">
         <label class="form-label" for="example-paid-fortnightly-pay">Weekly take home pay after tax</label>
         <input class="form-control" name="example-paid-fortnightly-pay" type="text" id="example-paid-fortnightly-pay">
       </div>
 
-      <label class="block-label selection-button-radio" data-target="paid-monthly" for="example-paid-monthly">
+      <div class="block-label" data-target="paid-monthly">
         <input type="radio" name="radio-income-group" value="Yes" id="example-paid-monthly">
-        Monthly
-      </label>
+        <label for="example-paid-monthly">Monthly</label>
+      </div>
       <div class="panel panel-border-narrow js-hidden" id="paid-monthly">
         <label class="form-label" for="example-paid-monthly-pay">Monthly take home pay after tax</label>
         <input class="form-control" name="example-paid-monthly-pay" type="text" id="example-paid-monthly-pay">
@@ -56,28 +56,28 @@
         <span class="form-label-bold">How often do you get paid?</span>
       </legend>
 
-      <label class="block-label selection-button-radio" data-target="paid-weekly-2" for="example-paid-weekly-2">
+      <div class="block-label" data-target="paid-weekly-2">
         <input type="radio" name="radio-income-group-2" value="Yes" id="example-paid-weekly-2">
-        Weekly
-      </label>
+        <label for="example-paid-weekly-2">Weekly</label>
+      </div>
       <div class="panel panel-border-narrow js-hidden" id="paid-weekly-2">
         <label class="form-label" for="example-paid-weekly-pay-2">Weekly take home pay after tax</label>
         <input class="form-control" name="example-paid-weekly-pay-2" type="text" id="example-paid-weekly-pay-2">
       </div>
 
-      <label class="block-label selection-button-radio" data-target="paid-fortnightly-2" for="example-paid-fortnightly-2">
+      <div class="block-label" data-target="paid-fortnightly-2">
         <input type="radio" name="radio-income-group-2" value="Yes" id="example-paid-fortnightly-2">
-        Fortnightly
-      </label>
+        <label for="example-paid-fortnightly-2">Fortnightly</label>
+      </div>
       <div class="panel panel-border-narrow js-hidden" id="paid-fortnightly-2">
         <label class="form-label" for="example-paid-fortnightly-pay-2">Weekly take home pay after tax</label>
         <input class="form-control" name="example-paid-fortnightly-pay-2" type="text" id="example-paid-fortnightly-pay-2">
       </div>
 
-      <label class="block-label selection-button-radio" data-target="paid-monthly-2" for="example-paid-monthly-2">
+      <div class="block-label" data-target="paid-monthly-2">
         <input type="radio" name="radio-income-group-2" value="Yes" id="example-paid-monthly-2" checked="checked">
-        Monthly
-      </label>
+        <label for="example-paid-monthly-2">Monthly</label>
+      </div>
       <div class="panel panel-border-narrow panel-with-error" id="paid-monthly-2">
         <div class="form-group error">
           <label class="form-label" for="example-paid-monthly-pay-2">

--- a/app/views/snippets/form_inset_radios_show_errors.html
+++ b/app/views/snippets/form_inset_radios_show_errors.html
@@ -12,7 +12,7 @@
         <span class="error-message">Choose an answer</span>
       </legend>
 
-      <div class="block-label" data-target="paid-weekly">
+      <div class="multiple-choice" data-target="paid-weekly">
         <input type="radio" name="radio-income-group" value="Yes" id="example-paid-weekly">
         <label for="example-paid-weekly">Weekly</label>
       </div>
@@ -21,7 +21,7 @@
         <input class="form-control" name="example-paid-weekly-pay" type="text" id="example-paid-weekly-pay">
       </div>
 
-      <div class="block-label" data-target="paid-fortnightly">
+      <div class="multiple-choice" data-target="paid-fortnightly">
         <input type="radio" name="radio-income-group" value="Yes" id="example-paid-fortnightly">
         <label for="example-paid-fortnightly">Fortnightly</label>
       </div>
@@ -30,7 +30,7 @@
         <input class="form-control" name="example-paid-fortnightly-pay" type="text" id="example-paid-fortnightly-pay">
       </div>
 
-      <div class="block-label" data-target="paid-monthly">
+      <div class="multiple-choice" data-target="paid-monthly">
         <input type="radio" name="radio-income-group" value="Yes" id="example-paid-monthly">
         <label for="example-paid-monthly">Monthly</label>
       </div>
@@ -56,7 +56,7 @@
         <span class="form-label-bold">How often do you get paid?</span>
       </legend>
 
-      <div class="block-label" data-target="paid-weekly-2">
+      <div class="multiple-choice" data-target="paid-weekly-2">
         <input type="radio" name="radio-income-group-2" value="Yes" id="example-paid-weekly-2">
         <label for="example-paid-weekly-2">Weekly</label>
       </div>
@@ -65,7 +65,7 @@
         <input class="form-control" name="example-paid-weekly-pay-2" type="text" id="example-paid-weekly-pay-2">
       </div>
 
-      <div class="block-label" data-target="paid-fortnightly-2">
+      <div class="multiple-choice" data-target="paid-fortnightly-2">
         <input type="radio" name="radio-income-group-2" value="Yes" id="example-paid-fortnightly-2">
         <label for="example-paid-fortnightly-2">Fortnightly</label>
       </div>
@@ -74,7 +74,7 @@
         <input class="form-control" name="example-paid-fortnightly-pay-2" type="text" id="example-paid-fortnightly-pay-2">
       </div>
 
-      <div class="block-label" data-target="paid-monthly-2">
+      <div class="multiple-choice" data-target="paid-monthly-2">
         <input type="radio" name="radio-income-group-2" value="Yes" id="example-paid-monthly-2" checked="checked">
         <label for="example-paid-monthly-2">Monthly</label>
       </div>

--- a/app/views/snippets/form_radio_buttons.html
+++ b/app/views/snippets/form_radio_buttons.html
@@ -6,19 +6,19 @@
 
       <legend class="visually-hidden">Where do you live?</legend>
 
-      <label class="block-label selection-button-radio" for="radio-1">
+      <div class="block-label">
         <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">
-        Northern Ireland
-      </label>
-      <label class="block-label selection-button-radio" for="radio-2">
+        <label for="radio-1">Northern Ireland</label>
+      </div>
+      <div class="block-label">
         <input id="radio-2" type="radio" name="radio-group" value="Isle of Man or the Channel Islands">
-        Isle of Man or the Channel Islands
-      </label>
+        <label for="radio-2">Isle of Man or the Channel Islands</label>
+      </div>
       <p class="form-block">or</p>
-      <label class="block-label selection-button-radio" for="radio-3">
+      <div class="block-label">
         <input id="radio-3" type="radio" name="radio-group" value="I am a British citizen living abroad">
-        I am a British citizen living abroad
-      </label>
+        <label for="radio-3">I am a British citizen living abroad</label>
+      </div>
 
     </fieldset>
   </div>

--- a/app/views/snippets/form_radio_buttons.html
+++ b/app/views/snippets/form_radio_buttons.html
@@ -6,16 +6,16 @@
 
       <legend class="visually-hidden">Where do you live?</legend>
 
-      <div class="block-label">
+      <div class="multiple-choice">
         <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">
         <label for="radio-1">Northern Ireland</label>
       </div>
-      <div class="block-label">
+      <div class="multiple-choice">
         <input id="radio-2" type="radio" name="radio-group" value="Isle of Man or the Channel Islands">
         <label for="radio-2">Isle of Man or the Channel Islands</label>
       </div>
       <p class="form-block">or</p>
-      <div class="block-label">
+      <div class="multiple-choice">
         <input id="radio-3" type="radio" name="radio-group" value="I am a British citizen living abroad">
         <label for="radio-3">I am a British citizen living abroad</label>
       </div>

--- a/app/views/snippets/form_radio_buttons_inline.html
+++ b/app/views/snippets/form_radio_buttons_inline.html
@@ -8,11 +8,11 @@
 
       <legend class="visually-hidden">Do you already have a personal user account?</legend>
 
-      <div class="block-label">
+      <div class="multiple-choice">
         <input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes">
         <label for="radio-inline-1">Yes</label>
       </div>
-      <div class="block-label">
+      <div class="multiple-choice">
         <input id="radio-inline-2" type="radio" name="radio-inline-group" value="No">
         <label for="radio-inline-2">No</label>
       </div>

--- a/app/views/snippets/form_radio_buttons_inline.html
+++ b/app/views/snippets/form_radio_buttons_inline.html
@@ -8,14 +8,14 @@
 
       <legend class="visually-hidden">Do you already have a personal user account?</legend>
 
-      <label class="block-label selection-button-radio" for="radio-inline-1">
+      <div class="block-label">
         <input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes">
-        Yes
-      </label>
-      <label class="block-label selection-button-radio" for="radio-inline-2">
+        <label for="radio-inline-1">Yes</label>
+      </div>
+      <div class="block-label">
         <input id="radio-inline-2" type="radio" name="radio-inline-group" value="No">
-        No
-      </label>
+        <label for="radio-inline-2">No</label>
+      </div>
 
     </fieldset>
   </div>

--- a/app/views/snippets/form_radio_inline_yes_no.html
+++ b/app/views/snippets/form_radio_inline_yes_no.html
@@ -8,11 +8,11 @@
 
       <legend class="visually-hidden">Do you yes/no?</legend>
 
-      <div class="block-label" data-target="yes-and-do-next">
+      <div class="multiple-choice" data-target="yes-and-do-next">
         <input id="radio-yes-no-yes" type="radio" name="yes-no-group" value="Yes">
         <label for="radio-yes-no-yes">Yes</label>
       </div>
-      <div class="block-label" data-target="no-and-do-next">
+      <div class="multiple-choice" data-target="no-and-do-next">
         <input id="radio-yes-no-no" type="radio" name="yes-no-group" value="No">
         <label for="radio-yes-no-no">No</label>
       </div>

--- a/app/views/snippets/form_radio_inline_yes_no.html
+++ b/app/views/snippets/form_radio_inline_yes_no.html
@@ -8,14 +8,14 @@
 
       <legend class="visually-hidden">Do you yes/no?</legend>
 
-      <label class="block-label selection-button-radio" data-target="yes-and-do-next" for="radio-yes-no-yes">
+      <div class="block-label" data-target="yes-and-do-next">
         <input id="radio-yes-no-yes" type="radio" name="yes-no-group" value="Yes">
-        Yes
-      </label>
-      <label class="block-label selection-button-radio" data-target="no-and-do-next" for="radio-yes-no-no">
+        <label for="radio-yes-no-yes">Yes</label>
+      </div>
+      <div class="block-label" data-target="no-and-do-next">
         <input id="radio-yes-no-no" type="radio" name="yes-no-group" value="No">
-        No
-      </label>
+        <label for="radio-yes-no-no">No</label>
+      </div>
 
       <div class="panel panel-border-narrow js-hidden" id="yes-and-do-next">
         <label class="form-label" for="yes-next">Yes, this next</label>

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -6,7 +6,7 @@ $(document).ready(function () {
   // Turn off jQuery animation
   jQuery.fx.off = true
 
-  // Where .block-label uses the data-target attribute
+  // Where .multiple-choice uses the data-target attribute
   // to toggle hidden content
   var showHideContent = new GOVUK.ShowHideContent()
   showHideContent.init()

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -6,11 +6,6 @@ $(document).ready(function () {
   // Turn off jQuery animation
   jQuery.fx.off = true
 
-  // Use GOV.UK selection-buttons.js to set selected
-  // and focused states for block labels
-  var $blockLabels = $(".block-label input[type='radio'], .block-label input[type='checkbox']")
-  new GOVUK.SelectionButtons($blockLabels) // eslint-disable-line
-
   // Where .block-label uses the data-target attribute
   // to toggle hidden content
   var showHideContent = new GOVUK.ShowHideContent()

--- a/public/sass/_govuk-elements.scss
+++ b/public/sass/_govuk-elements.scss
@@ -46,7 +46,7 @@
 @import "elements/details";                       // Details summary
 @import "elements/panels";                        // Panels with a left grey border
 @import "elements/forms";                         // Form - wrappers, inputs, labels
-@import "elements/forms/form-block-labels";       // Chunky labels for radios and checkboxes
+@import "elements/forms/form-multiple-choice";    // Chunky labels for radios and checkboxes
 @import "elements/forms/form-date";               // Date of birth pattern
 @import "elements/forms/form-validation";         // Errors and validation
 @import "elements/breadcrumbs";                   // Breadcrumbs

--- a/public/sass/_govuk-elements.scss
+++ b/public/sass/_govuk-elements.scss
@@ -46,7 +46,7 @@
 @import "elements/details";                       // Details summary
 @import "elements/panels";                        // Panels with a left grey border
 @import "elements/forms";                         // Form - wrappers, inputs, labels
-@import "elements/forms/form-multiple-choice";    // Chunky labels for radios and checkboxes
+@import "elements/forms/form-multiple-choice";    // Custom radio buttons and checkboxes
 @import "elements/forms/form-date";               // Date of birth pattern
 @import "elements/forms/form-validation";         // Errors and validation
 @import "elements/breadcrumbs";                   // Breadcrumbs

--- a/public/sass/elements/forms/_form-block-labels.scss
+++ b/public/sass/elements/forms/_form-block-labels.scss
@@ -1,4 +1,3 @@
-// Large hit area
 // Radio buttons & checkboxes
 
 // By default, block labels stack vertically
@@ -36,96 +35,85 @@
 
     // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there.
     @if ($is-ie == false) or ($ie-version == 9) {
-      .js-enabled & {
-        margin: 0;
-        @include opacity(0);
-      }
+      margin: 0;
+      @include opacity(0);
     }
   }
 
-  .js-enabled & {
-    &.selection-button-radio::before {
-      content: "";
-      border: 2px solid;
-      background: transparent;
-      width: 34px;
-      height: 34px;
-      position: absolute;
-      top: 0;
-      left: 0;
-      @include border-radius(50%);
-    }
+  label {
+    cursor: pointer;
+  }
 
-    &.selection-button-radio::after {
-      content: "";
-      border: 10px solid;
-      width: 0;
-      height: 0;
-      position: absolute;
-      top: 9px;
-      left: 9px;
-      @include border-radius(50%);
-      @include opacity(0);
-    }
+  [type=radio] + label::before {
+    content: "";
+    border: 2px solid;
+    background: transparent;
+    width: 34px;
+    height: 34px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    @include border-radius(50%);
+  }
 
-    &.selection-button-checkbox::before {
-      content: "";
-      border: 2px solid;
-      background: transparent;
-      width: 34px;
-      height: 34px;
-      position: absolute;
-      top: 0;
-      left: 0;
-    }
+  [type=radio] + label::after {
+    content: "";
+    border: 10px solid;
+    width: 0;
+    height: 0;
+    position: absolute;
+    top: 9px;
+    left: 9px;
+    @include border-radius(50%);
+    @include opacity(0);
+  }
 
-    &.selection-button-checkbox::after {
-      content: "";
-      border: solid;
-      border-width: 0 0 5px 5px;
-      background: transparent;
-      width: 17px;
-      height: 7px;
-      position: absolute;
-      top: 10px;
-      left: 8px;
-      -moz-transform: rotate(-45deg); // Firefox 15 compatibility
-      -o-transform: rotate(-45deg); // Opera 12.0 compatibility
-      -webkit-transform: rotate(-45deg); // Safari 8 compatibility
-      -ms-transform: rotate(-45deg); // IE9 compatibility
-      transform: rotate(-45deg);
-      @include opacity(0);
-    }
+  [type=checkbox] + label::before {
+    content: "";
+    border: 2px solid;
+    background: transparent;
+    width: 34px;
+    height: 34px;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
 
-    // Focused state
-    &.selection-button-checkbox.focused::before {
-      @include box-shadow(0 0 0 3px $focus-colour);
-    }
+  [type=checkbox] + label::after {
+    content: "";
+    border: solid;
+    border-width: 0 0 5px 5px;
+    background: transparent;
+    width: 17px;
+    height: 7px;
+    position: absolute;
+    top: 10px;
+    left: 8px;
+    -moz-transform: rotate(-45deg); // Firefox 15 compatibility
+    -o-transform: rotate(-45deg); // Opera 12.0 compatibility
+    -webkit-transform: rotate(-45deg); // Safari 8 compatibility
+    -ms-transform: rotate(-45deg); // IE9 compatibility
+    transform: rotate(-45deg);
+    @include opacity(0);
+  }
 
-    &.selection-button-radio.focused::before {
-      @include box-shadow(0 0 0 4px $focus-colour);
-    }
+  // Focused state
+  [type=radio]:focus + label::before {
+    @include box-shadow(0 0 0 4px $focus-colour);
+  }
 
-    // IE8 focus outline should stay as a border around the entire label
-    // Lack of padding doesn’t matter as IE8 won’t resize the inputs.
-    @include ie-lte(8) {
-      &.selection-button-radio.focused,
-      &.selection-button-checkbox.focused {
-        outline: 3px solid $focus-colour;
+  [type=checkbox]:focus + label::before {
+    @include box-shadow(0 0 0 3px $focus-colour);
+  }
 
-        input:focus {
-          outline: none;
-        }
-      }
-    }
+  // Selected state
+  input:checked + label::after {
+    @include opacity(1);
+  }
 
-    // Selected state
-    &.selection-button-radio,
-    &.selection-button-checkbox {
-      &.selected::after {
-        @include opacity(1);
-      }
-    }
+  // Disabled state
+  input:disabled + label {
+    @include opacity(0.5);
   }
 
   &:last-child,

--- a/public/sass/elements/forms/_form-multiple-choice.scss
+++ b/public/sass/elements/forms/_form-multiple-choice.scss
@@ -32,6 +32,7 @@
     top: 0;
     width: 38px;
     height: 38px;
+    z-index: 1;
 
     // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there.
     @if ($is-ie == false) or ($ie-version == 9) {

--- a/public/sass/elements/forms/_form-multiple-choice.scss
+++ b/public/sass/elements/forms/_form-multiple-choice.scss
@@ -1,7 +1,7 @@
 // Radio buttons & checkboxes
 
-// By default, block labels stack vertically
-.block-label {
+// By default, multiple choice inputs stack vertically
+.multiple-choice {
 
   display: block;
   float: none;
@@ -11,7 +11,7 @@
   padding: (8px $gutter-one-third 9px 50px);
   margin-bottom: $gutter-one-third;
 
-  cursor: pointer; // Encourage clicking on block labels
+  cursor: pointer; // Encourage clicking on the label
 
    // remove 300ms pause on mobile
   -ms-touch-action: manipulation;
@@ -122,8 +122,8 @@
   }
 }
 
-// To stack horizontally, use .inline on parent, to sit block labels next to each other
-.inline .block-label {
+// To sit multiple choice inputs next to each other, use .inline on parent
+.inline .multiple-choice {
   clear: none;
 
   @include media (tablet) {


### PR DESCRIPTION
This PR removes the [JavaScript requirement](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/selection-buttons.js) for radio buttons and checkboxes. To do this the markup had been changed, but there are no visual changes for users (beyond IE < 9 having a focus box around just the input rather than the whole label).

#### What problem does the pull request solve?
The new radios and checkboxes still required the selection buttons JS. This is a potential point of failure that’s a hangover from the old grey-box implementation, and isn’t really needed. We originally went with it because removing it would require markup changes and would mean that it they weren’t a drop-in solution. I think that was probably a mistake though, so this corrects it.

While making the markup changes I took the opportunity to rename the component from the old `block-label` to the more descriptive `multiple-choice`. This has better developer semantics, but also has the benefit that it’ll obviously require markup changes.

This fixes https://github.com/alphagov/govuk_elements/issues/375 and https://github.com/alphagov/govuk_elements/issues/367.

#### How has this been tested?
Tested in all macOS native browsers, and in Browserstack for IE and Edge on Windows (back to 8) and a selection of iOS and Android versions. The only initial bug found was a problem in IE9/10 that was fixed. No assistive tech testing has been done yet, and I’d want to do at least some to make sure that no new issues have been introduced. The assistive tech bugs fixed during the development of the new radios and checkboxes shouldn’t have regressed as their implementation hasn’t changed.

#### What type of change is it?
- Breaking change (fix or feature that would cause existing functionality to change)

#### Has the documentation been updated?
- I have updated the documentation accordingly.
