### PR TITLE
Fix label's `for` not matching input's `id`

### DIFF
--- a/app/views/snippets/form_input_sizes.html
+++ b/app/views/snippets/form_input_sizes.html
@@ -32,7 +32,7 @@
   </div>
 
   <div class="form-group">
-    <label class="form-label" for="form-label">
+    <label class="form-label" for="form-control-2-3">
       Input with class form-control-2-3 (66% width)
     </label>
     <input class="form-control form-control-2-3" id="form-control-2-3" type="text" name="form-control-2-3">


### PR DESCRIPTION
Very quick fix. The "Input with class form-control-2-3 (66% width)" label on the [form elements example page](https://govuk-elements.herokuapp.com/form-elements/example-form-elements/) didn't match the input field due to a typo on the `for` attribute.