### PR TITLE
De-duplicate legends/headings

### DIFF
--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -561,7 +561,7 @@
 
       <div class="form-section">
         <h3 class="heading-medium">
-          These examples are one-question-per-page examples and use a heading for the question, with a visually hidden legend inside a fieldset.
+          These examples are one-question-per-page examples and use a heading for the question inside the legend of the fieldset.
         </h3>
         <!-- "Chunky" Radio buttons, stacked -->
         {% include "snippets/form_radio_buttons.html" %}

--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -27,15 +27,13 @@
 
       <form action="/" method="post" class="form">
 
-        <h1 class="heading-large">
-          What is your nationality?
-        </h1>
-
         <div class="form-group">
           <fieldset>
 
             <legend>
-              <span class="visually-hidden">What is your nationality?</span>
+              <h1 class="heading-large">
+                What is your nationality?
+              </h1>
               <span class="body-text">If you have dual nationality, select all options that are relevant to you.</span>
             </legend>
 
@@ -64,15 +62,13 @@
           </fieldset>
         </div>
 
-        <h1 class="heading-large">
-          Where should we send your new<br> passport?
-        </h1>
-
         <div class="form-group">
           <fieldset>
 
-            <legend class="visually-hidden">
-              Where should we send your new passport?
+            <legend>
+              <h1 class="heading-large">
+                Where should we send your new passport?
+              </h1>
             </legend>
 
             <div class="multiple-choice">
@@ -87,14 +83,12 @@
 
             <div class="panel panel-border-narrow js-hidden" id="example-other-address">
 
-              <h2 class="heading-medium">
-                Your other address
-              </h2>
-
               <fieldset>
 
-                <legend class="visually-hidden">
-                  Your other address
+                <legend>
+                  <h2 class="heading-medium">
+                    Your other address
+                  </h2>
                 </legend>
 
                 <div class="form-group form-group-compound">
@@ -123,15 +117,13 @@
           </fieldset>
         </div>
 
-        <h1 class="heading-large">
-          Which part of the Housing Act was your licence issued under?
-        </h1>
-
         <div class="form-group">
           <fieldset>
 
             <legend>
-              <span class="visually-hidden">Which part of the Housing Act was your licence issued under?</span>
+              <h1 class="heading-large">
+                Which part of the Housing Act was your licence issued under?
+              </h1>
               <span class="body-text">Select one of the options below.</span>
             </legend>
 

--- a/app/views/snippets/form_checkboxes.html
+++ b/app/views/snippets/form_checkboxes.html
@@ -1,10 +1,8 @@
-<h3 class="heading-medium">Which types of waste do you transport regularly?</h3>
-
 <form>
   <fieldset>
 
     <legend>
-      <span class="visually-hidden">Which types of waste do you transport regularly?</span>
+      <h3 class="heading-medium">Which types of waste do you transport regularly?</h3>
       <span class="body-text">Select all that apply</span>
     </legend>
 

--- a/app/views/snippets/form_inset_checkboxes.html
+++ b/app/views/snippets/form_inset_checkboxes.html
@@ -1,13 +1,11 @@
-<h1 class="heading-medium">
-  What is your nationality?
-</h1>
-
 <form>
   <div class="form-group">
     <fieldset>
 
       <legend>
-        <span class="visually-hidden">What is your nationality?</span>
+        <h1 class="heading-medium">
+          What is your nationality?
+        </h1>
         <span class="body-text">Select all options that are relevant to you.</span>
       </legend>
 

--- a/app/views/snippets/form_inset_radios.html
+++ b/app/views/snippets/form_inset_radios.html
@@ -1,12 +1,12 @@
-<h1 class="heading-medium">
-  How do you want to be contacted?
-</h1>
-
 <form>
   <div class="form-group">
     <fieldset>
 
-      <legend class="visually-hidden">How do you want to be contacted?</legend>
+      <legend>
+        <h1 class="heading-medium">
+          How do you want to be contacted?
+        </h1>
+      </legend>
 
       <div class="multiple-choice" data-target="contact-by-email">
         <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Yes">

--- a/app/views/snippets/form_radio_buttons.html
+++ b/app/views/snippets/form_radio_buttons.html
@@ -1,10 +1,10 @@
-<h1 class="heading-medium">Where do you live?</h1>
-
 <form>
   <div class="form-group">
     <fieldset>
 
-      <legend class="visually-hidden">Where do you live?</legend>
+      <legend>
+        <h1 class="heading-medium">Where do you live?</h1>
+      </legend>
 
       <div class="multiple-choice">
         <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">

--- a/app/views/snippets/form_radio_buttons_inline.html
+++ b/app/views/snippets/form_radio_buttons_inline.html
@@ -1,12 +1,12 @@
-<h1 class="heading-medium">
-  Do you already have a personal user account?
-</h1>
-
 <form>
   <div class="form-group">
     <fieldset class="inline">
 
-      <legend class="visually-hidden">Do you already have a personal user account?</legend>
+      <legend>
+        <h1 class="heading-medium">
+          Do you already have a personal user account?
+        </h1>
+      </legend>
 
       <div class="multiple-choice">
         <input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes">

--- a/app/views/snippets/form_radio_inline_yes_no.html
+++ b/app/views/snippets/form_radio_inline_yes_no.html
@@ -1,12 +1,12 @@
-<h1 class="heading-medium">
-  Do you yes/no ?
-</h1>
-
 <form>
   <div class="form-group">
     <fieldset class="inline">
 
-      <legend class="visually-hidden">Do you yes/no?</legend>
+      <legend>
+        <h1 class="heading-medium">
+          Do you yes/no?
+        </h1>
+      </legend>
 
       <div class="multiple-choice" data-target="yes-and-do-next">
         <input id="radio-yes-no-yes" type="radio" name="yes-no-group" value="Yes">


### PR DESCRIPTION
## What problem does the pull request solve?

When we have one thing per page, our current pattern is to let the h1 be the question and then repeat but visually hide it in the legend (or label). That means screen readers will read the question twice, which is not a proper barrier but annoying and gets raised as an issue again and again, e.g. in #320 or [on the cross-government accessibility mailinglist](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!searchin/accessibility-community/error$20summary$20heading%7Csort:relevance/accessibility-community/oekFWa1LhdE/n2-pwcTHAQAJ).

This changes that by **moving the h1 into the legend**. That creates the following issues:

* It is currently invalid. But it will be valid in [HTML 5.2](https://www.w3.org/TR/html52/sec-forms.html#the-legend-element) and the W3C validator passes it fine. (See the [reason for the change](https://github.com/w3c/html/issues/724).) As such it might cause issues with existing validators run during CI. Does anyone know if this will be a problem for them?
* Because the h1 is moved further down into the code inside other elements, some systems/frameworks might make it difficult to do. Does anyone already know they would have problems with that? We could add some guidance that using the old way would be fine in that case (i.e. visually hiding the legend).
* When the label is in an h1 (see below), then also having the hint in there could potentially be too much. Although that will more be a problem for examples that use potentially unnecessary long hints. And please note, that is not a problem for the legend, only for the label as another element for the hint can exist alongside the h1.


## What else could solve this?

I tested some other ways of fixing this issue, some of which have been suggested by the cross-government accessibility community in the thread mentioned above:

* Visually hide the heading instead of the label: It doesn't solve the problem
* Remove the legend and use `aria-labelledby` instead: It solves the problem (except JAWS and legend combination) but feels wrong, 7 out of 10 testing tools fail this, although all tested AT is fine with it
* Remove heading and use `role=heading` instead: It solves the problem but feels even more wrong, the h1 is too essential to lose (even if it's there for AT, it would be missing for other things, e.g. search engines), 4 out of 10 testing tools fail this, although all tested AT is fine with it


## How has this been tested?

### Browsers
I tested this in various old and new browsers via BrowserStack and it's not causing any issues anywhere. I have also built a local version with the question being a label for a text input and the label being in an h1. That didn't cause an issue either.
Neither has had any visual effect in any of the tested browsers.

### Screen readers

I tested in a couple of screen readers:
JAWS with IE11, NVDA in Firefox and VoiceOver on iOS read everything once (instead of twice) when "down-arrowing". VoiceOver on macOS reads everything twice (instead of three times) and reads the heading after it announced the group.

### Accessibility testing tools

I also wanted to make sure that accessibility testing tools wouldn't report any unnecessary issues, so tested this in aXe, Tenon, AChecker, WAVE, FAE, EIII, HTML_CodeSniffer, SortSite, Google A11y Dev Tools and Asqatasun. And only EIII came back with one fail for the legend ("The name of the form control is not set correctly"). As I mentioned above, all the other viable solutions failed way more times than this solution.

### How to test yourself

If you want to test this solution yourself, I'd suggest to not use this branch because it only includes one single type of implementation, i.e. a single question for radio buttons with a legend. I have tested all the difference scenarios I could think of, including when the question is for a text input, i.e. it would need to be in a label not in a legend. Although I have tested that locally within a version of the prototype kit with GOV.UK branding and Elements styles etc, I have created three separate unstyled JSbin version, so you can test just the markup independently:

* [Heading in legend with radios](http://jsbin.com/jexekiv)
* [Heading in legend with inputs](http://jsbin.com/powavec)
* [Label in heading](http://jsbin.com/xecoli)


## What is potentially missing? / Open questions

* [ ] I wonder if we should add more examples? Although there are lots of examples, they are only of one type of implementation, the other two types are missing.
* [ ] Do we need to add to the documentation that falling back to visually hiding the legend is acceptable in case someone has problems implementing this solution?


## What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

## Has the documentation been updated?
- I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
