### PR TITLE
Associate form help text with form

### DIFF
--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -31,10 +31,10 @@
           What is your nationality?
         </h1>
 
-        <p>If you have dual nationality, select all options that are relevant to you.</p>
+        <p id="help-text-nationality">If you have dual nationality, select all options that are relevant to you.</p>
 
         <div class="form-group">
-          <fieldset>
+          <fieldset aria-describedby="help-text-nationality">
 
             <legend class="visually-hidden">What is your nationality?</legend>
 
@@ -126,12 +126,12 @@
           Which part of the Housing Act was your licence isued under?
         </h1>
 
-        <p>
+        <p id="help-text-housing">
           Select one of the options below.
         </p>
 
         <div class="form-group">
-          <fieldset>
+          <fieldset aria-describedby="help-text-housing">
 
             <legend class="visually-hidden">
               Which part of the Housing Act was your licence isued under?

--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -123,7 +123,7 @@
         </div>
 
         <h1 class="heading-large">
-          Which part of the Housing Act was your licence isued under?
+          Which part of the Housing Act was your licence issued under?
         </h1>
 
         <p id="help-text-housing">
@@ -134,7 +134,7 @@
           <fieldset aria-describedby="help-text-housing">
 
             <legend class="visually-hidden">
-              Which part of the Housing Act was your licence isued under?
+              Which part of the Housing Act was your licence issued under?
             </legend>
 
             <div class="multiple-choice">

--- a/app/views/snippets/form_checkboxes.html
+++ b/app/views/snippets/form_checkboxes.html
@@ -1,8 +1,8 @@
 <h3 class="heading-medium">Which types of waste do you transport regularly?</h3>
-<p>Select all that apply</p>
+<p id="help-text-waste">Select all that apply</p>
 
 <form>
-  <fieldset>
+  <fieldset aria-describedby="help-text-waste">
 
     <legend class="visually-hidden">Which types of waste do you transport regularly?</legend>
 

--- a/app/views/snippets/form_inset_checkboxes.html
+++ b/app/views/snippets/form_inset_checkboxes.html
@@ -1,13 +1,13 @@
 <h1 class="heading-medium">
   What is your nationality?
 </h1>
-<p>
+<p id="help-text-nationality2">
   Select all options that are relevant to you.
 </p>
 
 <form>
   <div class="form-group">
-    <fieldset>
+    <fieldset aria-describedby="help-text-nationality2">
 
       <legend class="visually-hidden">What is your nationality?</legend>
 


### PR DESCRIPTION
This is an alternative solution to #484.

## What problem does the pull request solve?

Most groups of checkboxes and radio buttons within Elements have an additional introductory help text which isn't a hint. It's usually there to help less technical people understand that you can select multiple checkboxes, but can also be used for other purposes.

This associates that text with the form via `aria-describedby` to make it more accessible to assistive technologies like screen readers. Ideally this should be put into the legend instead, but that proves to be difficult (see #484).

## How has this been tested?

I tested in the most used screen reader and browser combination: VoiceOver in Safari on macOS, JAWS in IE 11 on Windows 10 and NVDA in Firefox on Windows 10. They don't necessarily say the help text under all circumstances but always under some circumstances (e.g. when down-arrowing vs tabbing).

## What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

## Has the documentation been updated?
I'm not quite sure if this needs to be documented or not. We don't officially have the concept of a "form help text". (That's the name I gave it, that might need improving.) But I am aware of forms in the wild which use something similar. Where would a documentation fit? Maybe under "hint text" as that is related.