### PR TITLE
Update the govuk frontend toolkit to 5.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.0"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^5.1.1"
+    "govuk_frontend_toolkit": "^5.1.2"
   },
   "devDependencies": {
     "body-parser": "^1.14.1",


### PR DESCRIPTION
This updates show-hide-content.js and fixes the current issue for “Conditionally revealed content” where the toggled content areas aren’t shown.

From the GOV.UK Frontend Toolkit changelog:

- Update show-hide-content.js to work with new `.multiple-choice` custom radio buttons and checkboxes, released in GOV.UK elements 3.0.0 ([PR #390](https://github.com/alphagov/govuk_frontend_toolkit/pull/390))
- Fix buttons not having an outer edge when colours are changed via browser settings - add an outline so they look like buttons. ([PR #377](https://github.com/alphagov/govuk_frontend_toolkit/pull/377))