### PR TITLE
Move form help text into legend

### DIFF
--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -31,12 +31,13 @@
           What is your nationality?
         </h1>
 
-        <p>If you have dual nationality, select all options that are relevant to you.</p>
-
         <div class="form-group">
           <fieldset>
 
-            <legend class="visually-hidden">What is your nationality?</legend>
+            <legend>
+              <span class="visually-hidden">What is your nationality?</span>
+              <span class="body-text">If you have dual nationality, select all options that are relevant to you.</span>
+            </legend>
 
             <div class="multiple-choice">
               <input type="checkbox" name="nationality_british" value="British" id="nationality_british">
@@ -126,15 +127,12 @@
           Which part of the Housing Act was your licence isued under?
         </h1>
 
-        <p>
-          Select one of the options below.
-        </p>
-
         <div class="form-group">
           <fieldset>
 
-            <legend class="visually-hidden">
-              Which part of the Housing Act was your licence isued under?
+            <legend>
+              <span class="visually-hidden">Which part of the Housing Act was your licence isued under?</span>
+              <span class="body-text">Select one of the options below.</span>
             </legend>
 
             <div class="multiple-choice">

--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -124,14 +124,14 @@
         </div>
 
         <h1 class="heading-large">
-          Which part of the Housing Act was your licence isued under?
+          Which part of the Housing Act was your licence issued under?
         </h1>
 
         <div class="form-group">
           <fieldset>
 
             <legend>
-              <span class="visually-hidden">Which part of the Housing Act was your licence isued under?</span>
+              <span class="visually-hidden">Which part of the Housing Act was your licence issued under?</span>
               <span class="body-text">Select one of the options below.</span>
             </legend>
 

--- a/app/views/guide_form_elements.html
+++ b/app/views/guide_form_elements.html
@@ -194,6 +194,9 @@
   <p class="text">
     Use fieldsets to group related form controls. The first element inside a fieldset must be a <code class="code">legend</code> element which describes the group.
   </p>
+  <p class="text">
+    Any general text which is important for filling in the form and cannot be put into a <a href="#form-hint-text">hint</a>, should be in that legend (as shown in the <a href="#form-checkboxes">checkbox example</a>). But the legend shouldn't be too long either.
+  </p>
 
   <h3 class="heading-medium" id="form-select-boxes">Select boxes</h3>
   <p class="text">

--- a/app/views/snippets/form_checkboxes.html
+++ b/app/views/snippets/form_checkboxes.html
@@ -1,10 +1,12 @@
 <h3 class="heading-medium">Which types of waste do you transport regularly?</h3>
-<p>Select all that apply</p>
 
 <form>
   <fieldset>
 
-    <legend class="visually-hidden">Which types of waste do you transport regularly?</legend>
+    <legend>
+      <span class="visually-hidden">Which types of waste do you transport regularly?</span>
+      <span class="body-text">Select all that apply</span>
+    </legend>
 
     <div class="multiple-choice">
       <input id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal">

--- a/app/views/snippets/form_inset_checkboxes.html
+++ b/app/views/snippets/form_inset_checkboxes.html
@@ -1,15 +1,15 @@
 <h1 class="heading-medium">
   What is your nationality?
 </h1>
-<p>
-  Select all options that are relevant to you.
-</p>
 
 <form>
   <div class="form-group">
     <fieldset>
 
-      <legend class="visually-hidden">What is your nationality?</legend>
+      <legend>
+        <span class="visually-hidden">What is your nationality?</span>
+        <span class="body-text">Select all options that are relevant to you.</span>
+      </legend>
 
       <div class="multiple-choice">
         <input id="nationalities-british" name="nationalities" type="checkbox" value="British">

--- a/assets/sass/elements/_elements-typography.scss
+++ b/assets/sass/elements/_elements-typography.scss
@@ -135,7 +135,8 @@ main {
 }
 
 // Text
-p {
+p,
+.body-text {
   margin-top: em(5, 16);
   margin-bottom: em(20, 16);
 
@@ -144,6 +145,10 @@ p {
     margin-bottom: em(20);
   }
 
+}
+
+.body-text {
+  display: block;
 }
 
 // Lede, or intro text

--- a/assets/sass/elements/_forms.scss
+++ b/assets/sass/elements/_forms.scss
@@ -20,6 +20,11 @@ fieldset {
   width: 100%;
 }
 
+// Hack to let legends or elements within legends have margins in webkit browsers
+legend {
+  overflow: hidden;
+}
+
 // Fix left hand gap in IE7 and below
 @include ie-lte(7) {
   legend {


### PR DESCRIPTION
This is an alternative solution to #485.

## What problem does the pull request solve?

Most groups of checkboxes and radio buttons within Elements have an additional introductory help text which isn't a hint. It's usually there to help less technical people understand that you can select multiple checkboxes, but can also be used for other purposes.

This moves that text into the legend to also make it accessible to assistive technologies like screen readers. The styling is nearly the same as before and adds a class to the current paragraph declaration to re-use its styling.

There is a bit more spacing above the help text in the new version (probably `0.26316em` which translates to 5px with default settings), even though it uses the same CSS. That is because previously the margins were collapsing as the `p` came directly after the `h3` and now they aren't anymore because the text has been moved into the legend. I'm not sure if it's worth fixing as spacing within Elements is quite inconsistent and it doesn't look wrong.
Let me know if you think I should do something about it.

## How has this been tested?

I've tested in multiple browsers via BrowserStack.

## Screenshots

### Before
<img width="549" alt="form-help-text-before" src="https://cloud.githubusercontent.com/assets/108893/26735965/1bf342ee-47bc-11e7-9427-6eac502abc35.png">

### After
<img width="551" alt="form-help-text-after" src="https://cloud.githubusercontent.com/assets/108893/26735977/27b7219a-47bc-11e7-927f-ff91cba935dd.png">

### Differences
<img width="549" alt="form-help-text-differences" src="https://cloud.githubusercontent.com/assets/108893/26736963/1e82d8b8-47c0-11e7-85ee-8d4cb081a622.png">

## What type of change is it?
- Bug fix (non-breaking change which fixes an issue)
