### PR TITLE
Use h2 for error summary heading

### DIFF
--- a/app/views/snippets/form_error_multiple.html
+++ b/app/views/snippets/form_error_multiple.html
@@ -1,9 +1,9 @@
 {% if error %}
 <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
 
-  <h1 class="heading-medium error-summary-heading" id="error-summary-heading">
+  <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
     Message to alert the user to a problem goes here
-  </h1>
+  </h2>
 
   <p>
     Optional description of the errors and how to correct them

--- a/app/views/snippets/form_error_multiple_show_errors.html
+++ b/app/views/snippets/form_error_multiple_show_errors.html
@@ -3,9 +3,9 @@
 
     <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-2" tabindex="-1">
 
-      <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-2">
+      <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-2">
         Message to alert the user to a problem goes here
-      </h1>
+      </h2>
 
       <p>
         Optional description of the errors and how to correct them

--- a/app/views/snippets/form_error_radio.html
+++ b/app/views/snippets/form_error_radio.html
@@ -1,9 +1,9 @@
 {% if error %}
 <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
 
-  <h1 class="heading-medium error-summary-heading" id="error-summary-heading">
+  <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
     Message to alert the user to a problem goes here
-  </h1>
+  </h2>
 
   <p>
     Optional description of the errors and how to correct them

--- a/app/views/snippets/form_error_radio_show_errors.html
+++ b/app/views/snippets/form_error_radio_show_errors.html
@@ -3,9 +3,9 @@
 
     <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
 
-      <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+      <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
         Message to alert the user to a problem goes here
-      </h1>
+      </h2>
 
       <p>
         Optional description of the errors and how to correct them


### PR DESCRIPTION
## What problem does the pull request solve?

When there is an error in a form after submit, we show an error summary box above the h1. And the heading of that box is also an h1, making that two h1s per page.
The question why that is comes up again and again. For example, the accessibility audits by DAC (which a lot of departments are using) always raise that as an issue. And it was discussed a lot when it was first introduced in #71 (and previous PRs) and on various mailinglists.

As no visuals are affected, the main thing to look at is how screen reader users react to different heading levels.
I've been looking into how to "solve" this and if this really is an issue and tried various combinations:

* Error summary and main heading are h1 (current solution)
* Error summary heading is h1, main heading is h2
* Error summary heading is h2, main heading is h1 (solution in this PR)
* Main heading is h1 and is before error summary which is h2

I strongly believe that all of those variations are nearly equally fine. There are arguments for and against all of them. But none of them are ultimately really more accessible or more semantic or more right than the others.
The main problem why there is so much uncertainty around the subject and why even accessibility experts disagree on it is because HTML was not written for websites, it's written for web documents. It simply hasn't got the right semantic elements to build a meaningful website structure. Parts of that would have been solved with the [document outline](https://css-tricks.com/document-outline-dilemma/) but that wasn't meant to be.

One thing we can hopefully all agree on, none of the solutions above is creating any barriers. As such, I wanted to go for the solution which will cause the least friction and follows the most accepted "best practice", so that we don't need to spend more time with answering support requests about this.

So, I propose to **use an h2 instead of an h1 for the error summary heading**.
It strengthens the "only one h1 per page" pattern and keeps things consistent. Although, I'm also aware that not everybody will be happy with that.


### What about having the summary after the main heading?

The problem with that is that it will break the question and answer apart when using the "one thing per page" pattern.
What would solve that as well is to simply not have an error summary box on a page that follows that pattern as there will usually only be a maximum of one error, so you could jump straight to the error. In that case all other forms not following that pattern could have the summary box below the main heading.

But when they implemented the current solution they tried to do just that and it turned out to be much more complicated than expected. If someone has the resources to properly build the rules around that and user-test it, I think it might be the best solution. Until then we need to decide on the best quick solution.


## How has this been tested?

This version was user-tested with a couple of screen reader users, and the change of heading hierarchy didn't cause any problems. No-one noticed anything off or was distracted by anything unexpected.

And I've also run it through a couple of accessibility checkers. FAE and aXe didn't return any issues. HTML_CodeSniffer (on which pa11y is based) came back with a warning (not an error):

> The heading structure is not logically nested. This h2 element appears to be the primary document heading, so should be an h1 element.


## What type of change is it?
- Bug fix (non-breaking change which fixes an issue), although I wouldn't really say it's a bug as such

## Has the documentation been updated?
The documentation was already not specific about the heading level, so didn't need updating.