### PR TITLE
Move breadcrumb outside the main element

### DIFF
--- a/app/views/guide_alpha_beta.html
+++ b/app/views/guide_alpha_beta.html
@@ -2,11 +2,9 @@
 
 {% block page_title %}Alpha and beta banners — GOV.UK elements{% endblock %}
 
-{% block content %}
+{% block main_content %}
 
 <main id="content" role="main" tabindex="-1">
-
-  {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_buttons.html
+++ b/app/views/guide_buttons.html
@@ -2,11 +2,9 @@
 
 {% block page_title %}Buttons — GOV.UK elements{% endblock %}
 
-{% block content %}
+{% block main_content %}
 
 <main id="content" role="main" tabindex="-1">
-
-  {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_colour.html
+++ b/app/views/guide_colour.html
@@ -2,11 +2,9 @@
 
 {% block page_title %}Colour — GOV.UK elements{% endblock %}
 
-{% block content %}
+{% block main_content %}
 
 <main id="content" role="main" tabindex="-1">
-
-  {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_data.html
+++ b/app/views/guide_data.html
@@ -2,11 +2,9 @@
 
 {% block page_title %}Data — GOV.UK elements{% endblock %}
 
-{% block content %}
+{% block main_content %}
 
 <main id="content" role="main" tabindex="-1">
-
-  {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_errors.html
+++ b/app/views/guide_errors.html
@@ -2,11 +2,9 @@
 
 {% block page_title %}Errors and validation — GOV.UK elements{% endblock %}
 
-{% block content %}
+{% block main_content %}
 
 <main id="content" role="main" tabindex="-1">
-
-  {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_form_elements.html
+++ b/app/views/guide_form_elements.html
@@ -2,11 +2,9 @@
 
 {% block page_title %}Form elements — GOV.UK elements{% endblock %}
 
-{% block content %}
+{% block main_content %}
 
 <main id="content" role="main" tabindex="-1">
-
-  {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_icons_images.html
+++ b/app/views/guide_icons_images.html
@@ -2,11 +2,9 @@
 
 {% block page_title %}Icons and images — GOV.UK elements{% endblock %}
 
-{% block content %}
+{% block main_content %}
 
 <main id="content" role="main" tabindex="-1">
-
-  {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_layout.html
+++ b/app/views/guide_layout.html
@@ -2,11 +2,9 @@
 
 {% block page_title %}Layout — GOV.UK elements{% endblock %}
 
-{% block content %}
+{% block main_content %}
 
 <main id="content" role="main" tabindex="-1">
-
-  {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -2,11 +2,9 @@
 
 {% block page_title %}Typography — GOV.UK elements{% endblock %}
 
-{% block content %}
+{% block main_content %}
 
 <main id="content" role="main" tabindex="-1">
-
-  {% include "includes/breadcrumb.html" %}
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -4,11 +4,8 @@
   GOV.UK elements
 {% endblock %}
 
-{% block content %}
-
+{% block main_content %}
 <main class="elements-index" id="content" role="main" tabindex="-1">
-
-  {% include "includes/breadcrumb.html" %}
 
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -10,6 +10,13 @@
   {% include "includes/elements_tracking.html" %}
 {% endblock %}
 
+{% block content %}
+<div class="site-wrapper">
+  {% include "includes/breadcrumb.html" %}
+  {% block main_content %}{% endblock %}
+</div>
+{% endblock %}
+
 {% block cookie_message %}
   <p>{{cookieText | safe }}</p>
 {% endblock %}

--- a/assets/sass/elements-documentation.scss
+++ b/assets/sass/elements-documentation.scss
@@ -16,9 +16,21 @@
 
 // ==========================================================================
 // Elements page styles
+// These are example styles, used only for the elements pages
 // ==========================================================================
 
-// These are example styles, used only for the elements pages
+// Add a class to wrap the <main> element
+// This is so the breadcrumb can sit outside <main>
+.site-wrapper {
+  @extend %site-width-container;
+
+  // Override margins set on #content
+  // This is a kludge to prevent a breaking change to govuk_elements_sass
+  // where @extend %site-width-container; is set for #content, so we need to override its margins
+  #content {
+    margin: 0;
+  }
+}
 
 .elements-index {
   // Reduce top and bottom margins


### PR DESCRIPTION
#### What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This allows users to skip directly to the page content, avoiding the repetition of the breadcrumb on each page.

The `<main>` tag is wrapped with a containing div `site-wrapper`, to establish a central column.
The breadcrumb is a child of the site-wrapper container. 

The `<main>` element starts after the breadcrumb. 

GOV.UK currently has the breadcrumb inside the `<main>` element, ideally, the two should be consistent.

Fixes #343.

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
<!--- Delete the lines below that don't apply -->
- I have read the **CONTRIBUTING** document.
