### PR TITLE
Fix details polyfill for JAWS and NVDA in IE

### DIFF
--- a/public/javascripts/govuk/details.polyfill.js
+++ b/public/javascripts/govuk/details.polyfill.js
@@ -10,6 +10,8 @@
   'use strict'
 
   var NATIVE_DETAILS = typeof document.createElement('details').open === 'boolean'
+  var KEY_ENTER = 13
+  var KEY_SPACE = 32
 
   // Add event construct for modern browsers or IE
   // which fires the callback with a pre-converted target reference
@@ -25,25 +27,50 @@
     }
   }
 
+  // Cross-browser character code / key pressed
+  function charCode (e) {
+    return (typeof e.which === 'number') ? e.which : e.keyCode
+  }
+
+  // Cross-browser preventing default action
+  function preventDefault (e) {
+    if (e.preventDefault) {
+      e.preventDefault()
+    } else {
+      e.returnValue = false
+    }
+  }
+
   // Handle cross-modal click events
   function addClickEvent (node, callback) {
-    // Prevent space(32) from scrolling the page
     addEvent(node, 'keypress', function (e, target) {
-      if (target.nodeName === 'SUMMARY') {
-        if (e.keyCode === 32) {
-          if (e.preventDefault) {
-            e.preventDefault()
+      // When the key gets pressed - check if it is enter or space
+      if (charCode(e) === KEY_ENTER || charCode(e) === KEY_SPACE) {
+        if (target.nodeName.toLowerCase() === 'summary') {
+          // Prevent space from scrolling the page
+          // and enter from submitting a form
+          preventDefault(e)
+          // Click to let the click event do all the necessary action
+          if (target.click) {
+            target.click()
           } else {
-            e.returnValue = false
+            // except Safari 5.1 and under don't support .click() here
+            callback(e, target)
           }
         }
       }
     })
-    // When the key comes up - check if it is enter(13) or space(32)
+
+    // Prevent keyup to prevent clicking twice in Firefox when using space key
     addEvent(node, 'keyup', function (e, target) {
-      if (e.keyCode === 13 || e.keyCode === 32) { callback(e, target) }
+      if (charCode(e) === KEY_SPACE) {
+        if (target.nodeName === 'SUMMARY') {
+          preventDefault(e)
+        }
+      }
     })
-    addEvent(node, 'mouseup', function (e, target) {
+
+    addEvent(node, 'click', function (e, target) {
       callback(e, target)
     })
   }


### PR DESCRIPTION
#### What problem does the pull request solve?

As reported in #130, the details/summary cannot be opened when using JAWS or NVDA in Internet Explorer.
As part of my investigation I also found that using the enter key on the summary would also submit a form in IE if details is used within a form.
This fixes both issues.

Some screen readers map the screen reader key + space (or enter) to the **click** event. As you can see in [Event Handlers and Screen Readers](http://unobfuscated.blogspot.co.uk/2013/05/event-handlers-and-screen-readers.html), the click event is usually the **only** event fired for IE and JAWS/NVDA combinations.

Our polyfill is currently listening for the keyup, keypress and mouseup events. It used to listen to the click instead of the mouseup event, but that was [changed because it made it trigger twice in Chrome](https://github.com/alphagov/govuk_elements/commit/66ae6ce45a75a74fd4dcc61ecac8ad432a93b6b1).

I've now changed it to use click and keydown. As far as I know, it does not trigger twice anymore.
I've also done some minor refactoring.

#### How has this been tested?

I have not tested within Elements but have [isolated all the important bits into a JSbin](http://jsbin.com/cerajed). (I have added some debugging under that, not in a `console` because I wanted to easily test in older and mobile browsers.) See the [current version with the bugs and the debugging in a JSbin](http://jsbin.com/neheyey) for a comparison.

I have tested in various browsers and screen reader combinations, mainly IE and Firefox with JAWS and NVDA, both and Chrome on its own. I found that it's more likely to be troublesome if the browser doesn't [support `details`](http://caniuse.com/#feat=details), so I concentrated on testing in older browsers via Browserstack (Firefox 48 and under, Safari 5.1 and under, Android Browser 3 and under, Windows Phone; there is no version of Chrome which is old enough). I tested with mouse and keyboard and touch and Dragon when I could.

#### What type of change is it?

Bug fix (non-breaking change which fixes an issue)
