### PR TITLE
Only make column headers bold, not row headers

### DIFF
--- a/assets/sass/elements/_tables.scss
+++ b/assets/sass/elements/_tables.scss
@@ -16,7 +16,7 @@ table {
     border-bottom: 1px solid $border-colour;
   }
 
-  th {
+  thead th {
     font-weight: 700;
   }
 


### PR DESCRIPTION
## What problem does the pull request solve?

Having (row) headers is very important for accessibility.
But all of our table headers are bold, and that often doesn't look good with long row headers.
People who understand table semantics would need to overwrite that.
And people who don't understand semantics might choose not to use them.

We often have badly formatted tables. One reason for that is how govspeak works (I will raise an issue for that later). I suspect that another reason is that when you format a table correctly, it often doesn't look good. (But I don't have any evidence to back that up.)

E.g. if you formatted the tables on our [bank holiday page](https://www.gov.uk/bank-holidays) correctly, it would currently look like this:
<img width="623" alt="bank-holidays" src="https://cloud.githubusercontent.com/assets/108893/26733593/361036a4-47b3-11e7-90a0-fbd32a6e93b4.png">
(Although that doesn't use Elements but the example would be the same with Elements.)
And ideally, those headers shouldn't be bold. Although, there should be a way to make them bold (class for cells or modifier class for tables?).

This changes that so that only `th`s within a `thead` are bold. That might be controversial (and also be a breaking change), so I'd like your opinion on this. The question is also, how many services are using row headers?
What do you think?

This is how the table on the bank holiday page looks now, i.e. how a table within Elements would look with this change if it had row headers:
<img width="625" alt="bank-holidays-original" src="https://user-images.githubusercontent.com/108893/27083004-f5c0f824-503e-11e7-87ef-2acf3b334c8d.png">

## What type of change is it?
- Breaking change (fix or feature that would cause existing functionality to change)
Although, I'm not 100% sure if it's really a breaking change? If someone's row headers turn non-bold because of this, would that be "breaking" it?