### PR TITLE
Document invalid HTML in date pattern.

### DIFF
--- a/app/views/examples/example_date.html
+++ b/app/views/examples/example_date.html
@@ -97,13 +97,8 @@
     </div>
     <div class="panel panel-border-wide text">
       <p>
-        A HTML validator will produce the following error for this date pattern: "Attribute pattern is only allowed when the input type is email, password, search, tel, text, or url."
-      </p>
-      <p>
-        This is a known issue. The pattern attribute is needed to force numeric keypads on iOS devices. Type=number alone does not force the numeric keypad.
-      </p>
-      <p>
-        <a href="http://bradfrost.com/blog/mobile/better-numerical-inputs-for-mobile-forms/" target="_blank">Take a look at this article</a> which explains the issue in more detail.
+        Note: validators will identify the <span class="bold">pattern</span> attribute as not being valid for inputs
+        where the <span class="bold">type</span> attribute is <i>number</i>. It is added to <a href="http://bradfrost.com/blog/mobile/better-numerical-inputs-for-mobile-forms" target="_blank">force numeric keypads on iOS devices</a>.
       </p>
     </div>
   </div>

--- a/app/views/examples/example_date.html
+++ b/app/views/examples/example_date.html
@@ -97,8 +97,7 @@
     </div>
     <div class="panel panel-border-wide text">
       <p>
-        Note: validators will identify the <span class="bold">pattern</span> attribute as not being valid for inputs
-        where the <span class="bold">type</span> attribute is <i>number</i>. It is added to <a href="http://bradfrost.com/blog/mobile/better-numerical-inputs-for-mobile-forms" target="_blank">force numeric keypads on iOS devices</a>.
+        Note: The <code class="code">pattern</code> attribute is not valid HTML for inputs where the <code class="code">type</code> attribute is <code class="code">number</code>. It is added deliberately to <a href="http://bradfrost.com/blog/mobile/better-numerical-inputs-for-mobile-forms">force numeric keypads on iOS devices</a>.
       </p>
     </div>
   </div>

--- a/app/views/examples/example_date.html
+++ b/app/views/examples/example_date.html
@@ -95,6 +95,17 @@
       </div>
 
     </div>
+    <div class="panel panel-border-wide text">
+      <p>
+        A HTML validator will produce the following error for this date pattern: "Attribute pattern is only allowed when the input type is email, password, search, tel, text, or url."
+      </p>
+      <p>
+        This is a known issue. The pattern attribute is needed to force numeric keypads on iOS devices. Type=number alone does not force the numeric keypad.
+      </p>
+      <p>
+        <a href="http://bradfrost.com/blog/mobile/better-numerical-inputs-for-mobile-forms/" target="_blank">Take a look at this article</a> which explains the issue in more detail.
+      </p>
+    </div>
   </div>
 
 </main><!-- /#content -->

--- a/app/views/examples/example_date.html
+++ b/app/views/examples/example_date.html
@@ -95,11 +95,13 @@
       </div>
 
     </div>
-    <div class="panel panel-border-wide text">
-      <p>
-        Note: The <code class="code">pattern</code> attribute is not valid HTML for inputs where the <code class="code">type</code> attribute is <code class="code">number</code>. It is added deliberately to <a href="http://bradfrost.com/blog/mobile/better-numerical-inputs-for-mobile-forms">force numeric keypads on iOS devices</a>.
-      </p>
-    </div>
+    <div class="column-two-thirds">
+      <div class="panel panel-border-wide text">
+        <p>
+          Note: The <code class="code">pattern</code> attribute is not valid HTML for inputs where the <code class="code">type</code> attribute is <code class="code">number</code>. It is added deliberately to <a href="http://bradfrost.com/blog/mobile/better-numerical-inputs-for-mobile-forms">force numeric keypads on iOS devices</a>.
+        </p>
+      </div>
+    </div>  
   </div>
 
 </main><!-- /#content -->


### PR DESCRIPTION
This documents the reason for invalid HTML in the date pattern:
A HTML validator will produce the following error for this date pattern: "Attribute pattern is only allowed when the input type is email, password, search, tel, text, or url." This is a known issue. The pattern attribute is needed to force numeric keypads on iOS devices. Type=number alone does not force the numeric keypad. Take a look at [this article](http://bradfrost.com/blog/mobile/better-numerical-inputs-for-mobile-forms/) which explains the issue in more detail.

@selfthinker: do you know if this has been reported to W3?  

Fixes #551 

Tested in Chrome/FF/Safari.

#### What type of change is it?
- Added an explanation to a view using existing elements.
- I have read the **CONTRIBUTING** document.
