### PR TITLE
Increase the size of the text in the highlight box

### DIFF
--- a/app/views/guide_colour.html
+++ b/app/views/guide_colour.html
@@ -371,12 +371,12 @@
         </h1>
 
         <div class="govuk-box-highlight">
-          <h2 class="bold-large">
+          <h2 class="heading-xlarge">
             Application complete
           </h2>
-          <p>
+          <p class="font-large">
             Your reference number is <br>
-            <strong class="heading-medium">HDJ2123F</strong>
+            <strong class="bold">HDJ2123F</strong>
           </p>
         </div>
 

--- a/public/sass/elements/_components.scss
+++ b/public/sass/elements/_components.scss
@@ -2,7 +2,7 @@
 // Used for transaction end pages, and Bank Holidays
 .govuk-box-highlight {
   margin: 1em 0;
-  padding: 2em 0 1em;
+  padding: 2em 1em;
   color: $white;
   background: $turquoise;
   text-align: center;


### PR DESCRIPTION
Increase the heading size by one level and use large text (36px) for
the text which is currently failing contrast checks.

For smaller screens, the font-size (of the large text - as [we're using the govuk_frontend_toolkit's core-36 mixin](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_typography.scss#L73)) will be 24px.


Discussion over in #200.

#### Screenshots (if appropriate):

#### Before:

![screenshot-localhost-3000-2017-04-12-16-14-13](https://cloud.githubusercontent.com/assets/417754/24965965/7c127e84-1f9d-11e7-9980-7a0075a61ab7.png)

#### After:

![after](https://cloud.githubusercontent.com/assets/417754/24966004/9a65c472-1f9d-11e7-99be-4f4bca3171bb.png)

![small-screen](https://cloud.githubusercontent.com/assets/417754/24966678/929bcc58-1f9f-11e7-9c41-4191c75c0cab.png)

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue) Fixes #200.
