### PR TITLE
Add guidance on font size for confirmation page

### DIFF
--- a/app/views/guide_colour.html
+++ b/app/views/guide_colour.html
@@ -359,12 +359,19 @@
   </p>
 
   <h3 class="heading-medium" id="examples">Examples</h3>
-  <h4 class="heading-small">Transaction end page</h4>
+  <h4 class="heading-small">Confirmation page</h4>
+
+  <div class="text">
+    <div class="panel panel-border-wide">
+      <p>
+        When using the white text on a turquoise background &mdash; ensure the minimum text size is 24px normal weight, or 19px bold. This is to meet colour contrast ratio requirements.
+      </p>
+    </div>
+  </div>
 
   <div class="example">
-
-  <div class="grid-row">
-    <div class="column-two-thirds">
+    <div class="grid-row">
+      <div class="column-two-thirds">
 
         <h1 class="heading-xlarge">
           Example service name
@@ -393,11 +400,8 @@
         <p>
           They will contact you either to confirm your registration, or to ask for more information.
         </p>
-
       </div>
     </div>
-
   </div>
-
 </main><!-- / #content -->
 {% endblock %}


### PR DESCRIPTION
Add guidance on the minimum font size to be used for white text on a turquoise background.

![colour gov uk elements](https://cloud.githubusercontent.com/assets/417754/26729238/e14769fc-47a4-11e7-9419-55b7431617b1.png)
