### PR TITLE
fix(package): update govuk_template_jinja to version 0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "del": "^2.2.2",
     "express": "^4.15.2",
     "govuk_frontend_toolkit": "^6.0.2",
-    "govuk_template_jinja": "0.19.2",
+    "govuk_template_jinja": "0.22.0",
     "gulp": "^3.9.1",
     "gulp-cssnano": "^2.1.2",
     "gulp-mocha": "^4.3.1",


### PR DESCRIPTION
#### What problem does the pull request solve?

This PR updates  govuk_template_jinja from 0.20.0 to 0.22.0. 

# 0.22.0

- Adds new Apple touch icons to precompile list for Rails apps [PR #305](https://github.com/alphagov/govuk_template/pull/305)
- Revert SRI to avoid breaking the site for Firefox users on versions less than 52 [PR #308](https://github.com/alphagov/govuk_template/pull/301)

# 0.21.0

- Adds SRI to js and css assets ([PR #301](https://github.com/alphagov/govuk_template/pull/301)). This requires `sprockets-rails` >= 3.0 in the projects using this gem.

# 0.20.1
- Fix invalid html from Apple touch icons syntax [PR #300](https://github.com/alphagov/govuk_template/pull/300) and
update icon sizes to match Apple specs