### PR TITLE
Add a hover state for radios and checkboxes

### DIFF
--- a/assets/sass/elements/forms/_form-multiple-choice.scss
+++ b/assets/sass/elements/forms/_form-multiple-choice.scss
@@ -111,6 +111,17 @@
     @include box-shadow(0 0 0 3px $focus-colour);
   }
 
+  // Hover state
+  input:not(:checked):not(:disabled):hover + label::after {
+    @include opacity(0.15);
+  }
+  // hide the hover state in iOS9.1+ / mobile Chrome
+  @media (hover: none) {
+    input:not(:checked):not(:disabled):hover + label::after {
+      @include opacity(0);
+    }
+  }
+
   // Selected state
   input:checked + label::after {
     @include opacity(1);


### PR DESCRIPTION
This gives radio buttons and checkboxes a faint grey hover state, except in the following situations:

1. Where the input is already selected
2. Where the input is disabled
3. Where the user is on a mobile device (Android Chrome, iOS9.1+)

We originally had this as part of the initial custom radios / checkboxes work, but it was removed. The `@media hover` block wasn’t supported in iOS 9.0 and lower, and without that support ghost checkmarks would remain in place after unchecking them. This was decided to be too off-putting to warrant inclusion. Now that GOV.UK’s browsers and devices page suggests that iOS 9.3+ can be considered a reasonable minimum, we can consider adding hover back in again as a usability enhancement.

Fixes https://github.com/alphagov/govuk_elements/issues/357 .

#### How has this been tested?
Tested in latest Firefox, Chrome and iOS11 (Simulator). There’s nothing particularly complicated here, and I can’t see any particular problems with support for this. Firefox for Android, IE mobile and iOS9.0 and lower don’t support the `hover` media query, so unchecking a checkbox will leave a ghost checkmark in place until another click happens elsewhere in the page. The usage of these browsers will need to be balanced against the usability enhancement for other browsers. IE9+ should support all the main CSS here without problem.

#### Screenshots (if appropriate):

This is the behaviour with the patch:
![An image showing the hover behaviour described above.](https://user-images.githubusercontent.com/7414/32135563-7ffcb018-bc01-11e7-88ba-fd66353355f2.gif)

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
- New feature (non-breaking change which adds functionality)
