### PR TITLE
Add name attributes to form fields

### DIFF
--- a/app/views/snippets/form_focus.html
+++ b/app/views/snippets/form_focus.html
@@ -3,7 +3,7 @@
     <form>
       <div class="form-group">
         <label class="form-label" for="full-name-f2">Full name</label>
-        <input class="form-control" type="text" id="full-name-f2">
+        <input class="form-control" type="text" id="full-name-f2" name="full-name-f2">
       </div>
     </form>
   </div>

--- a/app/views/snippets/form_hint_text.html
+++ b/app/views/snippets/form_hint_text.html
@@ -6,4 +6,4 @@
     For example, ‘QQ 12 34 56 C’.
   </span>
 </label>
-<input class="form-control" id="ni-number" type="text">
+<input class="form-control" id="ni-number" type="text" name="ni-number">

--- a/app/views/snippets/form_input_sizes.html
+++ b/app/views/snippets/form_input_sizes.html
@@ -7,41 +7,41 @@
     <label class="form-label" for="form-control-1-8">
       Input with class form-control-1-8 (12.5% width)
     </label>
-    <input class="form-control form-control-1-8" id="form-control-1-8" type="text">
+    <input class="form-control form-control-1-8" id="form-control-1-8" type="text" name="form-control-1-8">
   </div>
 
   <div class="form-group">
     <label class="form-label" for="form-control-1-4">
       Input with class form-control-1-4 (25% width)
     </label>
-    <input class="form-control form-control-1-4" id="form-control-1-4" type="text">
+    <input class="form-control form-control-1-4" id="form-control-1-4" type="text" name="form-control-1-4">
   </div>
 
   <div class="form-group">
     <label class="form-label" for="form-control-1-3">
       Input with class form-control-1-3 (33% width)
     </label>
-    <input class="form-control form-control-1-3" id="form-control-1-3" type="text">
+    <input class="form-control form-control-1-3" id="form-control-1-3" type="text" name="form-control-1-3">
   </div>
 
   <div class="form-group">
     <label class="form-label" for="form-control-1-2">
       Input with class form-control-1-2 (50% width - default form-control size)
     </label>
-    <input class="form-control form-control-1-2" id="form-control-1-2" type="text">
+    <input class="form-control form-control-1-2" id="form-control-1-2" type="text" name="form-control-1-2">
   </div>
 
   <div class="form-group">
     <label class="form-label" for="form-label">
       Input with class form-control-2-3 (66% width)
     </label>
-    <input class="form-control form-control-2-3" id="form-control-2-3" type="text">
+    <input class="form-control form-control-2-3" id="form-control-2-3" type="text" name="form-control-2-3">
   </div>
 
   <div class="form-group">
     <label class="form-label" for="form-control-3-4">
       Input with class form-control-3-4 (75% width)
     </label>
-    <input class="form-control form-control-3-4" id="form-control-3-4" type="text">
+    <input class="form-control form-control-3-4" id="form-control-3-4" type="text" name="form-control-3-4">
   </div>
 </div>

--- a/app/views/snippets/form_labels.html
+++ b/app/views/snippets/form_labels.html
@@ -1,2 +1,2 @@
 <label class="form-label" for="full-name-f1">Full name</label>
-<input class="form-control" id="full-name-f1" type="text">
+<input class="form-control" id="full-name-f1" type="text" name="full-name-f1">

--- a/app/views/snippets/form_select_boxes.html
+++ b/app/views/snippets/form_select_boxes.html
@@ -1,6 +1,6 @@
 <div class="form-group">
   <label class="form-label" for="select-box">This is the label text</label>
-  <select class="form-control" id="select-box">
+  <select class="form-control" id="select-box" name="select-box">
     <option>GOV.UK elements option 1</option>
     <option>GOV.UK elements option 2</option>
     <option>GOV.UK elements option 3</option>


### PR DESCRIPTION
Add `name` attributes to form fields in snippets.

#### What problem does the pull request solve?
Makes the snippets more complete for when users are copying and pasting.

This is particularly helpful for users of the prototype kit. It's easier for us to tell users to change the value of the `name` attribute than it is to tell them to add one from scratch.

#### How has this been tested?
Has not been tested

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
I don't think this requires any updates to the documentation.
