### PR TITLE
Revert changes to dependencies and devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "node": ">=6.0"
   },
   "dependencies": {
+    "govuk_frontend_toolkit": "^5.2.0"
+  },
+  "devDependencies": {
     "body-parser": "^1.14.1",
     "consolidate": "^0.10.0",
     "express": "4.13.3",
     "express-nunjucks": "^0.9.3",
     "express-writer": "0.0.4",
-    "govuk_frontend_toolkit": "^5.2.0",
     "govuk_template_jinja": "0.19.2",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
Move the dependencies to run the govuk-elements app into
devDependencies.

Ensure that the dependencies for the govuk-elements-sass package are in
dependencies.

This reverts the [change made on Friday](https://github.com/alphagov/govuk_elements/commit/ff665369c81f8891b5dd99613507a1b5f7c4e8f4), when trying to debug the node_modules cache issue with Yarn and Heroku: https://github.com/yarnpkg/yarn/issues/1981

For this to work on Heroku, production mode will need to be disabled. 