### PR TITLE
Bump govuk_frontend_toolkit to 5.2.0

### DIFF
--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -15,14 +15,15 @@
         Example: Radio buttons <br> and checkboxes
       </h1>
 
-      <p class="text">
-        This test page demonstrates selection-buttons.js from the govuk frontend toolkit, which
-        sets ‘focused’ and ‘selected’ states for the large hit area labels that wrap checkboxes and radio buttons.
-      </p>
+      <div class="text">
+        <p>
+          This test page demonstrates the new <code class="code">.multiple-choice</code> radio buttons and checkboxes, released in GOV.UK elements v3.0.0.
+        </p>
 
-      <p class="text">
-        It also demonstrates setting ARIA attributes when showing and hiding additional content.
-      </p>
+        <p>
+          It also demonstrates setting ARIA attributes when showing and hiding additional content - using <a href="https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/show-hide-content.js">show-hide-content.js</a> from the GOV.UK frontend toolkit.
+        </p>
+      </div>
 
       <form action="/" method="post" class="form">
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.0"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^5.1.2"
+    "govuk_frontend_toolkit": "^5.2.0"
   },
   "devDependencies": {
     "body-parser": "^1.14.1",


### PR DESCRIPTION
#### What problem does the pull request solve?

Update govuk_elements to use the most recent version of govuk_frontend_toolkit.

Also remove any remaining references to selection-buttons.js (which was removed from this repo in #406), selection-buttons.js was deprecated in govuk_frontend_toolkit 5.2.0.

#### What type of change is it?
- New feature (non-breaking change which adds functionality)

#### Has the documentation been updated?
- I have read the **CONTRIBUTING** document.
