### PR TITLE
Fix a typo in release docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Update CHANGELOG.md to summarise these changes.
 To see the commits to be summarised in the changelog since the last release, [compare the latest-release branch with master](https://github.com/alphagov/govuk_elements/compare/latest-release...master).
 
 **The second commit:**
-Propose a new version numer in [`VERSION.txt`](https://github.com/alphagov/govuk-elements-sass/blob/master/packages/govuk-elements-sass/VERSION.txt) and update [`package.json`](https://github.com/alphagov/govuk-elements-sass/blob/master/packages/govuk-elements-sass/CHANGELOG.md) with the new version number.
+Propose a new version number in [`VERSION.txt`](https://github.com/alphagov/govuk-elements-sass/blob/master/packages/govuk-elements-sass/VERSION.txt) and update [`package.json`](https://github.com/alphagov/govuk-elements-sass/blob/master/packages/govuk-elements-sass/CHANGELOG.md) with the new version number.
 
 3. Once merged into master a new version will be built:
 


### PR DESCRIPTION
🎉 

#### What problem does the pull request solve?
There was a typo.

#### How has this been tested?
Used my knowledge of the English language to verify that the insertion of a 'b' fixed the typo.

#### Screenshots (if appropriate):
##### Before
<img width="55" alt="screen shot 2017-07-14 at 10 05 54bst" src="https://user-images.githubusercontent.com/121939/28205951-198559a8-687c-11e7-954f-6b1b884bb81c.png">

##### After
<img width="64" alt="screen shot 2017-07-14 at 10 06 03bst" src="https://user-images.githubusercontent.com/121939/28205953-1c38fba0-687c-11e7-9236-9c41a4739764.png">

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
<!--- Delete the lines below that don't apply -->
- My change literally is a change to the documentation.
- I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
