### PR TITLE
Set cursor:default for disabled radio buttons and checkboxes

### DIFF
--- a/app/views/guide_form_elements.html
+++ b/app/views/guide_form_elements.html
@@ -252,7 +252,7 @@
 </code>
 </pre>
 
-  <h4 class="heading-small">Disabled radio buttons</h4>
+  <h4 class="heading-small" id="form-radio-buttons-disabled">Disabled radio buttons</h4>
   <div class="example">
     {% include "snippets/form_radio_buttons_disabled.html" %}
   </div>
@@ -284,7 +284,7 @@
 </code>
 </pre>
 
-  <h4 class="heading-small">Disabled checkboxes</h4>
+  <h4 class="heading-small" id="form-checkboxes-disabled">Disabled checkboxes</h4>
   <div class="example">
     {% include "snippets/form_checkboxes_disabled.html" %}
   </div>

--- a/app/views/guide_form_elements.html
+++ b/app/views/guide_form_elements.html
@@ -252,6 +252,19 @@
 </code>
 </pre>
 
+  <h4 class="heading-small">Disabled radio buttons</h4>
+  <div class="example">
+    {% include "snippets/form_radio_buttons_disabled.html" %}
+  </div>
+
+<pre>
+<code class="language-markup">
+  {% filter escape %}
+    {% include "snippets/form_radio_buttons_disabled.html" %}
+  {% endfilter %}
+</code>
+</pre>
+
   <h3 class="heading-medium" id="form-checkboxes">Checkboxes</h3>
   <ul class="list list-bullet text">
     <li>use these to select either on/off toggles or multiple selections</li>
@@ -267,6 +280,19 @@
 <code class="language-markup">
   {% filter escape %}
     {% include "snippets/form_checkboxes.html" %}
+  {% endfilter %}
+</code>
+</pre>
+
+  <h4 class="heading-small">Disabled checkboxes</h4>
+  <div class="example">
+    {% include "snippets/form_checkboxes_disabled.html" %}
+  </div>
+
+<pre>
+<code class="language-markup">
+  {% filter escape %}
+    {% include "snippets/form_checkboxes_disabled.html" %}
   {% endfilter %}
 </code>
 </pre>

--- a/app/views/snippets/form_checkboxes_disabled.html
+++ b/app/views/snippets/form_checkboxes_disabled.html
@@ -1,0 +1,4 @@
+<div class="multiple-choice">
+  <input id="checkbox-disabled-example" name="checkbox-disabled-group" type="checkbox" value="waste-farm-agricultural" disabled>
+  <label for="checkbox-disabled-example">Farm or agricultural waste</label>
+</div>

--- a/app/views/snippets/form_radio_buttons_disabled.html
+++ b/app/views/snippets/form_radio_buttons_disabled.html
@@ -1,0 +1,4 @@
+<div class="multiple-choice">
+  <input id="radio-disabled-example" type="radio" name="radio-disabled-group" value="Isle of Man or the Channel Islands" disabled>
+  <label for="radio-disabled-example">Isle of Man or the Channel Islands</label>
+</div>

--- a/assets/sass/elements/forms/_form-multiple-choice.scss
+++ b/assets/sass/elements/forms/_form-multiple-choice.scss
@@ -116,8 +116,13 @@
   }
 
   // Disabled state
+  input:disabled {
+    cursor: default;
+  }
+
   input:disabled + label {
     @include opacity(0.5);
+    cursor: default;
   }
 
   &:last-child,


### PR DESCRIPTION
#### What problem does the pull request solve?

Fixes #517.

Adds cursor:default for both the disabled input and the label - for radio buttons and checkboxes.

Also adds examples of each.

#### Screenshots (if appropriate):

Radio button:
![disabled-radio-buttons](https://user-images.githubusercontent.com/417754/28019821-2defaefc-657a-11e7-8a88-357383af09dd.png)

Checkbox:
![disabled-checkboxes](https://user-images.githubusercontent.com/417754/28019815-291c11d6-657a-11e7-91b2-78541df9a10a.png)

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
- I have updated the documentation accordingly.
