### PR TITLE
Release as “GOV.UK Patterns & Tools CI User”

### DIFF
--- a/create-release.sh
+++ b/create-release.sh
@@ -5,8 +5,8 @@ REPO_PATH='alphagov/govuk_elements'
 
 echo "Add config for alphagov/$REPO_PATH"
 
-git config --global user.name "Travis CI"
-git config --global user.email "travis@travis-ci.org"
+git config --global user.name "GOV.UK Patterns & Tools CI User"
+git config --global user.email "patterns-and-tools-github-user@digital.cabinet-office.gov.uk"
 git remote add origin_ssh git@github.com:$REPO_PATH.git
 
 # This openssl command was generated automatically by `travis encrypt-file`, see `.travis/README.md` for more details


### PR DESCRIPTION
Amend the username and email to use the details for the GOV.UK Patterns & Tools CI User, in the create-release.sh script.