### PR TITLE
Update node-sass to fix Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "node": ">=6.0"
   },
   "dependencies": {
-    "govuk_frontend_toolkit": "^5.2.0",
     "body-parser": "^1.14.1",
     "consolidate": "^0.10.0",
     "express": "4.13.3",
     "express-nunjucks": "^0.9.3",
     "express-writer": "0.0.4",
+    "govuk_frontend_toolkit": "^5.2.0",
     "govuk_template_jinja": "0.19.2",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
@@ -25,7 +25,7 @@
     "grunt-nodemon": "^0.3.0",
     "grunt-sass": "^1.0.0",
     "grunt-shell": "^1.3.0",
-    "node-sass": "^3.2.0",
+    "node-sass": "^4.5.2",
     "readdir": "0.0.6",
     "standard": "^7.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1597,6 +1597,10 @@ lodash.clonedeep@^4.3.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
+lodash.mergewith@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
+
 lodash@^4.0.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -1802,7 +1806,7 @@ node-pre-gyp@^0.6.29:
     tar "~2.2.1"
     tar-pack "~3.3.0"
 
-node-sass@^3.2.0, node-sass@^3.7.0:
+node-sass@^3.7.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-3.13.1.tgz#7240fbbff2396304b4223527ed3020589c004fc2"
   dependencies:
@@ -1823,6 +1827,29 @@ node-sass@^3.2.0, node-sass@^3.7.0:
     request "^2.61.0"
     sass-graph "^2.1.1"
 
+node-sass@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.2.tgz#4012fa2bd129b1d6365117e88d9da0500d99da64"
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash.assign "^4.2.0"
+    lodash.clonedeep "^4.3.2"
+    lodash.mergewith "^4.6.0"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.3.2"
+    node-gyp "^3.3.1"
+    npmlog "^4.0.0"
+    request "^2.79.0"
+    sass-graph "^2.1.1"
+    stdout-stream "^1.4.0"
+
 nodemon@~1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.2.1.tgz#02a288045652e92350e7d752a8054472ed2c4824"
@@ -1831,9 +1858,9 @@ nodemon@~1.2.0:
     ps-tree "~0.0.3"
     update-notifier "~0.1.8"
 
-"nopt@2 || 3", nopt@~3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+"nopt@2 || 3", nopt@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-2.0.0.tgz#ca7416f20a5e3f9c3b86180f96295fa3d0b52e0d"
   dependencies:
     abbrev "1"
 
@@ -1843,9 +1870,9 @@ nopt@~1.0.10:
   dependencies:
     abbrev "1"
 
-nopt@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-2.0.0.tgz#ca7416f20a5e3f9c3b86180f96295fa3d0b52e0d"
+nopt@~3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   dependencies:
     abbrev "1"
 
@@ -2147,7 +2174,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.2.2:
+"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.2.2:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.6.tgz#8b43aed76e71483938d12a8d46c6cf1a00b1f816"
   dependencies:
@@ -2462,6 +2489,12 @@ statuses@1, "statuses@>= 1.3.1 < 2":
 statuses@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.2.1.tgz#dded45cc18256d51ed40aec142489d5c61026d28"
+
+stdout-stream@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.0.tgz#a2c7c8587e54d9427ea9edb3ac3f2cd522df378b"
+  dependencies:
+    readable-stream "^2.0.1"
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
It looks like there is a node_modules cache issue with Heroku when
using Yarn.

Attempting to fix by updating node-sass to version 4.5.2.

This commit has been deployed to Heroku manually and the app is running here:
http://govuk-elements.herokuapp.com/