### PR TITLE
Replace encoded snippets with escape filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 node_modules
 govuk_modules
 lib/govuk_template.html
-# Ignore generated snippets
-app/views/snippets/encoded/*.html
 # Ignore compiled stylesheets
 public/stylesheets/
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,11 +26,6 @@ module.exports = function (grunt) {
       }
     },
 
-    // Empty encoded snippets folder
-    clean: {
-      contents: ['app/views/snippets/encoded/*']
-    },
-
     // Copies templates and assets from external modules and dirs
     copy: {
       assets: {
@@ -62,14 +57,6 @@ module.exports = function (grunt) {
           src: '**',
           dest: 'lib/'
         }]
-      }
-    },
-
-    // Encode HTML snippets
-    htmlentities: {
-      files: {
-        src: ['app/views/snippets/*.html'],
-        dest: 'app/views/snippets/encoded/'
       }
     },
 
@@ -121,19 +108,12 @@ module.exports = function (grunt) {
     'grunt-contrib-watch',
     'grunt-sass',
     'grunt-nodemon',
-    'grunt-concurrent',
-    'grunt-htmlentities'
+    'grunt-concurrent'
   ].forEach(function (task) {
     grunt.loadNpmTasks(task)
   })
 
-  grunt.registerTask('default', ['clean', 'copy', 'encode-snippets', 'sass', 'concurrent:target'])
-
-  // Encode HTML snippets
-  grunt.registerTask('encode-snippets', ['htmlentities', 'encode-snippets-success'])
-  grunt.registerTask('encode-snippets-success', function () {
-    grunt.log.writeln('HTML snippets encoded.'['yellow'].bold)
-  })
+  grunt.registerTask('default', ['copy', 'sass', 'concurrent:target'])
 
   // Tests
   grunt.registerTask('test', ['lint', 'test-default', 'test-success'])
@@ -148,5 +128,5 @@ module.exports = function (grunt) {
   })
 
   // 2. Test that the default grunt task runs the app
-  grunt.registerTask('test-default', ['clean', 'copy', 'encode-snippets', 'sass'])
+  grunt.registerTask('test-default', ['copy', 'sass'])
 }

--- a/app/views/guide_alpha_beta.html
+++ b/app/views/guide_alpha_beta.html
@@ -36,7 +36,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/phase_banner_alpha.html" %}
+  {% filter escape %}
+    {% include "snippets/phase_banner_alpha.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -47,7 +49,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/phase_banner_beta.html" %}
+  {% filter escape %}
+    {% include "snippets/phase_banner_beta.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -63,7 +67,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/phase_tag_alpha.html" %}
+  {% filter escape %}
+    {% include "snippets/phase_tag_alpha.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -74,7 +80,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/phase_tag_beta.html" %}
+  {% filter escape %}
+    {% include "snippets/phase_tag_beta.html" %}
+  {% endfilter %}
 </code>
 </pre>
 

--- a/app/views/guide_buttons.html
+++ b/app/views/guide_buttons.html
@@ -41,7 +41,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/buttons_button.html" %}
+  {% filter escape %}
+    {% include "snippets/buttons_button.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -56,7 +58,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/buttons_button_start_now.html" %}
+  {% filter escape %}
+    {% include "snippets/buttons_button_start_now.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -93,7 +97,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/buttons_button_disabled.html" %}
+  {% filter escape %}
+    {% include "snippets/buttons_button_disabled.html" %}
+  {% endfilter %}
 </code>
 </pre>
 

--- a/app/views/guide_data.html
+++ b/app/views/guide_data.html
@@ -41,7 +41,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/data_table_numeric.html" %}
+  {% filter escape %}
+    {% include "snippets/data_table_numeric.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -56,7 +58,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/data_table.html" %}
+  {% filter escape %}
+    {% include "snippets/data_table.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -85,7 +89,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/data_80px_16px_example.html" %}
+  {% filter escape %}
+    {% include "snippets/data_80px_16px_example.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -102,7 +108,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/data_48px_16px_example.html" %}
+  {% filter escape %}
+    {% include "snippets/data_48px_16px_example.html" %}
+  {% endfilter %}
 </code>
 </pre>
 

--- a/app/views/guide_errors.html
+++ b/app/views/guide_errors.html
@@ -60,7 +60,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_error_radio_show_errors.html" %}
+  {% filter escape %}
+    {% include "snippets/form_error_radio_show_errors.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -94,7 +96,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_error_multiple_show_errors.html" %}
+  {% filter escape %}
+    {% include "snippets/form_error_multiple_show_errors.html" %}
+  {% endfilter %}
 </code>
 </pre>
 

--- a/app/views/guide_form_elements.html
+++ b/app/views/guide_form_elements.html
@@ -61,7 +61,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_labels.html" %}
+  {% filter escape %}
+    {% include "snippets/form_labels.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -112,7 +114,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_hint_text.html" %}
+  {% filter escape %}
+    {% include "snippets/form_hint_text.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -127,7 +131,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_spacing.html" %}
+  {% filter escape %}
+    {% include "snippets/form_spacing.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -140,7 +146,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_file_upload.html" %}
+  {% filter escape %}
+    {% include "snippets/form_file_upload.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -178,7 +186,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_select_boxes.html" %}
+  {% filter escape %}
+    {% include "snippets/form_select_boxes.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -202,7 +212,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_radio_buttons_inline.html" %}
+  {% filter escape %}
+    {% include "snippets/form_radio_buttons_inline.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -213,7 +225,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_radio_buttons.html" %}
+  {% filter escape %}
+    {% include "snippets/form_radio_buttons.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -230,7 +244,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_checkboxes.html" %}
+  {% filter escape %}
+    {% include "snippets/form_checkboxes.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -246,7 +262,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_checkbox.html" %}
+  {% filter escape %}
+    {% include "snippets/form_checkbox.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -277,7 +295,9 @@
 
   <pre>
   <code class="language-markup">
-    {% include "snippets/encoded/form_inset_radios.html" %}
+    {% filter escape %}
+      {% include "snippets/form_inset_radios.html" %}
+    {% endfilter %}
   </code>
   </pre>
 
@@ -297,7 +317,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_inset_panel.html" %}
+  {% filter escape %}
+    {% include "snippets/form_inset_panel.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -319,7 +341,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/form_inset_checkboxes.html" %}
+  {% filter escape %}
+    {% include "snippets/form_inset_checkboxes.html" %}
+  {% endfilter %}
 </code>
 </pre>
 

--- a/app/views/guide_icons_images.html
+++ b/app/views/guide_icons_images.html
@@ -55,7 +55,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/typography_legal_text.html" %}
+  {% filter escape %}
+    {% include "snippets/typography_legal_text.html" %}
+  {% endfilter %}
 </code>
 </pre>
 

--- a/app/views/guide_layout.html
+++ b/app/views/guide_layout.html
@@ -78,7 +78,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/layout_grid_full.html" %}
+  {% filter escape %}
+    {% include "snippets/layout_grid_full.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -89,7 +91,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/layout_grid_halves.html" %}
+  {% filter escape %}
+    {% include "snippets/layout_grid_halves.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -100,7 +104,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/layout_grid_thirds.html" %}
+  {% filter escape %}
+    {% include "snippets/layout_grid_thirds.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -111,7 +117,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/layout_grid_thirds_two_thirds_one_third.html" %}
+  {% filter escape %}
+    {% include "snippets/layout_grid_thirds_two_thirds_one_third.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -122,7 +130,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/layout_grid_thirds_one_third_two_thirds.html" %}
+  {% filter escape %}
+    {% include "snippets/layout_grid_thirds_one_third_two_thirds.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -133,7 +143,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/layout_grid_quarters.html" %}
+  {% filter escape %}
+    {% include "snippets/layout_grid_quarters.html" %}
+  {% endfilter %}
 </code>
 </pre>
 

--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -63,7 +63,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/typography_headings.html" %}
+  {% filter escape %}
+    {% include "snippets/typography_headings.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -84,7 +86,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/typography_lead_paragraph.html" %}
+  {% filter escape %}
+    {% include "snippets/typography_lead_paragraph.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -108,7 +112,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/typography_paragraphs.html" %}
+  {% filter escape %}
+    {% include "snippets/typography_paragraphs.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -128,14 +134,16 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/typography_links.html" %}
+  {% filter escape %}
+    {% include "snippets/typography_links.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
   <h3 class="heading-medium" id="typography-lists">Lists</h3>
-  
+
   <ul class="list list-bullet text">
-    <li>list items start with a lowercase letter and have no full stop at the end</li> 
+    <li>list items start with a lowercase letter and have no full stop at the end</li>
     <li>see the style guide to check how to <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#steps">punctuate numbered lists</a></li>
   </ul>
 
@@ -145,7 +153,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/typography_lists.html" %}
+  {% filter escape %}
+    {% include "snippets/typography_lists.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -162,7 +172,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/typography_inset_text.html" %}
+  {% filter escape %}
+    {% include "snippets/typography_inset_text.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -179,7 +191,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/typography_legal_text.html" %}
+  {% filter escape %}
+    {% include "snippets/typography_legal_text.html" %}
+  {% endfilter %}
 </code>
 </pre>
 
@@ -198,7 +212,9 @@
 
 <pre>
 <code class="language-markup">
-  {% include "snippets/encoded/typography_progressive_disclosure.html" %}
+  {% filter escape %}
+    {% include "snippets/typography_progressive_disclosure.html" %}
+  {% endfilter %}
 </code>
 </pre>
 


### PR DESCRIPTION
This PR removes the Grunt tasks to encode the HTML snippets, updates the paths to each of the snippets and wraps each code example snippet in an escape filter. 

This ensures the HTML inside a code example is escaped when the
snippet is rendered, so when JavaScript is disabled, the code snippets
remain visible.

Originally suggested by @selfthinker in #453, this fixes #453. To clarify, the snippets folder is 
still necessary, but not the `snippets/encoded` folder.

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
- I have read the **CONTRIBUTING** document.
