### PR TITLE
Remove the heroku deploy build stage from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,25 +13,17 @@ jobs:
         - set -e
         - ./scripts/check-lockfile.sh
         - yarn test
-    - stage: heroku deploy
-      script: echo "Deploying to Heroku ..."
-      deploy:
-        - provider: heroku    # Deploy master to Heroku - production (http://govuk-elements.herokuapp.com/)
-          api_key:
-            secure: nQCOBk2EnuJ0yaC0cO2RabfLlF+3WiZ4MrLLBPt3l+fNQO69KcJZu59Npbt45f/ip6Dv8cEGxdzSqzNsPu/XB+fmyAZd1bml0u7JMKWNQeVLKddoM+A1ETFSyXHoM/Ra3Qw8+2XS/ZJNTAD7BGibSh8SvzYdg9fy9kCN77Sn9Ro=
-          app: govuk-elements
-          on: master
-        - provider: heroku    # Deploy master to Heroku - review (http://govuk-elements-review.herokuapp.com/)
-          api_key:
-            secure: nQCOBk2EnuJ0yaC0cO2RabfLlF+3WiZ4MrLLBPt3l+fNQO69KcJZu59Npbt45f/ip6Dv8cEGxdzSqzNsPu/XB+fmyAZd1bml0u7JMKWNQeVLKddoM+A1ETFSyXHoM/Ra3Qw8+2XS/ZJNTAD7BGibSh8SvzYdg9fy9kCN77Sn9Ro=
-          app: govuk-elements-review
-          on: master
     - stage: create release
       script:
       # Ensure Travis aborts without creating a release if version hasn't changed
       - set -e
       - ./scripts/check-release-version.sh
       deploy:
+        # Automatic deploys are enabled in Heroku for this app
+        # Every push to master will deploy a new version of this app. Deploys happen automatically.
+        # Heroku will wait for CI to pass before deploying.
+        # Production (http://govuk-elements.herokuapp.com/)
+        # Review apps (http://govuk-elements-review.herokuapp.com/)
         - provider: script    # (If version.txt is updated) - create a new tag and push to Github, update the latest-release branch
           script: ./scripts/create-release.sh
           on: master


### PR DESCRIPTION
This section is no longer required now that automatic deploys are enabled in Heroku for this app.

Add a comment to travis.yml to explain how this app is deployed:
Every push to master will deploy a new version of this app. Deploys
happen automatically. Heroku will wait for CI to pass before deploying.

#### Screenshots (if appropriate):

![govuk elements github heroku](https://user-images.githubusercontent.com/417754/30921228-d9d06606-a39d-11e7-8064-5a7193879d86.png)