### PR TITLE
Add a textarea example to the form elements page

### DIFF
--- a/app/views/guide_form_elements.html
+++ b/app/views/guide_form_elements.html
@@ -24,6 +24,7 @@
         <li><a href="#form-optional-fields">Optional and mandatory fields</a></li>
         <li><a href="#form-labels">Labels</a></li>
         <li><a href="#form-fields">Form fields</a></li>
+        <li><a href="#form-textarea">Textarea</a></li>
         <li><a href="#form-focus-states">Form focus states</a></li>
         <li><a href="#form-hint-text">Hint text</a></li>
         <li><a href="#form-spacing">Spacing</a></li>
@@ -85,6 +86,25 @@
       Discuss form fields on the design patterns Hackpad
     </a>
   </p>
+
+  <h3 class="heading-medium" id="form-textarea">Textarea</h3>
+  <div class="text">
+    <p>
+      Make the height of a textarea proportional to the amount of text to be entered.
+    </p>
+  </div>
+
+  <div class="example">
+    {% include "snippets/form_textarea.html" %}
+  </div>
+
+<pre>
+<code class="language-markup">
+  {% filter escape %}
+    {% include "snippets/form_textarea.html" %}
+  {% endfilter %}
+</code>
+</pre>
 
   <h3 class="heading-medium" id="form-focus-states">Form focus states</h3>
   <div class="text">

--- a/app/views/snippets/form_textarea.html
+++ b/app/views/snippets/form_textarea.html
@@ -1,4 +1,4 @@
 <label class="form-label" for="textarea">
-  This is the label text
+  Why can't you provide a National Insurance number?
 </label>
 <textarea class="form-control" name="textarea" id="textarea"></textarea>

--- a/app/views/snippets/form_textarea.html
+++ b/app/views/snippets/form_textarea.html
@@ -1,4 +1,4 @@
 <label class="form-label" for="textarea">
   Why can't you provide a National Insurance number?
 </label>
-<textarea class="form-control" name="textarea" id="textarea"></textarea>
+<textarea class="form-control form-control-3-4" name="textarea" id="textarea" rows="5"></textarea>

--- a/app/views/snippets/form_textarea.html
+++ b/app/views/snippets/form_textarea.html
@@ -1,0 +1,4 @@
+<label class="form-label" for="textarea">
+  This is the label text
+</label>
+<textarea class="form-control" name="textarea" id="textarea"></textarea>

--- a/assets/sass/elements/_forms.scss
+++ b/assets/sass/elements/_forms.scss
@@ -163,10 +163,15 @@ textarea {
 // scss-lint:disable QualifyingElement
 input.form-control,
 textarea.form-control {
-  // Remove inner shadow
+  // Disable inner shadow and remove rounded corners
   -webkit-appearance: none;
-  // Remove rounded corners
   border-radius: 0;
+}
+
+textarea.form-control {
+  // Disable opacity and background image for Firefox
+  opacity: 1;
+  background-image: none;
 }
 // scss-lint:enable QualifyingElement
 


### PR DESCRIPTION
Move the textarea snippet from the form example page into its own snippet. 
Show this example on the form elements page. 

#### What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #458.

#### Screenshot:

![form elements gov uk elements](https://cloud.githubusercontent.com/assets/417754/26414508/4c7a3f6a-40a7-11e7-9d31-6af549bc084c.png)

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
<!--- Delete the lines below that don't apply -->
- My change requires a change to the documentation.
- I have updated the documentation accordingly.