### PR TITLE
Make old JAWS recognise disabled buttons

### DIFF
--- a/app/views/guide_buttons.html
+++ b/app/views/guide_buttons.html
@@ -85,12 +85,13 @@
   <ul class="list list-bullet text">
     <li>don’t disable buttons, unless there’s a good reason to</li>
     <li>if you have to disable buttons, make sure they look like you can’t click them (use 50% opacity)</li>
+    <li>use the <code class="code">aria-disabled</code> attribute for older screen readers</li>
     <li>an example of a useful disabled option is a calendar with greyed out days where no bookings are available</li>
     <li>provide another way for the user to continue, add an error message or text to explain why the button is disabled</li>
   </ul>
 
 <div class="example">
-  <button class="button" disabled="disabled">Disabled primary button</button>
+  <button class="button" disabled="disabled" aria-disabled="true">Disabled primary button</button>
 </div>
 
 <pre>

--- a/app/views/snippets/buttons_button_disabled.html
+++ b/app/views/snippets/buttons_button_disabled.html
@@ -1,1 +1,1 @@
-<input class="button" type="submit" value="Save and continue" disabled="disabled">
+<input class="button" type="submit" value="Save and continue" disabled="disabled" aria-disabled="true">


### PR DESCRIPTION
## What problem does the pull request solve?

JAWS 15 and below don't recognise the `disabled` attribute on buttons.
This adds the `aria-disabled` attribute to make disabled buttons compatible with older screen readers.

This does not apply to other `disabled` elements. I also tested the new disabled radio buttons and checkboxes, and they are fine in older JAWS versions without this change.

## How has this been tested?

I tested with JAWS 14, 15 and 17.
JAWS 17 is fine without the change and reads e.g. "Save button - unavailable" but all the others read "Save button" as if it was a normal button, not making it clear that you cannot use it. Adding `aria-disabled` fixes that. It seems redundant but is similar to our practice to add `role="main"` to our `<main>` element to support older browsers.

I couldn't test with JAWS 16 yet. In case that also doesn't support `disabled`, I will update the commit message and this PR accordingly.

## What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

## Has the documentation been updated?
<del>I'm not sure if this needs to be documented?</del>
I have added an item to the page.
