### PR TITLE
Bump govuk_frontend_toolkit to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "body-parser": "^1.14.1",
     "del": "^2.2.2",
     "express": "^4.15.2",
-    "govuk_frontend_toolkit": "^5.2.0",
+    "govuk_frontend_toolkit": "^6.0.2",
     "govuk_template_jinja": "0.19.2",
     "gulp": "^3.9.1",
     "gulp-cssnano": "^2.1.2",


### PR DESCRIPTION
# 6.0.2

- Increase button focus specificity to avoid being overridden by
govuk_template

# 6.0.1

- Fix a Javascript error in IE7 caused by trying to access a character
within a string using array notation

# 6.0.0

- Breaking change: configure the GOV.UK Analytics tracker with
`govukTrackerUrl` instead of `govukTrackerGifUrl`
- Fix the sending of the GA Client ID with calls to the GOV.UK Tracker
- Disable GA ad tracking
