### PR TITLE
Remove "Example service name" from the confirmation page

### DIFF
--- a/app/views/guide_colour.html
+++ b/app/views/guide_colour.html
@@ -371,14 +371,10 @@
     <div class="grid-row">
       <div class="column-two-thirds">
 
-        <h1 class="heading-xlarge">
-          Example service name
-        </h1>
-
         <div class="govuk-box-highlight">
-          <h2 class="heading-xlarge">
+          <h1 class="heading-xlarge">
             Application complete
-          </h2>
+          </h1>
           <p class="font-large">
             Your reference number is <br>
             <strong class="bold">HDJ2123F</strong>


### PR DESCRIPTION
The main heading for the page is “Application complete”.

#### Before:
![before - colour gov uk elements](https://user-images.githubusercontent.com/417754/29316913-a6166980-81c1-11e7-882f-e7b38a6743bc.png)

#### After:
![after - colour gov uk elements](https://user-images.githubusercontent.com/417754/29316910-a22e639a-81c1-11e7-8c0d-c7851840bb5b.png)

