### PR TITLE
Replace 'lorem ipsum' with English

### DIFF
--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -56,7 +56,7 @@
   </ul>
 
 <div class="example">
-  {% include "snippets/typography_headings_example.html" %}
+  {% include "snippets/typography_headings.html" %}
 </div>
 
 <pre>
@@ -78,7 +78,7 @@
 
 <div class="example">
   <div class="text">
-    {% include "snippets/typography_lead_paragraph_example.html" %}
+    {% include "snippets/typography_lead_paragraph.html" %}
   </div>
 </div>
 
@@ -104,7 +104,7 @@
 
 <div class="example">
   <div class="text">
-    {% include "snippets/typography_paragraphs_example.html" %}
+    {% include "snippets/typography_paragraphs.html" %}
   </div>
 </div>
 

--- a/app/views/snippets/typography_headings_example.html
+++ b/app/views/snippets/typography_headings_example.html
@@ -1,7 +1,0 @@
-<h1 class="heading-xlarge">A <em class="highlight">48px Bold</em> heading</h1>
-
-<h2 class="heading-large">A <em class="highlight">36px Bold</em> heading</h2>
-
-<h3 class="heading-medium">A <em class="highlight">24px Bold</em> heading</h3>
-
-<h4 class="heading-small">A <em class="highlight">19px Bold</em> heading</h4>

--- a/app/views/snippets/typography_lead_paragraph.html
+++ b/app/views/snippets/typography_lead_paragraph.html
@@ -1,7 +1,7 @@
 <p class="lede">
-  A 24px lead paragraph, maecenas sed diam eget risus varius blandit sit amet non magna.
+  A 24px lead paragraph with some longer text so that you can see how it wraps.
 </p>
 
 <p>
-  A 19px body copy paragraph, maecenas sed diam eget risus varius blandit sit amet non magna.
+  A 19px body copy paragraph with some longer text so that you can see how it wraps.
 </p>

--- a/app/views/snippets/typography_lead_paragraph_example.html
+++ b/app/views/snippets/typography_lead_paragraph_example.html
@@ -1,7 +1,0 @@
-<p class="lede">
-  A <em class="highlight">24px</em> lead paragraph, maecenas sed diam eget risus varius blandit sit amet non magna.
-</p>
-
-<p>
-  A <em class="highlight">19px</em> body copy paragraph, maecenas sed diam eget risus varius blandit sit amet non magna.
-</p>

--- a/app/views/snippets/typography_links.html
+++ b/app/views/snippets/typography_links.html
@@ -3,7 +3,7 @@
 </p>
 
 <p>
-  <a href="#">A 19px body copy link</a>. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
+  <a href="#">A 19px body copy link</a> with surrounding text which shows the link in more context.
 </p>
 
 <a href="#" class="link-back">Back</a>

--- a/app/views/snippets/typography_lists.html
+++ b/app/views/snippets/typography_lists.html
@@ -1,19 +1,18 @@
 <ul class="list list-bullet">
   <li>here is a bulleted list</li>
-  <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
-  <li>vestibulum id ligula porta felis euismod semper</li>
-  <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
+  <li>this is another item in the list</li>
+  <li>and another item with a bit more text</li>
 </ul>
 
 <ol class="list list-number">
-  <li>This is a numbered list.</li>
-  <li>This is the second step in a numbered list.</li>
-  <li>The third step is to make sure each item is a full sentence ending with a full stop.</li>
+  <li>Understand that this is a numbered list.</li>
+  <li>Follow the second step in this numbered list.</li>
+  <li>Make sure each item is a full sentence ending with a full stop.</li>
 </ol>
 
 <ul class="list">
   <li><a href="#">Related link</a></li>
-  <li><a href="#">Related link</a></li>
-  <li><a href="#">Related link</a></li>
+  <li><a href="#">Another related link</a></li>
+  <li><a href="#">And another link</a></li>
   <li><a href="#" class="bold-xsmall">More</a></li>
 </ul>

--- a/app/views/snippets/typography_paragraphs.html
+++ b/app/views/snippets/typography_paragraphs.html
@@ -1,7 +1,7 @@
 <p>
-  A 19px body copy paragraph, maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla.
+  A 19px body copy paragraph. This includes even more text to give a good representation of a more average length paragraph. That way you can see more than one line wrapping.
 </p>
 
 <p class="font-xsmall">
-  A 16px supporting text paragraph, maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla.
+  A 16px supporting text paragraph.  This includes even more text to give a good representation of a more average length paragraph. That way you can see more than one line wrapping.
 </p>

--- a/app/views/snippets/typography_paragraphs_example.html
+++ b/app/views/snippets/typography_paragraphs_example.html
@@ -1,7 +1,0 @@
-<p>
-  A <em class="highlight">19px</em> body copy paragraph. Maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla.
-</p>
-
-<p class="font-xsmall">
-  A <em class="highlight">16px</em> supporting text paragraph. Maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla.
-</p>


### PR DESCRIPTION
We currently use filler text in some instances on the typography page. This replaces that with English. It also improves the copy of the various list items.

Because some of the text was duplicated in two files each, I also added a filter to use just one of the files instead of two.
Unfortunately a filter block would not allow to chain multiple filters (e.g. `{% filter replace('foo', '') | replace('bar', '') %}`), so I needed to do it in a bit of a roundabout way.