### PR TITLE
Fix spacing above nested panels

### DIFF
--- a/assets/sass/elements/_panels.scss
+++ b/assets/sass/elements/_panels.scss
@@ -49,12 +49,13 @@
 
 // The last panel in a group
 .form-group .panel-border-narrow:last-child {
-  margin-top: 10px;
+  margin-top: 0;
   margin-bottom: 0;
 }
 
 // For inline panels
-.inline .panel-border-narrow {
+.inline .panel-border-narrow,
+.inline .panel-border-narrow:last-child {
   margin-top: 10px;
   margin-bottom: 0;
 }


### PR DESCRIPTION
#### What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The margin above the last item is too large, as seen in the image below.

![image](https://user-images.githubusercontent.com/417754/27093513-e429e2cc-505e-11e7-862e-0f8a4031d246.png)

Fixes #428.

#### Screenshots (if appropriate):

![jun-13-2017 17-37-57](https://user-images.githubusercontent.com/417754/27093818-fa754ed0-505f-11e7-82fd-9d8178e9b768.gif)

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
<!--- Delete the lines below that don't apply -->
I have read the **CONTRIBUTING** document.
