### PR TITLE
Update link to GOV.UK Design Patterns

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -112,7 +112,9 @@
 
       <h3 class="heading-small">Want to discuss these patterns?</h3>
       <p>
-        <a href="https://designpatterns.hackpad.com/" rel="external">Discuss design patterns for GOV.UK services on our hackpad</a>.
+        <a href="https://paper.dropbox.com/doc/About-GOV.UK-Design-Patterns-hkou7bpzKya8Dadv24V1z" rel="external">
+          Discuss GOV.UK Design Patterns
+        </a>.
       </p>
 
     </div>


### PR DESCRIPTION
Replace the link mentioning the "Hackpad" to the index page of GOV.UK Design Patterns.

cc. @timpaul.