### PR TITLE
Fix 502: Hard error in details.polyfill.js

### DIFF
--- a/assets/javascripts/govuk/details.polyfill.js
+++ b/assets/javascripts/govuk/details.polyfill.js
@@ -116,6 +116,10 @@
       details.__summary = details.getElementsByTagName('summary').item(0)
       details.__content = details.getElementsByTagName('div').item(0)
 
+      if (!details.__summary || !details.__content) {
+        return
+      }
+
       // If the content doesn't have an ID, assign it one now
       // which we'll need for the summary's aria-controls assignment
       if (!details.__content.id) {

--- a/packages/govuk-elements-sass/public/sass/elements/forms/_form-multiple-choice.scss
+++ b/packages/govuk-elements-sass/public/sass/elements/forms/_form-multiple-choice.scss
@@ -87,6 +87,7 @@
     content: "";
     border: solid;
     border-width: 0 0 5px 5px;
+    border-top-color: transparent;
     background: transparent;
     width: 17px;
     height: 7px;


### PR DESCRIPTION
#### What problem does the pull request solve?
The details.polyfill.js script expected `<details>` to contain a `<summary>` and a `<div>` representing the content. If this structure didn't exists the script crashes with a hard error as shown in #502.

As the `<details>` component can be potentially used in other scenarios across the page, if the structure is not followed, the polyfill script will not be executed.

#### How has this been tested?
Tested locally: Latest Safari, Firefox and Chrome on Mac
Tester with BrowserStack: IE11 and Edge15 on Windows.

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
- I have read the **CONTRIBUTING** document.
