### PR TITLE
Adjust the icon position for legal text

### DIFF
--- a/assets/sass/elements/_elements-typography.scss
+++ b/assets/sass/elements/_elements-typography.scss
@@ -286,8 +286,12 @@ hr {
   .icon {
     position: absolute;
     left: 0;
-    top: 50%;
-    margin-top: -17px; // Half the height of the important icon
+    top: 0;
+
+    margin-top: -8px;   // Adjust the position of the icon, so text aligns with the center of the icon
+    @include media(tablet) {
+      margin-top: -5px; // Reduce the adjustment for 19px text
+    }
   }
 
   strong {


### PR DESCRIPTION
### What problem does the pull request solve?

Ensure that the icon sits aligned with the middle of the first line of
text, rather than vertically centred for the entire block of text.

Adjust the position for larger viewports, when the text size increases
from 16px to 19px.

### Screenshots

#### Before:

![legal text - before - typography gov uk elements](https://user-images.githubusercontent.com/417754/29310927-9dea4a84-81a7-11e7-8010-5deaf21870cb.png)

#### After: 

![legal text - after - typography gov uk elements](https://user-images.githubusercontent.com/417754/29310917-968c84c8-81a7-11e7-8ded-3dee51611841.png)

---

For smaller viewports when the text wraps:

![small screen - typography gov uk elements](https://user-images.githubusercontent.com/417754/29310941-aa4106d8-81a7-11e7-8a5c-a86d487d8966.png)

---

For larger viewports with a single line of text:

![wide screen - typography gov uk elements](https://user-images.githubusercontent.com/417754/29310988-e1ad6be8-81a7-11e7-8eca-70c76882d2bf.png)



