### PR TITLE
Fix example of radio markup

### DIFF
--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -139,14 +139,14 @@
             <div class="multiple-choice">
               <input id="radio-part-2" type="radio" name="housing-act" value="Part 2">
               <label for="radio-part-2"><span class="heading-small">Part 2 of the Housing Act 2004</span><br></label>
-              For divroperties that are 3 or more stories high and occupied by 5 or more people
-            </label>
+              For properties that are 3 or more stories high and occupied by 5 or more people
+            </div>
 
             <div class="multiple-choice">
               <input id="radio-part-3" type="radio" name="housing-act" value="Part 3">
               <label for="radio-part-3"><span class="heading-small">Part 3 of the Housing Act 2004</span><br></label>
-              For divroperties that are within a geographical area defined by a local council
-            </label>
+              For properties that are within a geographical area defined by a local council
+            </div>
 
           </fieldset>
         </div>


### PR DESCRIPTION
[example_radios_checkboxes.html](https://github.com/alphagov/govuk_elements/blob/a06c8ec857c3b84e0d7da6c6ea734b8dcb45dd29/app/views/examples/example_radios_checkboxes.html) has markup that was broken in the the [radio button update](https://github.com/alphagov/govuk_elements/commit/4fb688e208fb65a04d5ccde59700ee4d73c39b7d). This updates it to match the correct multiple-choice markup.

Fixes https://github.com/alphagov/govuk_elements/issues/436.