### PR TITLE
Update broken link to the details polyfill

### DIFF
--- a/app/views/examples/example_details_summary.html
+++ b/app/views/examples/example_details_summary.html
@@ -20,7 +20,7 @@
       </p>
 
       <p>
-        These elements are only supported by <a href="http://caniuse.com/#feat=details" rel="external">a few modern browsers</a> at the moment so you’ll need a JavaScript polyfill to make them work in other browsers. <a href="https://github.com/alphagov/govuk_elements/blob/master/public/javascripts/vendor/details.polyfill.js" rel="external">Here’s the polyfill used by GOV.UK elements</a>.
+        These elements are only supported by <a href="http://caniuse.com/#feat=details" rel="external">a few modern browsers</a> at the moment so you’ll need a JavaScript polyfill to make them work in other browsers. <a href="https://github.com/alphagov/govuk_elements/blob/master/public/javascripts/govuk/details.polyfill.js" rel="external">Here’s the polyfill used by GOV.UK elements</a>.
       </p>
 
       <p>


### PR DESCRIPTION
This was moved into a govuk/ folder, update the example page to reflect
this.