### PR TITLE
Change error summary ARIA role to "alert"

### DIFF
--- a/app/views/examples/example_form_validation_multiple_questions.html
+++ b/app/views/examples/example_form_validation_multiple_questions.html
@@ -30,9 +30,9 @@
           </span>
         </li>
         <li>
-          indicate to screenreaders that the summary represents a collection of information
+          ensure that the summary is announced to as many screen readers as possible
           <span class="panel panel-border-narrow">
-            add the ARIA <code>role="group"</code> to the containing <code>div</code>
+            use <code>role="alert"</code> on the containing <code>div</code>
           </span>
         </li>
         <li>

--- a/app/views/examples/example_form_validation_single_question_radio.html
+++ b/app/views/examples/example_form_validation_single_question_radio.html
@@ -36,9 +36,9 @@
           </span>
         </li>
         <li>
-          indicate to screenreaders that the summary represents a collection of information
+          ensure that the summary is announced to as many screen readers as possible
           <span class="panel panel-border-narrow">
-            add the ARIA <code>role="group"</code> to the containing <code>div</code>
+            use <code>role="alert"</code> on the containing <code>div</code>
           </span>
         </li>
         <li>

--- a/app/views/snippets/form_error_multiple.html
+++ b/app/views/snippets/form_error_multiple.html
@@ -1,5 +1,5 @@
 {% if error %}
-<div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
+<div class="error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
 
   <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
     Message to alert the user to a problem goes here

--- a/app/views/snippets/form_error_multiple_show_errors.html
+++ b/app/views/snippets/form_error_multiple_show_errors.html
@@ -1,7 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
 
-    <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-2" tabindex="-1">
+    <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-2" tabindex="-1">
 
       <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-2">
         Message to alert the user to a problem goes here

--- a/app/views/snippets/form_error_radio.html
+++ b/app/views/snippets/form_error_radio.html
@@ -1,5 +1,5 @@
 {% if error %}
-<div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
+<div class="error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
 
   <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
     Message to alert the user to a problem goes here

--- a/app/views/snippets/form_error_radio_show_errors.html
+++ b/app/views/snippets/form_error_radio_show_errors.html
@@ -1,7 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
 
-    <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+    <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
 
       <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
         Message to alert the user to a problem goes here


### PR DESCRIPTION
## What problem does the pull request solve?

Currently neither VoiceOver on iOS or macOS nor TalkBack on Android announce that there is an error when submitting a form with errors. Although we focus on the error summary box, it doesn't have the desired effect. In the iOS case it's because of [one browser bug](https://bugs.webkit.org/show_bug.cgi?id=163719) and in the macOS case because of [another browser bug](https://bugs.webkit.org/show_bug.cgi?id=171006). At least the iOS and Android issue can be fixed by adding the ARIA `role="alert"` to the error summary box.

I am not sure what the effect will be of removing the `group` role. It didn't seem to have an effect when I tested this but I would like to have someone else's opinion on this.


## How has this been tested?

Changing this doesn't change the behaviour (postively or negatively) in JAWS, NVDA or VO on macOS, but it does mean that ZoomText is not announcing anything.
As VO on iOS is used much more often by blind people than ZoomText (ZoomText is used more by visually impaired people who would be able to see the big red alert box), this seems to be a sensible sacrifice.


## What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
- I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
