### PR TITLE
Remove `aria-describedby` from erroring form fields and hint text

### DIFF
--- a/app/views/examples/example_date.html
+++ b/app/views/examples/example_date.html
@@ -24,13 +24,13 @@
         <fieldset>
           <legend>
             <span class="form-label-bold">Date of birth</span>
-            <span class="form-hint" id="example-dob-hint-1">For example, 31 3 1980</span>
+            <span class="form-hint">For example, 31 3 1980</span>
             <span class="error-message">Error message goes here</span>
           </legend>
           <div class="form-date">
             <div class="form-group form-group-day">
               <label class="form-label" for="example-dob-day-1">Day</label>
-              <input class="form-control form-control-error" id="example-dob-day-1" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint-1">
+              <input class="form-control form-control-error" id="example-dob-day-1" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
             </div>
             <div class="form-group form-group-month">
               <label class="form-label" for="example-dob-month-1">Month</label>
@@ -49,13 +49,13 @@
         <fieldset>
           <legend>
             <span class="form-label-bold">Date of birth</span>
-            <span class="form-hint" id="example-dob-hint-2">For example, 31 3 1980</span>
+            <span class="form-hint">For example, 31 3 1980</span>
             <span class="error-message">Error message goes here</span>
           </legend>
           <div class="form-date">
             <div class="form-group form-group-day">
               <label class="form-label" for="example-dob-day-2">Day</label>
-              <input class="form-control" id="example-dob-day-2" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint-2">
+              <input class="form-control" id="example-dob-day-2" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
             </div>
             <div class="form-group form-group-month">
               <label class="form-label" for="example-dob-month-2">Month</label>
@@ -74,13 +74,13 @@
         <fieldset>
           <legend>
             <span class="form-label-bold">Date of birth</span>
-            <span class="form-hint" id="example-dob-hint-3">For example, 31 3 1980</span>
+            <span class="form-hint">For example, 31 3 1980</span>
             <span class="error-message">Error message goes here</span>
           </legend>
           <div class="form-date">
             <div class="form-group form-group-day">
               <label class="form-label" for="example-dob-day-3">Day</label>
-              <input class="form-control" id="example-dob-day-3" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint-3">
+              <input class="form-control" id="example-dob-day-3" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
             </div>
             <div class="form-group form-group-month">
               <label class="form-label" for="example-dob-month-3">Month</label>

--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -98,12 +98,12 @@
             <fieldset>
               <legend>
                 <span class="form-label-bold">This is the label text in bold</span>
-                <span class="form-hint" id="dob-hint">This is hint text</span>
+                <span class="form-hint">This is hint text</span>
               </legend>
               <div class="form-date">
                 <div class="form-group form-group-day">
                   <label class="form-label" for="dob-day">Day</label>
-                  <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="dob-hint">
+                  <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
                 </div>
                 <div class="form-group form-group-month">
                   <label class="form-label" for="dob-month">Month</label>
@@ -178,13 +178,13 @@
             <fieldset>
               <legend>
                 <span class="form-label-bold">Date of birth</span>
-                <span class="form-hint" id="example-dob-hint-1">For example, 31 3 1980</span>
+                <span class="form-hint">For example, 31 3 1980</span>
                 <span class="error-message">Error message goes here</span>
               </legend>
               <div class="form-date">
                 <div class="form-group form-group-day">
                   <label class="form-label" for="example-dob-day-1">Day</label>
-                  <input class="form-control form-control-error" id="example-dob-day-1" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint-1">
+                  <input class="form-control form-control-error" id="example-dob-day-1" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
                 </div>
                 <div class="form-group form-group-month">
                   <label class="form-label" for="example-dob-month-1">Month</label>
@@ -203,13 +203,13 @@
             <fieldset>
               <legend>
                 <span class="form-label-bold">Date of birth</span>
-                <span class="form-hint" id="example-dob-hint-2">For example, 31 3 1980</span>
+                <span class="form-hint">For example, 31 3 1980</span>
                 <span class="error-message">Error message goes here</span>
               </legend>
               <div class="form-date">
                 <div class="form-group form-group-day">
                   <label class="form-label" for="example-dob-day-2">Day</label>
-                  <input class="form-control" id="example-dob-day-2" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint-2">
+                  <input class="form-control" id="example-dob-day-2" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
                 </div>
                 <div class="form-group form-group-month">
                   <label class="form-label" for="example-dob-month-2">Month</label>
@@ -228,13 +228,13 @@
             <fieldset>
               <legend>
                 <span class="form-label-bold">Date of birth</span>
-                <span class="form-hint" id="example-dob-hint-3">For example, 31 3 1980</span>
+                <span class="form-hint">For example, 31 3 1980</span>
                 <span class="error-message">Error message goes here</span>
               </legend>
               <div class="form-date">
                 <div class="form-group form-group-day">
                   <label class="form-label" for="example-dob-day-3">Day</label>
-                  <input class="form-control" id="example-dob-day-3" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="example-dob-hint-3">
+                  <input class="form-control" id="example-dob-day-3" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
                 </div>
                 <div class="form-group form-group-month">
                   <label class="form-label" for="example-dob-month-3">Month</label>

--- a/app/views/examples/example_form_validation_multiple_questions.html
+++ b/app/views/examples/example_form_validation_multiple_questions.html
@@ -51,10 +51,7 @@
           show an error message before each field with an error
         </li>
         <li>
-          associate each error message with the corresponding field
-          <span class="panel panel-border-narrow">
-             add an ID to each error message and associate this with the field using <code>aria-describedby</code>
-          </span>
+          associate each error message with the corresponding field by adding it to the label (or legend)
         </li>
       </ul>
 

--- a/app/views/examples/example_form_validation_single_question_radio.html
+++ b/app/views/examples/example_form_validation_single_question_radio.html
@@ -57,10 +57,7 @@
           show an error message before each field with an error
         </li>
         <li>
-          associate each error message with the corresponding field
-          <span class="panel panel-border-narrow">
-             add an ID to each error message and associate this with the field using <code>aria-describedby</code>
-          </span>
+          associate each error message with the corresponding field by adding it to the label (or legend)
         </li>
       </ul>
 

--- a/app/views/snippets/form_date.html
+++ b/app/views/snippets/form_date.html
@@ -5,12 +5,12 @@
         <span class="form-label-bold">
           What is your date of birth?
         </span>
-        <span class="form-hint" id="dob-hint">For example, 31 3 1980</span>
+        <span class="form-hint">For example, 31 3 1980</span>
       </legend>
       <div class="form-date">
         <div class="form-group form-group-day">
           <label class="form-label" for="dob-day">Day</label>
-          <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="dob-hint">
+          <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
         </div>
         <div class="form-group form-group-month">
           <label class="form-label" for="dob-month">Month</label>

--- a/app/views/snippets/form_date_show_errors.html
+++ b/app/views/snippets/form_date_show_errors.html
@@ -5,13 +5,13 @@
         <span class="form-label-bold">
           What is your date of birth?
         </span>
-        <span class="form-hint" id="dob-hint-example">For example, 31 3 1980</span>
+        <span class="form-hint">For example, 31 3 1980</span>
         <span class="error-message">Error message goes here</span>
       </legend>
       <div class="form-date">
         <div class="form-group form-group-day">
           <label class="form-label" for="dob-day-example">Day</label>
-          <input class="form-control form-control-error" id="dob-day-example" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="dob-hint-example">
+          <input class="form-control form-control-error" id="dob-day-example" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
         </div>
         <div class="form-group form-group-month">
           <label class="form-label" for="dob-month-example">Month</label>

--- a/app/views/snippets/form_error_multiple.html
+++ b/app/views/snippets/form_error_multiple.html
@@ -33,13 +33,13 @@
     <span class="form-hint">As shown on your birth certificate or passport</span>
     {% if error %}
       {% if not fullName %}
-      <span class="error-message" id="error-message-full-name">Error message about full name goes here</span>
+      <span class="error-message">Error message about full name goes here</span>
       {% endif %}
     {% endif %}
 
   </label>
 
-  <input class="form-control {% if error %}{% if not fullName %} form-control-error{% endif %}{% endif %}" id="example-full-name" type="text" name="fullName" value="{{fullName}}" {% if error %}{% if not fullName %} aria-describedby="error-message-full-name"{% endif %}{% endif %}>
+  <input class="form-control {% if error %}{% if not fullName %} form-control-error{% endif %}{% endif %}" id="example-full-name" type="text" name="fullName" value="{{fullName}}">
 </div>
 
 <div class="form-group {% if error %}{% if not niNo %} form-group-error{% endif %}{% endif %}">
@@ -54,14 +54,14 @@
     </span>
     {% if error %}
       {% if not niNo %}
-      <span class="error-message" id="error-message-ni-number">
+      <span class="error-message">
         Error message about National Insurance number goes here
       </span>
       {% endif %}
     {% endif %}
   </label>
 
-  <input class="form-control {% if error %}{% if not niNo %} form-control-error{% endif %}{% endif %}" id="example-ni-number" type="text" name="niNo" value="{{niNo}}" {% if error %}{% if not niNo %} aria-describedby="error-message-ni-number"{% endif %}{% endif %}>
+  <input class="form-control {% if error %}{% if not niNo %} form-control-error{% endif %}{% endif %}" id="example-ni-number" type="text" name="niNo" value="{{niNo}}">
 
 </div>
 

--- a/app/views/snippets/form_error_multiple_show_errors.html
+++ b/app/views/snippets/form_error_multiple_show_errors.html
@@ -25,11 +25,11 @@
 
     <span class="form-label-bold">Full name</span>
     <span class="form-hint">As shown on your birth certificate or passport</span>
-    <span class="error-message" id="error-message-full-name">Error message about full name goes here</span>
+    <span class="error-message">Error message about full name goes here</span>
 
   </label>
 
-  <input class="form-control form-control-error" id="example-full-name" type="text" name="fullName" value="" aria-describedby="error-message-full-name">
+  <input class="form-control form-control-error" id="example-full-name" type="text" name="fullName" value="">
 </div>
 
 <div class="form-group form-group-error">
@@ -42,13 +42,13 @@
       <br>
       For example, ‘QQ 12 34 56 C’.
     </span>
-    <span class="error-message" id="error-message-ni-number">
+    <span class="error-message">
       Error message about National Insurance number goes here
     </span>
 
   </label>
 
-  <input class="form-control form-control-error" id="example-ni-number" type="text" name="niNo" value="" aria-describedby="error-message-ni-number">
+  <input class="form-control form-control-error" id="example-ni-number" type="text" name="niNo" value="">
 
 </div>
 


### PR DESCRIPTION
The `aria-describedby` attribute was added before we moved the error message or hint text for a field into its label (or legend in case of radio/checkboxes) in 87449f013521d09ca2b51df113f4c85c85ec36d8.

Now that it's also in the label/legend, it gets read out multiple times to screen readers. Therefore it is not necessary anymore and should be removed.

<!--- Provide a summary of your changes in the Title above -->

#### What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The error message and/or hint text is read out twice to screen readers. Example pages where that happens:
* http://govuk-elements.herokuapp.com/errors/example-form-validation-multiple-questions
* http://govuk-elements.herokuapp.com/form-elements/example-date/

#### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested with JAWS in IE 11, NVDA in Firefox and VoiceOver in Safari.
They all behave the same when tabbing to the input field. Before they were reading the additional text twice and with this change only once. When using the down arrow key, only JAWS read the additional text twice, the others didn't.

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
<!--- Delete the lines below that don't apply -->
- I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
