### PR TITLE
Add an aria-current attribute to the breadcrumbs

### DIFF
--- a/app/views/includes/breadcrumb.html
+++ b/app/views/includes/breadcrumb.html
@@ -6,7 +6,7 @@
     <li><a href="/{{ section }}/">{% if section_name %} {{ section_name }} {% endif %}</a></li>
     {% endif %}
     {% if page_name %}
-    <li>{{ page_name }}</li>
+    <li aria-current="page">{{ page_name }}</li>
     {% endif %}
   </ol>
 </div>


### PR DESCRIPTION
#### What problem does the pull request solve?
This PR updates the breadcrumbs to use the aria-current attribute as described here:
http://tink.uk/using-the-aria-current-attribute/.

Fixes #412.

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
- I have read the **CONTRIBUTING** document.
