### PR TITLE
Apply black text colour to link-back on :focus

### DIFF
--- a/assets/sass/elements/_elements-typography.scss
+++ b/assets/sass/elements/_elements-typography.scss
@@ -201,9 +201,11 @@ p,
   &:link,
   &:visited,
   &:hover,
+  a#{&}:focus,
   &:active {
     color: $black;
   }
+
 
   text-decoration: none;
   border-bottom: 1px solid $black;
@@ -234,7 +236,6 @@ p,
   }
 
 }
-
 // Code styles
 .code {
   color: $text-colour;


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

#### What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #540

#### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Supported browsers

#### Screenshots (if appropriate):
![screen shot 2017-08-08 at 13 37 13](https://user-images.githubusercontent.com/3758555/29072225-baff7d10-7c3e-11e7-872d-262c9ed0d882.png)

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
<!--- Delete the lines below that don't apply -->
- I have read the **CONTRIBUTING** document.
