### PR TITLE
Fix #518: stray line on checkbox on IE11

### DIFF
--- a/packages/govuk-elements-sass/public/sass/elements/forms/_form-multiple-choice.scss
+++ b/packages/govuk-elements-sass/public/sass/elements/forms/_form-multiple-choice.scss
@@ -87,6 +87,7 @@
     content: "";
     border: solid;
     border-width: 0 0 5px 5px;
+    border-top-color: transparent;
     background: transparent;
     width: 17px;
     height: 7px;


### PR DESCRIPTION
#### What problem does the pull request solve?
IE sometimes miscalculates the border width of a rotated element resulting in a thin border as shown in #518. Setting a transparent border will fix the issue without affecting semantics or rendering on any other browser.

#### How has this been tested?
Tester with BrowserStack: IE10, IE11 on Windows 7

#### Screenshots (if appropriate):
Before
<img width="310" alt="screen shot 2017-07-10 at 17 33 33" src="https://user-images.githubusercontent.com/788096/28029483-1f1a21fa-6598-11e7-8821-3d63dc822fe0.png">

After
<img width="310" alt="screen shot 2017-07-10 at 17 37 32" src="https://user-images.githubusercontent.com/788096/28029400-de1357a8-6597-11e7-87b9-dfbf8565c79e.png">

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
- I have read the **CONTRIBUTING** document.
