### PR TITLE
Fix table spacing

### DIFF
--- a/assets/sass/elements/_tables.scss
+++ b/assets/sass/elements/_tables.scss
@@ -20,6 +20,11 @@ table {
     font-weight: 700;
   }
 
+  td:last-child,
+  th:last-child {
+    padding-right: 0;
+  }
+
   // Right align table header cells and table cells with a numeric class
   .numeric {
     text-align: right;

--- a/assets/sass/elements/_tables.scss
+++ b/assets/sass/elements/_tables.scss
@@ -12,7 +12,6 @@ table {
     padding: em(12, 19) em(20, 19) em(9, 19) 0;
 
     text-align: left;
-    color: $black;
     border-bottom: 1px solid $border-colour;
   }
 


### PR DESCRIPTION
Remove right padding from last table cells.
I also removed the `color` declaration as it isn't necessary.

## What problem does the pull request solve?

This is a design-y problem. Can a designer please fill this section in and explain what the problem is? @edwardhorsford raised it.

Ed: it makes things look neater, and matches the padding (or lack thereof) used on the other side.

## Screenshots

### Before
<img width="257" alt="spacing-before" src="https://cloud.githubusercontent.com/assets/108893/26732778/b7c3e4b4-47b0-11e7-8e5d-f083e566743c.png">

### After
<img width="221" alt="spacing-after" src="https://cloud.githubusercontent.com/assets/108893/26732793/c758eb54-47b0-11e7-8664-706f8c416623.png">

## What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

I'm not 100% sure if it's a breaking change? If it is, it's only breaking things minimally.