### PR TITLE
Ensure documentation styles don't override examples

### DIFF
--- a/assets/sass/elements-documentation.scss
+++ b/assets/sass/elements-documentation.scss
@@ -43,8 +43,8 @@
   }
 }
 
-// Increase spacing above headings
-.heading-xlarge {
+// Increase spacing above GOV.UK elements page headings
+main > .heading-xlarge {
   @include media(tablet) {
     margin-top: em(60, 48);
     margin-bottom: em(30, 48);


### PR DESCRIPTION
Use a child combinator to ensure that only headings using the
`.heading-xlarge` class - page headings in GOV.UK elements - get
larger top margins and smaller bottom margins.

This margin was affecting the typography example, which shows an
example of using the `.heading-xlarge` class.

### Screenshots

#### Before:
![before - typography gov uk elements](https://user-images.githubusercontent.com/417754/29312448-427967c4-81ad-11e7-8b6f-684fe400a8d1.png)

---
#### After: 
![after - typography gov uk elements](https://user-images.githubusercontent.com/417754/29312444-3eec75e2-81ad-11e7-9499-91ff3c04c6fa.png)

---

### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)