### PR TITLE
fix broken link to polyfill

### DIFF
--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -222,7 +222,7 @@
     </p>
     <p>
       You’ll need to ensure that your markup matches the example above.
-      <a href="https://github.com/alphagov/govuk_elements/blob/master/public/javascripts/govuk/details.polyfill.js">GOV.UK elements uses this polyfill</a>.
+      <a href="https://github.com/alphagov/govuk_elements/blob/master/assets/javascripts/govuk/details.polyfill.js">GOV.UK elements uses this polyfill</a>.
     </p>
     <p>
       <a href="/typography/example-details-summary/">Take a look at example page</a> which demonstrates conditionally revealing information, using the HTML5 details and summary elements.


### PR DESCRIPTION
Fix a broken link on the typography page where it linked to a polyfill that had been moved.