### PR TITLE
Upgrade node.js version for Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://govuk-elements.herokuapp.com/",
   "license": "MIT",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8.1.4"
   },
   "dependencies": {
     "body-parser": "^1.14.1",


### PR DESCRIPTION
The Node.js team has announced that a high severity remote Denial of Service (DoS) Constant Hashtable Seeds vulnerability in Node.js versions 4.x through 8.x has been patched in the following versions: 

4.8.4
6.11.1
7.10.1
8.1.4

Use the engines section of package.json to specify the version of Node.js to use on Heroku: 8.1.4.