### PR TITLE
Resolve 'dead area' between radio/checkbox and label that has hand cursor but is not clickable

### DIFF
--- a/public/sass/elements/forms/_form-multiple-choice.scss
+++ b/public/sass/elements/forms/_form-multiple-choice.scss
@@ -8,20 +8,11 @@
   clear: left;
   position: relative;
 
-  padding: (8px $gutter-one-third 9px 50px);
+  padding: 0 0 0 38px;
   margin-bottom: $gutter-one-third;
-
-  cursor: pointer; // Encourage clicking on the label
-
-   // remove 300ms pause on mobile
-  -ms-touch-action: manipulation;
-  touch-action: manipulation;
 
   @include media(tablet) {
     float: left;
-    padding-top: 7px;
-    padding-bottom: 7px;
-    // width: 25%; - Test : check that text within labels will wrap
   }
 
   // Absolutely position inputs within label, to allow text to wrap
@@ -43,6 +34,18 @@
 
   label {
     cursor: pointer;
+    padding: 8px $gutter-one-third 9px 12px;
+    display: block;
+
+    // remove 300ms pause on mobile
+    -ms-touch-action: manipulation;
+    touch-action: manipulation;
+
+    @include media(tablet) {
+      float: left;
+      padding-top: 7px;
+      padding-bottom: 7px;
+    }
   }
 
   [type=radio] + label::before {


### PR DESCRIPTION
#### What problem does the pull request solve?
On the new radio buttons / checkboxes, there is a 12px gap between the input control and the label which has a hand cursor (inherited from the `.multiple-choice` parent div) but is not clickable. Since it has the hand cursor, I feel it _should_ be clickable.

The alternative would be to not show the hand cursor in this 12px dead area but that doesn't feel right to me?

#### How has this been tested?
Checked in Chrome (Ubuntu), IE8, IE9, IE10, IE11, Edge 14, iOS9 Safari, Android 6 Chrome.
Can test more if necessary, if this change is approved. Just let me know...

#### Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/134642/24361783/bcd21274-1302-11e7-89dd-b76d502d89fc.png)

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
- I have read the **CONTRIBUTING** document.
