### PR TITLE
Fix poor alignment of text in radios example

### DIFF
--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -138,14 +138,18 @@
 
             <div class="multiple-choice">
               <input id="radio-part-2" type="radio" name="housing-act" value="Part 2">
-              <label for="radio-part-2"><span class="heading-small">Part 2 of the Housing Act 2004</span><br></label>
-              For properties that are 3 or more stories high and occupied by 5 or more people
+              <label for="radio-part-2">
+                <span class="heading-small">Part 2 of the Housing Act 2004</span><br>
+                For properties that are 3 or more stories high and occupied by 5 or more people
+              </label>
             </div>
 
             <div class="multiple-choice">
               <input id="radio-part-3" type="radio" name="housing-act" value="Part 3">
-              <label for="radio-part-3"><span class="heading-small">Part 3 of the Housing Act 2004</span><br></label>
-              For properties that are within a geographical area defined by a local council
+              <label for="radio-part-3">
+                <span class="heading-small">Part 3 of the Housing Act 2004</span><br>
+                For properties that are within a geographical area defined by a local council
+              </label>
             </div>
 
           </fieldset>


### PR DESCRIPTION
Closes #442.

Has the added effect of providing more information to users of assistive technology, which seems desirable. I tested in VoiceOver and the behaviour is that the bold part of the label gets pronounced, followed by a short pause, followed by the rest of it, which is ok.

I have not looked to see if this problem exists in other places. [Digging here might uncover more places](https://github.com/alphagov/govuk_elements/commit/4fb688e208fb65a04d5ccde59700ee4d73c39b7d).

## Before

![screen shot 2017-04-06 at 18 21 28](https://cloud.githubusercontent.com/assets/1650875/24767281/6210366c-1af6-11e7-90e1-2999c5e835ee.png)

## After

![screen shot 2017-04-06 at 18 21 20](https://cloud.githubusercontent.com/assets/1650875/24767290/670e73a4-1af6-11e7-8b6f-5767c1dec649.png)
