### PR TITLE
Replace postinstall script with Heroku's postbuild script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "pretest": "npm run lint --silent",
     "test": "standard && gulp test",
     "lint": "bundle && bundle exec govuk-lint-sass assets/sass/elements/",
-    "postinstall": "gulp build",
-    "start": "gulp develop"
+    "start": "gulp develop",
+    "heroku-postbuild": "gulp build"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
#### What problem does the pull request solve?

The postinstall script is causing the [npm release of govuk-elements-sass to fail](
https://travis-ci.org/alphagov/govuk_elements/jobs/253564908#L384).

Since [this script was added](https://github.com/alphagov/govuk_elements/commit/8a8867a281c2bfb9a5583b97eb6f1b9ab5e96a39) to build assets for Heroku, instead use
a [Heroku-specific build step](https://devcenter.heroku.com/articles/nodejs-support#heroku-specific-build-steps).

Replace `postinstall` with `heroku-postbuild`, which runs after Heroku installs dependencies.

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
- I have read the **CONTRIBUTING** document.
