### PR TITLE
Windows10 select box contrast ratio in IE and Edge

### DIFF
--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -9,6 +9,7 @@
 // 4. Form hints
 // 5. Form controls
 // 6. Form control widths
+// 7. Browser accessibility fixes
 
 // 1. Helpers
 // ==========================================================================
@@ -222,4 +223,14 @@ textarea.form-control {
   @include media(tablet) {
     width: 12.5%;
   }
+}
+
+// 7. Browser accessibility fixes
+// ==========================================================================
+
+option:active,
+option:checked,
+select:focus::-ms-value {
+  color: $white;
+  background-color: $govuk-blue;
 }


### PR DESCRIPTION
#### What problem does the pull request solve?
Accessibility fix on Windows 10 IE and Edge select box active 
Issue : https://trello.com/c/LGKKreic/461-tech-spike-insufficient-colour-contrast-of-select-box-items

#### How has this been tested?
Tested on IE11 and Edge 15 where the issue existed.
Also tested on latest Chrome. Firefox and Safari to make sure nothing was affected there. 

#### Before:
<img width="548" alt="before" src="https://cloud.githubusercontent.com/assets/3758555/25475909/404a70fc-2b30-11e7-873b-a3d394cfa96c.png">

#### After:
<img width="564" alt="after" src="https://cloud.githubusercontent.com/assets/3758555/25476692/e9161c84-2b32-11e7-8bf3-aa3ef032fb60.png">


#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)


