### PR TITLE
Remove tabindex from main element

### DIFF
--- a/app/views/examples/example_date.html
+++ b/app/views/examples/example_date.html
@@ -3,7 +3,7 @@
 {% block page_title %}Example: Date — Form elements — GOV.UK elements{% endblock %}
 
 {% block content %}
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   {% include "includes/breadcrumb.html" %}
 

--- a/app/views/examples/example_details_summary.html
+++ b/app/views/examples/example_details_summary.html
@@ -3,7 +3,7 @@
 {% block page_title %}Example: Details summary — Typography — GOV.UK elements{% endblock %}
 
 {% block content %}
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   {% include "includes/breadcrumb.html" %}
 

--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -3,7 +3,7 @@
 {% block page_title %}Example: Form elements — Form elements — GOV.UK elements{% endblock %}
 
 {% block content %}
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   {% include "includes/breadcrumb.html" %}
 

--- a/app/views/examples/example_form_validation_multiple_questions.html
+++ b/app/views/examples/example_form_validation_multiple_questions.html
@@ -3,7 +3,7 @@
 {% block page_title %}Example: Form validation — Errors — GOV.UK elements{% endblock %}
 
 {% block content %}
-<main class="js-error-example" id="content" role="main" tabindex="-1">
+<main class="js-error-example" id="content" role="main">
 
   {% include "includes/breadcrumb.html" %}
 

--- a/app/views/examples/example_form_validation_single_question_radio.html
+++ b/app/views/examples/example_form_validation_single_question_radio.html
@@ -3,7 +3,7 @@
 {% block page_title %}Example: Form validation — Errors — GOV.UK elements{% endblock %}
 
 {% block content %}
-<main class="js-error-example" id="content" role="main" tabindex="-1">
+<main class="js-error-example" id="content" role="main">
 
   {% include "includes/breadcrumb.html" %}
 

--- a/app/views/examples/example_grid_layout.html
+++ b/app/views/examples/example_grid_layout.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block content %}
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   {% include "includes/breadcrumb.html" %}
 

--- a/app/views/examples/example_icons.html
+++ b/app/views/examples/example_icons.html
@@ -3,7 +3,7 @@
 {% block page_title %}Example: Icons — Icons and images — GOV.UK elements{% endblock %}
 
 {% block content %}
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   {% include "includes/breadcrumb.html" %}
 

--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -3,7 +3,7 @@
 {% block page_title %}Example: Radio buttons and checkboxes — Form elements — GOV.UK elements{% endblock %}
 
 {% block content %}
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   {% include "includes/breadcrumb.html" %}
 

--- a/app/views/examples/example_typography.html
+++ b/app/views/examples/example_typography.html
@@ -3,7 +3,7 @@
 {% block page_title %}Example: Typography — Typography — GOV.UK elements{% endblock %}
 
 {% block content %}
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   {% include "includes/breadcrumb.html" %}
 

--- a/app/views/guide_alpha_beta.html
+++ b/app/views/guide_alpha_beta.html
@@ -4,7 +4,7 @@
 
 {% block main_content %}
 
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_buttons.html
+++ b/app/views/guide_buttons.html
@@ -4,7 +4,7 @@
 
 {% block main_content %}
 
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_colour.html
+++ b/app/views/guide_colour.html
@@ -4,7 +4,7 @@
 
 {% block main_content %}
 
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_data.html
+++ b/app/views/guide_data.html
@@ -4,7 +4,7 @@
 
 {% block main_content %}
 
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_errors.html
+++ b/app/views/guide_errors.html
@@ -4,7 +4,7 @@
 
 {% block main_content %}
 
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_form_elements.html
+++ b/app/views/guide_form_elements.html
@@ -4,7 +4,7 @@
 
 {% block main_content %}
 
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_icons_images.html
+++ b/app/views/guide_icons_images.html
@@ -4,7 +4,7 @@
 
 {% block main_content %}
 
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_layout.html
+++ b/app/views/guide_layout.html
@@ -4,7 +4,7 @@
 
 {% block main_content %}
 
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -4,7 +4,7 @@
 
 {% block main_content %}
 
-<main id="content" role="main" tabindex="-1">
+<main id="content" role="main">
 
   <h1 class="heading-xlarge">
     <span class="heading-secondary">GOV.UK elements</span>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block main_content %}
-<main class="elements-index" id="content" role="main" tabindex="-1">
+<main class="elements-index" id="content" role="main">
 
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/assets/sass/elements/_layout.scss
+++ b/assets/sass/elements/_layout.scss
@@ -14,9 +14,6 @@
   @include media(desktop) {
     padding-bottom: $gutter * 3;
   }
-  // Pressing enter when focus is on the skiplink sets focus on the #content area
-  // Remove the blue outline
-  outline: none;
 }
 
 

--- a/assets/sass/elements/_layout.scss
+++ b/assets/sass/elements/_layout.scss
@@ -14,6 +14,11 @@
   @include media(desktop) {
     padding-bottom: $gutter * 3;
   }
+
+  // DEPRECATED: Tabindex on #content
+  // https://github.com/alphagov/govuk_elements/pull/534
+  // We no longer recommend using tabindex on #content
+  outline: none;
 }
 
 


### PR DESCRIPTION
Reverts https://github.com/alphagov/govuk_elements/pull/225
See: https://github.com/alphagov/govuk_template/pull/321

Putting tabindex on the `<main>` element causes different problems:
* Some apps will display the browser's default focus styles around the main element
* When clicking anywhere in the page focus will return back to the top

Consider a user interacting with an input field who clicks away from it to remove
the focus style. Should they then hit tab they will be taken to the top of the page.

The [linked to browser bug](https://bugs.chromium.org/p/chromium/issues/detail?id=37721) was fixed in Apr. Testing on Safari 10.1.1 it works with VoiceOver on desktop. Testing on iOS 10.2.1 it works in mobile Safari with VoiceOver on.

More context around the issue:
https://github.com/twbs/bootstrap/issues/20732

## Example problem
GIF showing focus styles and tab order problem on Registers:

![focus-order-issue-tabindex-main](https://user-images.githubusercontent.com/319055/28467721-b49b1ebc-6e28-11e7-8b52-fe163bedba8f.gif)
