### PR TITLE
Constrain width of validation summary boxes to 2/3

### DIFF
--- a/app/views/snippets/form_error_multiple_show_errors.html
+++ b/app/views/snippets/form_error_multiple_show_errors.html
@@ -1,55 +1,61 @@
-<div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-2" tabindex="-1">
+<div class="grid-row">
+  <div class="column-two-thirds">
 
-  <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-2">
-    Message to alert the user to a problem goes here
-  </h1>
+    <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-2" tabindex="-1">
 
-  <p>
-    Optional description of the errors and how to correct them
-  </p>
+      <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-2">
+        Message to alert the user to a problem goes here
+      </h1>
 
-  <ul class="error-summary-list">
-    <li><a href="#example-full-name">Descriptive link to the question with an error</a></li>
-    <li><a href="#example-ni-number">Descriptive link to the question with an error</a></li>
-  </ul>
+      <p>
+        Optional description of the errors and how to correct them
+      </p>
 
+      <ul class="error-summary-list">
+        <li><a href="#example-full-name">Descriptive link to the question with an error</a></li>
+        <li><a href="#example-ni-number">Descriptive link to the question with an error</a></li>
+      </ul>
+
+    </div>
+
+    <h1 class="heading-large">
+      Your personal details
+    </h1>
+
+    <div class="form-group form-group-error">
+
+      <label for="example-full-name" id="error-full-name">
+
+        <span class="form-label-bold">Full name</span>
+        <span class="form-hint">As shown on your birth certificate or passport</span>
+        <span class="error-message">Error message about full name goes here</span>
+
+      </label>
+
+      <input class="form-control form-control-error" id="example-full-name" type="text" name="fullName" value="">
+    </div>
+
+    <div class="form-group form-group-error">
+
+      <label for="example-ni-number" id="error-ni-number">
+
+        <span class="form-label-bold">National Insurance number</span>
+        <span class="form-hint">
+          It’s on your National Insurance card, benefit letter, payslip or P60.
+          <br>
+          For example, ‘QQ 12 34 56 C’.
+        </span>
+        <span class="error-message">
+          Error message about National Insurance number goes here
+        </span>
+
+      </label>
+
+      <input class="form-control form-control-error" id="example-ni-number" type="text" name="niNo" value="">
+
+    </div>
+
+    <input class="button" type="submit" value="Continue">
+
+  </div>
 </div>
-
-<h1 class="heading-large">
-  Your personal details
-</h1>
-
-<div class="form-group form-group-error">
-
-  <label for="example-full-name" id="error-full-name">
-
-    <span class="form-label-bold">Full name</span>
-    <span class="form-hint">As shown on your birth certificate or passport</span>
-    <span class="error-message">Error message about full name goes here</span>
-
-  </label>
-
-  <input class="form-control form-control-error" id="example-full-name" type="text" name="fullName" value="">
-</div>
-
-<div class="form-group form-group-error">
-
-  <label for="example-ni-number" id="error-ni-number">
-
-    <span class="form-label-bold">National Insurance number</span>
-    <span class="form-hint">
-      It’s on your National Insurance card, benefit letter, payslip or P60.
-      <br>
-      For example, ‘QQ 12 34 56 C’.
-    </span>
-    <span class="error-message">
-      Error message about National Insurance number goes here
-    </span>
-
-  </label>
-
-  <input class="form-control form-control-error" id="example-ni-number" type="text" name="niNo" value="">
-
-</div>
-
-<input class="button" type="submit" value="Continue">

--- a/app/views/snippets/form_error_radio_show_errors.html
+++ b/app/views/snippets/form_error_radio_show_errors.html
@@ -1,55 +1,61 @@
-<div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+<div class="grid-row">
+  <div class="column-two-thirds">
 
-  <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
-    Message to alert the user to a problem goes here
-  </h1>
+    <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
 
-  <p>
-    Optional description of the errors and how to correct them
-  </p>
+      <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        Message to alert the user to a problem goes here
+      </h1>
 
-  <ul class="error-summary-list">
-    <li><a href="#example-personal-details">Descriptive link to the question with an error</a></li>
-  </ul>
+      <p>
+        Optional description of the errors and how to correct them
+      </p>
 
-</div>
+      <ul class="error-summary-list">
+        <li><a href="#example-personal-details">Descriptive link to the question with an error</a></li>
+      </ul>
 
-<h1 class="heading-large">
-  Check your personal details
-</h1>
+    </div>
 
-<p>
-  Look at your name, signature and other details.
-</p>
+    <h1 class="heading-large">
+      Check your personal details
+    </h1>
 
-<form>
-  <div class="form-group form-group-error">
-    <fieldset>
+    <p>
+      Look at your name, signature and other details.
+    </p>
 
-      <legend id="example-personal-details">
+    <form>
+      <div class="form-group form-group-error">
+        <fieldset>
 
-        <span class="form-label-bold">
-          Are your personal details correct and up-to-date?
-        </span>
-        <span class="error-message">
-          Error message about personal details goes here
-        </span>
+          <legend id="example-personal-details">
 
-      </legend>
+            <span class="form-label-bold">
+              Are your personal details correct and up-to-date?
+            </span>
+            <span class="error-message">
+              Error message about personal details goes here
+            </span>
 
-      <div class="multiple-choice">
-        <input id="personal_details_yes" type="radio" name="personalDetails" value="Yes">
-        <label for="personal_details_yes">Yes, my personal details are correct</label>
+          </legend>
+
+          <div class="multiple-choice">
+            <input id="personal_details_yes" type="radio" name="personalDetails" value="Yes">
+            <label for="personal_details_yes">Yes, my personal details are correct</label>
+          </div>
+
+          <div class="multiple-choice">
+            <input id="personal_details_no" type="radio" name="personalDetails" value="No">
+            <label for="personal_details_no">No, some details are wrong or have changed</label>
+          </div>
+
+        </fieldset>
       </div>
 
-      <div class="multiple-choice">
-        <input id="personal_details_no" type="radio" name="personalDetails" value="No">
-        <label for="personal_details_no">No, some details are wrong or have changed</label>
-      </div>
+      <input class="button" type="submit" value="Continue">
 
-    </fieldset>
+    </form>
+
   </div>
-
-  <input class="button" type="submit" value="Continue">
-
-</form>
+</div>


### PR DESCRIPTION
#### What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add grid and column wrappers to constrain summary boxes. These are now
2/3 of the width of the page.

Fixes #356.

#### Screenshots

#### Before:

![before - errors and validation gov uk elements](https://cloud.githubusercontent.com/assets/417754/26677521/455fd33e-46c4-11e7-83a8-e320c8ecdf4d.png)

#### After:

![after - errors and validation gov uk elements](https://cloud.githubusercontent.com/assets/417754/26677524/48faea24-46c4-11e7-8094-6dd616d49a64.png)

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
- Bug fix (non-breaking change which fixes an issue)