### PR TITLE
Update govuk-frontent-toolkit name to match npm package naming

### DIFF
--- a/packages/govuk-elements-sass/README.md
+++ b/packages/govuk-elements-sass/README.md
@@ -22,7 +22,7 @@ Choose partials from:
 
 GOV.UK elements has the [GOV.UK frontend toolkit](https://github.com/alphagov/govuk_frontend_toolkit) as a dependency.
 
-    npm install govuk-frontend-toolkit
+    npm install govuk_frontend_toolkit
 
 > The GOV.UK frontend toolkit scss dependencies listed below must be imported before any govuk-elements partials.
 


### PR DESCRIPTION
#### What problem does the pull request solve?
When using the guidance for 'packages/govuk-elements-sass', the README.md file (changed in this pull request) directs to use 'npm install govuk-frontend-toolkit' command however the correct name for the npm package is 'govuk_frontend_toolkit' (just changing hyphens for underscores).

#### How has this been tested?
Single change to README.md file therefore no tests executed.

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
- I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document. - Apologies though, wasn't sure if this actually needed a new version given that it's a minor, non-functional change.
