### PR TITLE
Bump govuk_frontend_toolkit to 5.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.0"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^5.0.2"
+    "govuk_frontend_toolkit": "^5.1.1"
   },
   "devDependencies": {
     "body-parser": "^1.14.1",


### PR DESCRIPTION
#### What problem does the pull request solve?

Update the govuk_frontend toolkit to the latest version.

This includes the following changes:

**5.1.1**

- Update the alpha, beta and discovery colours to $govuk-blue to match
the updated phase banner ([PR #370](https://github.com/alphagov/govuk_frontend_toolkit/pull/370))
- Fix radio button show/hide behaviour when used outside a form ([PR #375](https://github.com/alphagov/govuk_frontend_toolkit/pull/375))
- Fix a "Stick at top when scrolling" component bug related to scroll
anchoring in Chrome 56+ ([PR #376](https://github.com/alphagov/govuk_frontend_toolkit/pull/376))
- Minor travis fixes ([PR #373](https://github.com/alphagov/govuk_frontend_toolkit/pull/373))

**5.1.0**

- Allow custom options when tracking events ([PR #365](https://github.com/alphagov/govuk_frontend_toolkit/pull/365))

**5.0.3** 

- Change HMRC and DEFRA text colours for improved contrast ([PR #368](https://github.com/alphagov/govuk_frontend_toolkit/pull/368))


#### What type of change is it?
- New feature (non-breaking change which adds functionality)

#### Has the documentation been updated?
- My change requires a change to the documentation.
- I have read the **CONTRIBUTING** document.
