### PR TITLE
Make Travis deployment config consistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ language: node_js
 node_js:
  - "4.4.7"
 before_install:
-- git config --global user.name "Travis CI"
-- git config --global user.email "travis@travis-ci.org"
-- git remote add origin_ssh git@github.com:alphagov/govuk_elements.git
-- 'if [ "$TRAVIS_PULL_REQUEST_BRANCH" = "master" ]; then openssl aes-256-cbc -K $encrypted_85ebe8034b89_key -iv $encrypted_85ebe8034b89_iv -in .travis/govuk_elements.enc -out ~/.ssh/id_rsa -d && chmod 600 ~/.ssh/id_rsa; fi'
-  # This openssl command was generated automatically by `travis encrypt-file`, see `.travis/README.md` for more details
 - npm install -g grunt-cli
 install:
 - npm install
@@ -16,6 +11,11 @@ notifications:
   email: false
 before_deploy:
 - test $TRAVIS_TEST_RESULT = 0
+- git config --global user.name "Travis CI"
+- git config --global user.email "travis@travis-ci.org"
+- git remote add origin_ssh git@github.com:alphagov/govuk_elements.git
+# This openssl command was generated automatically by `travis encrypt-file`, see `.travis/README.md` for more details
+- openssl aes-256-cbc -K $encrypted_85ebe8034b89_key -iv $encrypted_85ebe8034b89_iv -in .travis/govuk_elements.enc -out ~/.ssh/id_rsa -d && chmod 600 ~/.ssh/id_rsa; fi'
 deploy:
 - provider: script
   script: './push-version-tag.sh'


### PR DESCRIPTION
With other GDS FE repos, see:
https://github.com/alphagov/govuk_frontend_toolkit/pull/385

Steps specified in before_deploy are only run if a deployment is
triggered [1], which will only happen on master, which can't be
done by a user without write perms.

[1] [Travis before_deploy documentation](https://docs.travis-ci.com/user/deployment/npm/#Running-commands-before-and-after-deploy)