### PR TITLE
Use govuk_elements as a Node.js dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ GOV.UK elements uses [standardjs](http://standardjs.com/), an opinionated JavaSc
 Both linters run on CI to ensure that new pull requests are in line with them.
 
 
+## Add govuk_elements to your project
+
+### Install with NPM
+From the command line, run the following to include elements as a dependency in your project:
+```bash
+npm install --save alphagov/govuk_elements
+```
+
+### Require the code
+Code can be required in the standard way (even on the client if using `browserify`):
+```javascript
+// polyfill `details` elements on older browsers
+require('govuk-elements/assets/javascripts/govuk/details.polyfill');
+```
+
+
 ## Running Wraith to compare changes
 
 GOV.UK elements uses Wraith so that regressions can be easily spotted.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "govuk-elements",
+  "version": "0.0.0",
   "private": "true",
   "description": "The GOV.UK elements application",
   "repository": "alphagov/govuk_elements",


### PR DESCRIPTION
# Added a version number to `package.json'.

Allows the project to be installed as a dependency with NPM.

Tested by inclusion into another project.
This project can now be added as a dependency in any Node.js project as described in the following steps:
 - install the dependency
```bash
npm install --save alphagov/govuk_elements
```
 - require the code
```javascript
require('govuk-elements/assets/javascripts/govuk/details.polyfill');
```

## About the change:
- New feature (non-breaking change which adds functionality)

- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.