### PR TITLE
Move Google Tag Manager snippet to <head>. Add <noscript> snippet.

### DIFF
--- a/app/views/includes/elements_tracking_body.html
+++ b/app/views/includes/elements_tracking_body.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MNK4G3"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/app/views/includes/elements_tracking_head.html
+++ b/app/views/includes/elements_tracking_head.html
@@ -1,9 +1,7 @@
 <!-- Google Tag Manager -->
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-MNK4G3"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-MNK4G3');</script>
 <!-- End Google Tag Manager -->

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -1,13 +1,14 @@
 {% extends "govuk_template.html" %}
 
 {% block head %}
+  {% include "includes/elements_tracking_head.html" %}
   {% include "includes/elements_stylesheets.html" %}
   {% include "includes/elements_documentation_styles.html" %}
   {% include "includes/vendor/prism.html" %}
 {% endblock %}
 
 {% block body_start %}
-  {% include "includes/elements_tracking.html" %}
+  {% include "includes/elements_tracking_body.html" %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
#### What problem does the pull request solve?
Google Tag Manager is currently not tracking correctly as the snippet is not placed in `head`. This issue was reported by Maria Lopez, a performance analyst on the Design System team.

According to the [docs](https://developers.google.com/tag-manager/quickstart), the snippet should be placed as close to the opening `head` tag as possible, and the `noscript` snippet be placed immediately after the opening `body` tag.

This change moves the snippet to `head` and adds a `noscript` snippet. 

The snippets have been copy pasted from the Google Tag Manager account for GOV.UK Elements and verified to be correct by Maria.

#### How has this been tested?
By inspecting the source and verifying that the snippets are now placed appropriately. 

Once merged into master, I will confirm with Maria that Google Tag Manager is tracking correctly. There is usually a delay of up to 24 hours before changes to tracking code take effect.

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
- I have read the **CONTRIBUTING** document.
