### PR TITLE
fix(package): update govuk_template_jinja to version 0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "del": "^2.2.2",
     "express": "^4.15.2",
     "govuk_frontend_toolkit": "^6.0.2",
-    "govuk_template_jinja": "0.20.1",
+    "govuk_template_jinja": "0.22.0",
     "gulp": "^3.9.1",
     "gulp-cssnano": "^2.1.2",
     "gulp-mocha": "^4.3.1",


### PR DESCRIPTION
0.22.0

- Adds new Apple touch icons to precompile list for Rails apps [PR #305](https://github.com/alphagov/govuk_template/pull/305)
