### PR TITLE
Ensure that table cells using tabular-numbers are 19px

### DIFF
--- a/public/sass/elements/_tables.scss
+++ b/public/sass/elements/_tables.scss
@@ -18,17 +18,17 @@ table {
 
   th {
     font-weight: 700;
-    // Right align headings for numeric content
-    &.numeric {
-      text-align: right;
-    }
+  }
+
+  // Right align table header cells and table cells with a numeric class
+  .numeric {
+    text-align: right;
   }
 
   // Allow a qualifying element, only table data cells should use tabular numbers
   // scss-lint:disable QualifyingElement
   td.numeric {
-    @include core-16($tabular-numbers: true);
-    text-align: right;
+    font-family: $toolkit-font-stack-tabular;
   }
 }
 


### PR DESCRIPTION
#### What problem does the pull request solve?

Fixes #403 - Tables have inconsistent front sizes.

Remove the core-16 mixin being applied to table cells with a class of
numeric. All tables should use 19px - to match the body text size.

#### How has this been tested?
Tested by running the GOV.UK elements app locally, see screenshots, or Heroku app preview.

#### Screenshots (if appropriate):

#### Before:

![before - tables](https://cloud.githubusercontent.com/assets/417754/24041375/01f77b06-0b05-11e7-9c53-0b2448718464.png)

#### After: 

![after - tables](https://cloud.githubusercontent.com/assets/417754/24041381/062b3f46-0b05-11e7-8187-4ae365eec352.png)

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
- Bug fix (non-breaking change which fixes an issue)


#### Has the documentation been updated?
- I have read the **CONTRIBUTING** document.
