### PR TITLE
Corrected numbered list rules

### DIFF
--- a/app/views/examples/example_typography.html
+++ b/app/views/examples/example_typography.html
@@ -42,27 +42,8 @@
         Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.
       </p>
 
-      <ul class="list list-bullet">
-        <li>here is a bulleted list</li>
-        <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
-        <li>vestibulum id ligula porta felis euismod semper</li>
-        <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
-      </ul>
-
-      <ol class="list list-number">
-        <li>here is a numbered list</li>
-        <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
-        <li>vestibulum id ligula porta felis euismod semper</li>
-        <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
-      </ol>
-
-      <ul class="list">
-        <li><a href="#">Related link</a></li>
-        <li><a href="#">Related link</a></li>
-        <li><a href="#">Related link</a></li>
-        <li><a href="#" class="bold-xsmall">More</a></li>
-      </ul>
-
+      {% include "snippets/typography_lists.html" %}
+      
       <p>
         Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.
       </p>

--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -133,9 +133,11 @@
 </pre>
 
   <h3 class="heading-medium" id="typography-lists">Lists</h3>
-  <p class="text">
-    List items start with a lowercase letter and have no full stop at the end.
-  </p>
+  
+  <ul class="list list-bullet text">
+    <li>list items start with a lowercase letter and have no full stop at the end</li> 
+    <li>numbered list items start with an uppercase letter and do have a full stop on the end</li>
+  </ul>
 
 <div class="example">
   {% include "snippets/typography_lists.html" %}

--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -136,7 +136,7 @@
   
   <ul class="list list-bullet text">
     <li>list items start with a lowercase letter and have no full stop at the end</li> 
-    <li>numbered list items start with an uppercase letter and do have a full stop on the end</li>
+    <li>see the style guide to check how to <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#steps">punctuate numbered lists</a></li>
   </ul>
 
 <div class="example">

--- a/app/views/snippets/typography_lists.html
+++ b/app/views/snippets/typography_lists.html
@@ -6,10 +6,9 @@
 </ul>
 
 <ol class="list list-number">
-  <li>here is a numbered list</li>
-  <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
-  <li>vestibulum id ligula porta felis euismod semper</li>
-  <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
+  <li>This is a numbered list.</li>
+  <li>This is the second step in a numbered list.</li>
+  <li>The third step is to make sure each item is a full sentence ending with a full stop.</li>
 </ol>
 
 <ul class="list">


### PR DESCRIPTION
Numbered lists should be written as sentences (start with a capital, end with a full stop).
This is confirmed in https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#numbered-list 
and
http://govspeak-guide.herokuapp.com/#lists-of-steps