### PR TITLE
[DO NOT MERge] Add txt file to reclaim Google Analytics account

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -254,5 +254,10 @@ module.exports = {
       var pageName = 'Alpha and beta banners'
       res.render('guide_alpha_beta', { 'page_name': pageName })
     })
+
+    // temporary access to analytics txt file
+    app.get('/analytics.txt', function (req, res) {
+      res.sendFile('/analytics.txt', { root: 'public' })
+    })
   }
 }

--- a/assets/analytics.txt
+++ b/assets/analytics.txt
@@ -1,0 +1,1 @@
+﻿GooGhywoiu9839t543j0s7543uw1.  Please add maria.lopez@digital.cabinet-office.gov.uk to GA account UA-49672752 with “Manage Users and Edit” permissions - date 6/12/2017.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,6 +46,14 @@ gulp.task('images', () => {
     .pipe(gulp.dest(paths.publicImg))
 })
 
+// ---------------------------------------
+// Copies .txt file to /public/
+// ---------------------------------------
+gulp.task('copy-txt-file', () => {
+  return gulp.src('assets/*.txt')
+    .pipe(gulp.dest(paths.public))
+})
+
 // Scripts build task ---------------------
 // Copies JavaScript to /public/javascripts
 // ---------------------------------------
@@ -59,7 +67,7 @@ gulp.task('scripts', () => {
 // ---------------------------------------
 
 gulp.task('build', cb => {
-  runsequence('clean', ['styles', 'images', 'scripts'], cb)
+  runsequence('clean', ['styles', 'images', 'scripts', 'copy-txt-file'], cb)
 })
 
 // Server task --------------------------


### PR DESCRIPTION
#### What problem does the pull request solve?
We need to reclaim a google analytics account. To do this a file needs
to be added to the root of the site.

As we can't direct upload files to heroku and our `public/` folder isnt
checked in, so this is a workaround.

Once the account is verified, the file and amended tasks will be
deleted.

#### How has this been tested?
Locally with the `heroku-postbuild` task that runs `gulp build` task

#### What type of change is it?
- New feature (non-breaking change which adds functionality)

[Design System Trello ticket](https://trello.com/c/STpEjt79/459-add-txt-file-to-elements-so-we-can-claim-the-account)
