### PR TITLE
Remove duplicate IDs from inset panel example

### DIFF
--- a/app/views/snippets/form_inset_panel.html
+++ b/app/views/snippets/form_inset_panel.html
@@ -1,6 +1,6 @@
 <div class="form-group">
   <div class="panel panel-border-narrow">
-    <label class="form-label" for="contact-text-message">Mobile phone number</label>
-    <input class="form-control" name="contact-text-message" type="text" id="contact-text-message">
+    <label class="form-label" for="example-phone-number">Mobile phone number</label>
+    <input class="form-control" id="example-phone-number" name="example-phone-number" type="text">
   </div>
 </div>

--- a/app/views/snippets/form_inset_panel.html
+++ b/app/views/snippets/form_inset_panel.html
@@ -1,5 +1,5 @@
 <div class="form-group">
-  <div class="panel panel-border-narrow" id="contact-by-text">
+  <div class="panel panel-border-narrow">
     <label class="form-label" for="contact-text-message">Mobile phone number</label>
     <input class="form-control" name="contact-text-message" type="text" id="contact-text-message">
   </div>


### PR DESCRIPTION
This example is a smaller part of another example on the same page,
hence the IDs were duplicated.

The ID on the panel isn't relevant for this standalone example and the values of the for, id and name attributes have been updated to use an id that isn't already in use on the page.
