### PR TITLE
Add custom styling for select elements

### DIFF
--- a/app/views/includes/elements_documentation_styles.html
+++ b/app/views/includes/elements_documentation_styles.html
@@ -2,3 +2,4 @@
 <!--[if IE 6]><link href="/public/stylesheets/elements-documentation-ie6.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if IE 7]><link href="/public/stylesheets/elements-documentation-ie7.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if IE 8]><link href="/public/stylesheets/elements-documentation-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
+<!--[if IE 9]><link href="/public/stylesheets/elements-documentation-ie9.css" rel="stylesheet" type="text/css" /><![endif]-->

--- a/app/views/includes/elements_stylesheets.html
+++ b/app/views/includes/elements_stylesheets.html
@@ -2,3 +2,4 @@
 <!--[if IE 6]><link href="/public/stylesheets/govuk-elements-styles-ie6.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if IE 7]><link href="/public/stylesheets/govuk-elements-styles-ie7.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if IE 8]><link href="/public/stylesheets/govuk-elements-styles-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
+<!--[if IE 9]><link href="/public/stylesheets/govuk-elements-styles-ie9.css" rel="stylesheet" type="text/css" /><![endif]-->

--- a/assets/sass/elements-documentation-ie9.scss
+++ b/assets/sass/elements-documentation-ie9.scss
@@ -1,0 +1,4 @@
+$is-ie: true;
+$ie-version: 9;
+
+@import "elements-documentation";

--- a/assets/sass/elements/_forms.scss
+++ b/assets/sass/elements/_forms.scss
@@ -32,12 +32,6 @@ legend {
   }
 }
 
-// Remove margin under textarea in Chrome and FF
-textarea {
-  display: block;
-}
-
-
 // 2. Form wrappers
 // ==========================================================================
 
@@ -87,8 +81,8 @@ textarea {
 // TODO: Amend so there is only one label style
 .form-label,
 .form-label-bold {
-  display: block;
   color: $text-colour;
+  display: block;
   padding-bottom: 2px;
 }
 
@@ -102,15 +96,14 @@ textarea {
 
 // Used for the 'or' in between block label options
 .form-block {
-  float: left;
   clear: left;
-
-  margin-top: -5px;
+  float: left;
   margin-bottom: 5px;
+  margin-top: -5px;
 
   @include media(tablet) {
-    margin-top: 0;
     margin-bottom: 10px;
+    margin-top: 0;
   }
 }
 
@@ -120,10 +113,9 @@ textarea {
 // Form hints and example text are light grey and sit above a form control
 .form-hint {
   @include core-19;
-  display: block;
   color: $secondary-text-colour;
+  display: block;
   font-weight: normal;
-
   margin-top: -2px;
   padding-bottom: 2px;
 }
@@ -142,12 +134,13 @@ textarea {
 .form-control {
   @include box-sizing(border-box);
   @include core-19;
-  width: 100%;
-
-  padding: 5px 4px 4px;
   // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
   // as background-color and color need to always be set together, color should not be set either
   border: 2px solid $text-colour;
+  height: 2em;
+  padding: 5px 4px 4px;
+  vertical-align: middle;
+  width: 100%;
 
   // TODO: Remove 50% width set for tablet and up
   // !! BREAKING CHANGE !!
@@ -167,12 +160,43 @@ textarea.form-control {
 }
 
 textarea.form-control {
+  background-image: none;
+  // Remove margin under textarea in Chrome and FF
+  display: block;
+  height: auto;
   // Disable opacity and background image for Firefox
   opacity: 1;
-  background-image: none;
+}
+
+select.form-control {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAYCAYAAACbU/80AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAIpJREFUeNrEkckNgDAMBBfRkEt0ObRBBdsGXUDgmQfK4XhH2m8czQAAy27R3tsw4Qfe2x8uOO6oYLb6GlOor3GF+swURAOmUJ+RwtEJs9WvTGEYxBXqI1MQAZhCfUQKRzDMVj+TwrAIV6jvSUEkYAr1LSkcyTBb/V+KYfX7xAeusq3sLDtGH3kEGACPWIflNZfhRQAAAABJRU5ErkJggg==');
+  background-position: center right 10px;
+  background-repeat: no-repeat;
+  background-size: 12px;
+  border-radius: 0;
+  padding-right: 30px;
+
+  // Removed fixed height and background when multiple select
+  &[multiple] {
+    background-image: none;
+    height: auto;
+  }
+
+  // Hide the native dropdown arrow in ie10
+  &::-ms-expand {
+    display: none;
+  }
+
+  // You can't hide the native dropdown icon on ie9 so we hide the custom one
+  @include ie(9) {
+    background: none;
+    padding-right: 5px;
+  }
 }
 // scss-lint:enable QualifyingElement
-
 
 // 6. Form control widths
 // ==========================================================================
@@ -234,6 +258,6 @@ textarea.form-control {
 option:active,
 option:checked,
 select:focus::-ms-value {
-  color: $white;
   background-color: $govuk-blue;
+  color: $white;
 }

--- a/assets/sass/govuk-elements-styles-ie9.scss
+++ b/assets/sass/govuk-elements-styles-ie9.scss
@@ -1,0 +1,4 @@
+$is-ie: true;
+$ie-version: 9;
+
+@import "govuk-elements-styles";


### PR DESCRIPTION
#### What problem does the pull request solve?
Overwrites the default browser styling on select elements to make them consistent with other inputs

#### How has this been tested?
Chrome, Safari, Firefox, ie9, ie10, ie11, Edge

#### Screenshots (if appropriate):
#### Before
![screen shot 2017-07-24 at 10 34 01](https://user-images.githubusercontent.com/3071606/28517225-abc010ce-705b-11e7-8cf2-b7e839d382c2.png)

#### After
![screen shot 2017-07-21 at 13 47 17](https://user-images.githubusercontent.com/3071606/28463981-21d7ea90-6e1b-11e7-9473-5a0d1319ba4e.png)
![screen shot 2017-07-21 at 13 47 06](https://user-images.githubusercontent.com/3071606/28463983-21d83a4a-6e1b-11e7-9056-436443e81b12.png)
![screen shot 2017-07-21 at 13 45 35](https://user-images.githubusercontent.com/3071606/28463982-21d85f02-6e1b-11e7-8c6f-88c1dfb5c1aa.png)
![screen shot 2017-07-24 at 15 03 02](https://user-images.githubusercontent.com/3071606/28527057-4de6fbfe-7081-11e7-9629-924e2607cfa0.png)
![screen shot 2017-07-24 at 15 02 39](https://user-images.githubusercontent.com/3071606/28527061-5323b576-7081-11e7-8e87-c8518975087a.png)

#### What type of change is it?
- New feature (non-breaking change which adds functionality)

#### Has the documentation been updated?
- Not required
