### PR TITLE
Remove float and width 100% from form group

### DIFF
--- a/assets/sass/elements/_forms.scss
+++ b/assets/sass/elements/_forms.scss
@@ -56,9 +56,6 @@ textarea {
   @extend %contain-floats;
   @include box-sizing(border-box);
 
-  float: left;
-  width: 100%;
-
   margin-bottom: $gutter-half;
 
   @include media(tablet) {

--- a/assets/sass/elements/_forms.scss
+++ b/assets/sass/elements/_forms.scss
@@ -36,14 +36,14 @@ textarea {
 // 2. Form wrappers
 // ==========================================================================
 
-// Form section is used to wrap .form-group and has twice its margin
-.form-section {
+.form-section,
+.form-group {
   @extend %contain-floats;
   @include box-sizing(border-box);
+}
 
-  float: left;
-  width: 100%;
-
+// Form section is used to wrap .form-group and has twice its margin
+.form-section {
   margin-bottom: $gutter;
 
   @include media(tablet) {
@@ -53,9 +53,6 @@ textarea {
 
 // Form group is used to wrap label and input pairs
 .form-group {
-  @extend %contain-floats;
-  @include box-sizing(border-box);
-
   margin-bottom: $gutter-half;
 
   @include media(tablet) {

--- a/assets/sass/elements/_forms.scss
+++ b/assets/sass/elements/_forms.scss
@@ -97,9 +97,8 @@ textarea {
 
 // Used for the 'or' in between block label options
 .form-block {
-  @extend %contain-floats;
   float: left;
-  width: 100%;
+  clear: left;
 
   margin-top: -5px;
   margin-bottom: 5px;


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

#### What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Removes float and width 100%, for `.form-group`, `.form-section`, `.form-block`.

Fixes #257.

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
<!--- Delete the lines below that don't apply -->
I have read the **CONTRIBUTING** document.
