### PR TITLE
Fix table semantics

### DIFF
--- a/app/views/snippets/data_table.html
+++ b/app/views/snippets/data_table.html
@@ -1,9 +1,5 @@
 <table>
-  <thead>
-    <tr>
-      <th colspan="2">Dates and amounts</th>
-    </tr>
-  </thead>
+  <caption class="heading-small">Dates and amounts</caption>
   <tbody>
     <tr>
       <td>First 6 weeks</td>
@@ -14,7 +10,7 @@
       <td>£109.80 per week</td>
     </tr>
     <tr>
-     <td>Total estimated pay</td>
+      <td>Total estimated pay</td>
       <td>£4,282.20</td>
     </tr>
     <tr>

--- a/app/views/snippets/data_table_numeric.html
+++ b/app/views/snippets/data_table_numeric.html
@@ -1,26 +1,31 @@
 <table>
   <thead>
     <tr>
-      <th scope="col">Date</th>
-      <th class="numeric" scope="col">Paper form</th>
-      <th class="numeric" scope="col">Digital</th>
+      <th scope="col">Month you apply</th>
+      <th class="numeric" scope="col">Rate for vehicles</th>
+      <th class="numeric" scope="col">Rate for bicycles</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>25 November to 1 December 2013</td>
-      <td class="numeric">2,763</td>
-      <td class="numeric">1,792</td>
+      <th scope="row">January</th>
+      <td class="numeric">£165.00</td>
+      <td class="numeric">£85.00</td>
     </tr>
     <tr>
-      <td>2 to 8 December 2013</td>
-      <td class="numeric">2,850</td>
-      <td class="numeric">1,740</td>
+      <th scope="row">February</th>
+      <td class="numeric">£165.00</td>
+      <td class="numeric">£85.00</td>
     </tr>
     <tr>
-     <td>9 to 15 December 2013</td>
-      <td class="numeric">2,388</td>
-      <td class="numeric">1,683</td>
+      <th scope="row">March</th>
+      <td class="numeric">£151.25</td>
+      <td class="numeric">£77.90</td>
+    </tr>
+    <tr>
+      <th scope="row">April</th>
+      <td class="numeric">£136.10</td>
+      <td class="numeric">£70.10</td>
     </tr>
   </tbody>
 </table>

--- a/assets/sass/elements/_tables.scss
+++ b/assets/sass/elements/_tables.scss
@@ -30,6 +30,10 @@ table {
   td.numeric {
     font-family: $toolkit-font-stack-tabular;
   }
+
+  caption {
+    text-align: left;
+  }
 }
 
 .table-font-xsmall {


### PR DESCRIPTION
The table examples on http://govuk-elements.herokuapp.com/data/ have some semantic and therefore accessibility issues.

## What problem does the pull request solve?

1. The "numeric tabular data" table should have the first column marked up as row headings (`th`). When I tried that, it didn't look right because there was too much bold. Adding more styling to remove that depending on types of tables would open a whole new can of worms, so I opted to change the content of the table instead. That should also make the table clearer out of context. (The data for that table was taken from https://www.gov.uk/vehicle-tax-rate-tables/other-vehicle-tax-rates)
2. The "data in a table" table uses `thead` wrongly. I moved that into a `caption` instead. And as we didn't have any styling for captions yet, I've added that as well. Hopefully this will also make it easier for services to use captions. (I noticed the vast majority of tables on gov.uk don't have any.)

I wasn't sure if to style `caption` directly or give it a class `.table-caption` as tables are one of the few elements within Elements which are styled globally. I'm happy to change to a class instead.

## How has this been tested?

I have mostly tested the caption styling in various browsers via BrowserStack. All was fine except some older browsers showed double the spacing: Android 4 (but 4.4 was fine) and iOS 4 and 5. As we're not officially supporting those anymore and the styling on them is not really bad, I'd suggest to just ignore those issue.

## Screenshots

### Numeric tabular data - before
<img width="714" alt="numeric-tabular-data-before" src="https://cloud.githubusercontent.com/assets/108893/26646434/7d6e9a9e-4633-11e7-89ce-89396ca48cbe.png">

### Numeric tabular data - after
<img width="681" alt="numeric-tabular-data-after" src="https://cloud.githubusercontent.com/assets/108893/26727287/31fc475c-479e-11e7-81ca-20e677b77e0d.png">

### Data in a table - before
<img width="712" alt="data-in-a-table-before" src="https://cloud.githubusercontent.com/assets/108893/26646433/7d6cefe6-4633-11e7-8284-a637b1a37bbc.png">

### Data in a table - after
<img width="687" alt="data-in-a-table-after" src="https://cloud.githubusercontent.com/assets/108893/26727302/419992dc-479e-11e7-8457-70532cd820fd.png">

## What type of change is it?
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
