### PR TITLE
Specific layout fixes for iPhone X to allow full width content with the notch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,11 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-16
 
 DEPENDENCIES
   govuk-lint (= 0.7.0)
   sass (= 3.4.15)
+
+BUNDLED WITH
+   1.16.0.pre.3

--- a/assets/sass/_elements.scss
+++ b/assets/sass/_elements.scss
@@ -12,6 +12,7 @@
 
 // Objects (unstyled design patterns)
 @import "elements/layout";                        // Main content container. Grid layout - rows and column widths
+@import "elements/iphone-x-notch-layout";
 
 // Components (chunks of UI)
 @import "elements/elements-typography";           // Typography

--- a/assets/sass/elements/_iphone-x-notch-layout.scss
+++ b/assets/sass/elements/_iphone-x-notch-layout.scss
@@ -5,7 +5,21 @@
   // scss-lint:disable IdSelector
   // scss-lint:disable QualifyingElement
   // scss-lint:disable DuplicateProperty
-  header#global-header,
+  header#global-header {
+    box-sizing: border-box;
+    // iOS 11
+    padding-left: constant(safe-area-inset-left);
+    padding-right: constant(safe-area-inset-right);
+    // iOS 11.2+
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
+
+  header#global-header .header-wrapper {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   #wrapper,
   .site-wrapper,
   footer#footer,

--- a/assets/sass/elements/_iphone-x-notch-layout.scss
+++ b/assets/sass/elements/_iphone-x-notch-layout.scss
@@ -1,30 +1,29 @@
-@media only screen 
-and (device-width : 375px) 
-and (device-height : 812px)
-and (orientation: landscape) 
-and (-webkit-device-pixel-ratio : 3)  {
-  
+// Checks for iPhone X landscape mode
+@media only screen and (device-width : 375px) and (device-height : 812px)and (orientation: landscape) and (-webkit-device-pixel-ratio : 3)  {
+  // Only apply styles to the main layout wrapper elements
+  // scss-lint:disable Comment
+  // scss-lint:disable IdSelector
+  // scss-lint:disable QualifyingElement
+  // scss-lint:disable DuplicateProperty
   header#global-header,
-  #wrapper, .site-wrapper,
+  #wrapper,
+  .site-wrapper,
   footer#footer,
   #global-app-error {
-    /* iOS 11 */
+    // iOS 11
     padding-left: calc(constant(safe-area-inset-left) - 30px);
     padding-right: calc(constant(safe-area-inset-right) - 30px);
-    
-    /* iOS 11.2+ */
+    // iOS 11.2+
     padding-left: calc(env(safe-area-inset-left) - 30px);
     padding-right: calc(env(safe-area-inset-right) - 30px);
   }
 
   #global-header-bar {
-    /* iOS 11 */
+    //iOS 11
     margin-left: constant(safe-area-inset-left);
     margin-right: constant(safe-area-inset-right);
-    
-    /* iOS 11.2+ */
+    // iOS 11.2+
     margin-left: env(safe-area-inset-left);
     margin-right: env(safe-area-inset-right);
   }
-
 }

--- a/assets/sass/elements/_iphone-x-notch-layout.scss
+++ b/assets/sass/elements/_iphone-x-notch-layout.scss
@@ -1,0 +1,30 @@
+@media only screen 
+and (device-width : 375px) 
+and (device-height : 812px)
+and (orientation: landscape) 
+and (-webkit-device-pixel-ratio : 3)  {
+  
+  header#global-header,
+  #wrapper, .site-wrapper,
+  footer#footer,
+  #global-app-error {
+    /* iOS 11 */
+    padding-left: calc(constant(safe-area-inset-left) - 30px);
+    padding-right: calc(constant(safe-area-inset-right) - 30px);
+    
+    /* iOS 11.2+ */
+    padding-left: calc(env(safe-area-inset-left) - 30px);
+    padding-right: calc(env(safe-area-inset-right) - 30px);
+  }
+
+  #global-header-bar {
+    /* iOS 11 */
+    margin-left: constant(safe-area-inset-left);
+    margin-right: constant(safe-area-inset-right);
+    
+    /* iOS 11.2+ */
+    margin-left: env(safe-area-inset-left);
+    margin-right: env(safe-area-inset-right);
+  }
+
+}


### PR DESCRIPTION
#### What problem does the pull request solve?
The change is required to allow for a better user experience on the iPhone X. Since the new iPhone X has a notch at the top, on landscape mode the page content is scaled down by default. This fix will allow the content to be full width but still prevent the iPhone X notch from overlapping the content. This is the recommended method to use by Apple.

#### How has this been tested?

- I added a specific file to deal with all the new changes for the iPhone X
- The new fixes will rely on the media queries to check for iPhone X landscape mode
- New constants provided by Apple allow to check wether the content is within the same visible area, which will prevent the iPhone X notch from overlapping the content

##### Testing
I have tested this with an iPhone X on iOS 11 and 11.2. This is the only device that requires this fix. It will not affect any other device.

#### Screenshots (if appropriate):

##### Before
![iphone-x-before](https://user-images.githubusercontent.com/15384037/33882823-5ecc3032-df31-11e7-9855-aea7ebd1513d.gif)

##### After
![iphone-x-after](https://user-images.githubusercontent.com/15384037/33882809-555c8ee8-df31-11e7-9161-a8605f8c5b02.gif)


#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
- Does not require any documentation changes.

#### Dependencies
- This change required an update to the main govuk template layout file.
- I have made this change and will make a pull request on the govuk_template_jinja repo.
- EDIT: I have now made the pull request (https://github.com/alphagov/govuk_template_jinja/pull/3).

It requires the meta viewport tag to include the viewport attribute, **viewport-fit=cover**, which will allow iPhone X to not use the default behaviour. It will also be ignored on other devices.
```html
<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
```