### PR TITLE
Ensure Travis runs tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 language: node_js
 node_js:
  - "4.4.7"
-script:
-# Ensures `package.json` and `yarn.lock` stay in sync
-- yarn check --integrity
-- yarn test
 notifications:
   email: false
 before_deploy:
 - test $TRAVIS_TEST_RESULT = 0
 jobs:
   include:
+    - stage: run tests
+      script:
+        # Ensures `package.json` and `yarn.lock` stay in sync
+        - yarn check --integrity
+        - yarn test
     - stage: heroku deploy
       script: echo "Deploying to Heroku ..."
       deploy:


### PR DESCRIPTION
Move tests into their own build stage. It appears the script to run the
tests is being ignored without this.

This can be seen working here:
https://travis-ci.org/alphagov/govuk_elements/builds/234778197#L217

and then no longer working here:
https://travis-ci.org/alphagov/govuk_elements/builds/246248025

After 938689db433c1cadfc1a93a2ac0ce28e8f0f62f8 was merged. 


