### PR TITLE
Reflect form validation error in title

### DIFF
--- a/app/views/examples/_form_validation_implementation_advice.html
+++ b/app/views/examples/_form_validation_implementation_advice.html
@@ -3,15 +3,6 @@
 <p class="lead-in">When an error occurs:</p>
 <ul class="list list-bullet text">
   <li>
-    add a 5px red left border to the field with the error
-  </li>
-  <li>
-    the error message be red and bold and appear after the question
-  </li>
-  <li>
-    the error message must sit inside the <code>&lt;legend&gt;</code>
-  </li>
-  <li>
     show an error summary at the top of the page
   </li>
   <li>
@@ -39,7 +30,10 @@
     link from the error list in the summary to the fields with errors
   </li>
   <li>
-    show an error message before each field with an error
+    add a 5px red left border to the field with the error
+  </li>
+  <li>
+    show a red and bold error message between each question and field with an error
   </li>
   <li>
     associate each error message with the corresponding field by adding it to the label (or legend)

--- a/app/views/examples/_form_validation_implementation_advice.html
+++ b/app/views/examples/_form_validation_implementation_advice.html
@@ -3,6 +3,9 @@
 <p class="lead-in">When an error occurs:</p>
 <ul class="list list-bullet text">
   <li>
+    prefix the <code>&lt;title&gt;</code> with "Error: "
+  </li>
+  <li>
     show an error summary at the top of the page
   </li>
   <li>

--- a/app/views/examples/_form_validation_implementation_advice.html
+++ b/app/views/examples/_form_validation_implementation_advice.html
@@ -1,0 +1,51 @@
+<h2 class="heading-medium implementation-advice">Implementation advice</h2>
+
+<p class="lead-in">When an error occurs:</p>
+<ul class="list list-bullet text">
+  <li>
+    add a 5px red left border to the field with the error
+  </li>
+  <li>
+    the error message be red and bold and appear after the question
+  </li>
+  <li>
+    the error message must sit inside the <code>&lt;legend&gt;</code>
+  </li>
+  <li>
+    show an error summary at the top of the page
+  </li>
+  <li>
+    move keyboard focus to the start of the summary
+    <span class="panel panel-border-narrow">
+      to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
+    </span>
+  </li>
+  <li>
+    ensure that the summary is announced to as many screen readers as possible
+    <span class="panel panel-border-narrow">
+      use <code>role="alert"</code> on the containing <code>div</code>
+    </span>
+  </li>
+  <li>
+    use a heading at the top of the summary
+  </li>
+  <li>
+    associate the heading with the summary box
+    <span class="panel panel-border-narrow">
+      use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
+    </span>
+  </li>
+  <li>
+    link from the error list in the summary to the fields with errors
+  </li>
+  <li>
+    show an error message before each field with an error
+  </li>
+  <li>
+    associate each error message with the corresponding field by adding it to the label (or legend)
+  </li>
+</ul>
+
+<p class="text">
+  Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
+</p>

--- a/app/views/examples/example_form_validation_multiple_questions.html
+++ b/app/views/examples/example_form_validation_multiple_questions.html
@@ -14,50 +14,7 @@
         {% include "snippets/form_error_multiple.html" %}
       </form>
 
-      <h2 class="heading-medium implementation-advice">Implementation advice</h2>
-      <p class="lead-in">When an error occurs:</p>
-      <ul class="list list-bullet text">
-        <li>
-          add a 5px red left border to the field with the error
-        </li>
-        <li>
-          show an error summary at the top of the page
-        </li>
-        <li>
-          move keyboard focus to the start of the summary
-          <span class="panel panel-border-narrow">
-            to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
-          </span>
-        </li>
-        <li>
-          ensure that the summary is announced to as many screen readers as possible
-          <span class="panel panel-border-narrow">
-            use <code>role="alert"</code> on the containing <code>div</code>
-          </span>
-        </li>
-        <li>
-          use a heading at the top of the summary
-        </li>
-        <li>
-          associate the heading with the summary box
-          <span class="panel panel-border-narrow">
-            use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
-          </span>
-        </li>
-        <li>
-          link from the error list in the summary to the fields with errors
-        </li>
-        <li>
-          show an error message before each field with an error
-        </li>
-        <li>
-          associate each error message with the corresponding field by adding it to the label (or legend)
-        </li>
-      </ul>
-
-      <p class="text">
-        Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
-      </p>
+      {% include "examples/_form_validation_implementation_advice.html" %}
 
     </div>
   </div>

--- a/app/views/examples/example_form_validation_multiple_questions.html
+++ b/app/views/examples/example_form_validation_multiple_questions.html
@@ -1,6 +1,6 @@
 {% extends "layout_example.html" %}
 
-{% block page_title %}Example: Form validation — Errors — GOV.UK elements{% endblock %}
+{% block page_title %}{% if error %}Error: {% endif %}Example: Form validation — Errors — GOV.UK elements{% endblock %}
 
 {% block content %}
 <main class="js-error-example" id="content" role="main" tabindex="-1">

--- a/app/views/examples/example_form_validation_single_question_radio.html
+++ b/app/views/examples/example_form_validation_single_question_radio.html
@@ -1,6 +1,6 @@
 {% extends "layout_example.html" %}
 
-{% block page_title %}Example: Form validation — Errors — GOV.UK elements{% endblock %}
+{% block page_title %}{% if error %}Error: {% endif %}Example: Form validation — Errors — GOV.UK elements{% endblock %}
 
 {% block content %}
 <main class="js-error-example" id="content" role="main" tabindex="-1">

--- a/app/views/examples/example_form_validation_single_question_radio.html
+++ b/app/views/examples/example_form_validation_single_question_radio.html
@@ -14,56 +14,7 @@
         {% include "snippets/form_error_radio.html" %}
       </form>
 
-      <h2 class="heading-medium implementation-advice">Implementation advice</h2>
-      <p class="lead-in">When an error occurs:</p>
-      <ul class="list list-bullet text">
-        <li>
-          add a 5px red left border to the field with the error
-        </li>
-        <li>
-          the error message be red and bold and appear after the question
-        </li>
-        <li>
-          the error message must sit inside the <code>&lt;legend&gt;</code>
-        </li>
-        <li>
-          show an error summary at the top of the page
-        </li>
-        <li>
-          move keyboard focus to the start of the summary
-          <span class="panel panel-border-narrow">
-            to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
-          </span>
-        </li>
-        <li>
-          ensure that the summary is announced to as many screen readers as possible
-          <span class="panel panel-border-narrow">
-            use <code>role="alert"</code> on the containing <code>div</code>
-          </span>
-        </li>
-        <li>
-          use a heading at the top of the summary
-        </li>
-        <li>
-          associate the heading with the summary box
-          <span class="panel panel-border-narrow">
-            use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
-          </span>
-        </li>
-        <li>
-          link from the error list in the summary to the fields with errors
-        </li>
-        <li>
-          show an error message before each field with an error
-        </li>
-        <li>
-          associate each error message with the corresponding field by adding it to the label (or legend)
-        </li>
-      </ul>
-
-      <p class="text">
-        Also consider using the <code>aria-invalid</code> attribute to programmatically indicate that a field has an error. The value of the <a href="http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid">aria-invalid attribute</a> will vary depending on the type of error.
-      </p>
+      {% include "examples/_form_validation_implementation_advice.html" %}
 
     </div>
   </div>

--- a/app/views/guide_errors.html
+++ b/app/views/guide_errors.html
@@ -51,6 +51,8 @@
     <li>link to each of the problematic questions</li>
   </ul>
 
+  <p class="text">Additionally, you should reflect that there's been an error in the <code>&lt;title&gt;</code> by prefixing the existing title with "Error: ". That will make sure screen readers are alerted to there being an error as soon as possible.</p>
+
   <h4 class="heading-small">Error message and summary box</h4>
 <div class="example example-error">
   {% include "snippets/form_error_radio_show_errors.html" %}


### PR DESCRIPTION
## What problem does the pull request solve?

When a form submit wasn't successful and there are errors in the form which need to be highlighted, it is very important that every user is alerted to that as soon and effectively as possible. Although our solution for that is pretty good, it can still be improved.
Seeing users, even those with low vision, can see the big red box pretty clearly. Even in case they cannot read the text easily, they will know something is wrong. So, it's mostly the journey for blind screen reader users we should be concerned about.

Because we automatically focus on the error summary, some screen readers read that out pretty early, while others never read it. But what most screen readers read first is the title. That's what we can use to make them aware that there has been an error as soon as possible.

That's why this adds guidance to prefix the `title` with something (like "Error in:"). It also adds the required code to the two validation example forms.

This was very successfully user-tested with screen reader users, with users actively pointing out how useful it is.
It is also mentioned in the [W3C's Web Accessibility Tutorial](https://www.w3.org/WAI/tutorials/forms/notifications/#using-the-page-title) as a good practice example of how to notify users of interaction successes or failures. Changing the main heading would also be an option.

As some of the guidance was duplicated and overlapping a bit, this also moves it into a partial for re-use and rearranges some of its content.

One open question I still have is about the copy: Is "Error in: " a good example? I could also think of "Error - ". Who should I talk to to get feedback on that? What is our style?

## How has this been tested?

This was tested in a couple of screen readers (always using the default configuration). All of these tests only reflect how they behave in case of a page with errors after a form post:

* JAWS 17 in IE 11 reads the title first, except when following an anchor
* NVDA in Firefox always reads the title first
* none of the VoiceOver versions read the title at all
* ZoomText never reads the title

Those are the ones we care most about, but for completeness' sake, I have also tested:

* Narrator in IE 11 always reads the title first (if scan mode is off)
* TalkBack in Chrome reads the title first, except when following an anchor or if there is a `role=alert`
* ChromeVox in Chrome also always reads the title first

When the title is not read, this change doesn't change anything. But when the title is read first, that's an improvement over being alerted about the error a couple of seconds later or never in case a user decides to quickly navigate somewhere else within the page.

## What type of change is it?
- New feature (non-breaking change which adds functionality)

## Has the documentation been updated?
- I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
