### PR TITLE
Revert Make Travis deployment config consistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ node_js:
  - "4.4.7"
 before_install:
 - npm install -g grunt-cli
+- git config --global user.name "Travis CI"
+- git config --global user.email "travis@travis-ci.org"
+- git remote add origin_ssh git@github.com:alphagov/govuk_elements.git
+- 'if [ "$TRAVIS_PULL_REQUEST_BRANCH" = "master" ]; then openssl aes-256-cbc -K $encrypted_85ebe8034b89_key -iv $encrypted_85ebe8034b89_iv -in .travis/govuk_elements.enc -out ~/.ssh/id_rsa -d && chmod 600 ~/.ssh/id_rsa; fi'
+-  # This openssl command was generated automatically by `travis encrypt-file`, see `.travis/README.md` for more details
 install:
 - npm install
 script:
@@ -11,11 +16,6 @@ notifications:
   email: false
 before_deploy:
 - test $TRAVIS_TEST_RESULT = 0
-- git config --global user.name "Travis CI"
-- git config --global user.email "travis@travis-ci.org"
-- git remote add origin_ssh git@github.com:alphagov/govuk_elements.git
-# This openssl command was generated automatically by `travis encrypt-file`, see `.travis/README.md` for more details
-- openssl aes-256-cbc -K $encrypted_85ebe8034b89_key -iv $encrypted_85ebe8034b89_iv -in .travis/govuk_elements.enc -out ~/.ssh/id_rsa -d && chmod 600 ~/.ssh/id_rsa
 deploy:
 - provider: script
   script: './push-version-tag.sh'


### PR DESCRIPTION
#### What problem does the pull request solve?

This PR attempts to fix deployment to Heroku, which is currently failing.

This reverts the changes made in #404:
https://github.com/alphagov/govuk_elements/pull/408

It moves the open_ssl command back to before_install, otherwise it runs more than once (as
there is more than one deploy provider).

See related issue here:
https://github.com/travis-ci/travis-ci/issues/2570

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)
