### PR TITLE
Fix broken travis deployment setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_deploy:
 - git config --global user.email "travis@travis-ci.org"
 - git remote add origin_ssh git@github.com:alphagov/govuk_elements.git
 # This openssl command was generated automatically by `travis encrypt-file`, see `.travis/README.md` for more details
-- openssl aes-256-cbc -K $encrypted_85ebe8034b89_key -iv $encrypted_85ebe8034b89_iv -in .travis/govuk_elements.enc -out ~/.ssh/id_rsa -d && chmod 600 ~/.ssh/id_rsa; fi'
+- openssl aes-256-cbc -K $encrypted_85ebe8034b89_key -iv $encrypted_85ebe8034b89_iv -in .travis/govuk_elements.enc -out ~/.ssh/id_rsa -d && chmod 600 ~/.ssh/id_rsa
 deploy:
 - provider: script
   script: './push-version-tag.sh'


### PR DESCRIPTION
This was broken in #408, where the setup was moved to `before_deploy`
to avoid permission issues when running PR tests in a way consistent
with other `alphagov` apps.

Previously that was guarded by a shell if, which was removed, but a
bit at the end was left and is breaking deployment builds. :(

#### What problem does the pull request solve?
- Fixes deployment builds.

#### What type of change is it?
Internal change, no effect on semver.