### PR TITLE
Add a new class for bare list items

### DIFF
--- a/public/sass/elements/_lists.scss
+++ b/public/sass/elements/_lists.scss
@@ -13,7 +13,7 @@ ol {
 }
 
 .list li {
-  margin-bottom: 5px;
+  margin-bottom: 10px;
 }
 
 // Bulleted lists


### PR DESCRIPTION
#### What problem does the pull request solve?

Add a new class for bare list items (without numbers or bullets) and increase the spacing underneath these list items - so there is more visual separation between items.

Increase the spacing underneath bare list items to 10px, also update the bare list example to match the two lists above (and to show how lists wrap onto two lines).

Fixes #407.

#### How has this been tested?
You can see this working in the preview app here: 

#### What type of change is it?
- New feature (non-breaking change which adds functionality)

#### Has the documentation been updated?
- I have read the **CONTRIBUTING** document.
