### PR TITLE
Deprecate inset text for highlighting important text

### DIFF
--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -27,9 +27,9 @@
         <li><a href="#typography-body-copy">Body copy</a></li>
         <li><a href="#typography-links">Links</a></li>
         <li><a href="#typography-lists">Lists</a></li>
-        <li><a href="#typography-inset-text">Inset text</a></li>
         <li><a href="#typography-warning-text">Warning text</a></li>
         <li><a href="#typography-hidden-text">Hidden text (progressive disclosure)</a></li>
+        <li><a href="#typography-inset-text">Inset text</a></li>
         <li><a href="#examples">Examples</a></li>
       </ul>
     </div>
@@ -157,25 +157,6 @@
 </code>
 </pre>
 
-  <h3 class="heading-medium" id="typography-inset-text">Inset text</h3>
-  <p class="text">
-    Use bordered inset text to draw attention to important content on the page.
-  </p>
-
-<div class="example">
-  <div class="text">
-    {% include "snippets/typography_inset_text.html" %}
-  </div>
-</div>
-
-<pre>
-<code class="language-markup">
-  {% filter escape %}
-    {% include "snippets/typography_inset_text.html" %}
-  {% endfilter %}
-</code>
-</pre>
-
   <h3 class="heading-medium" id="typography-warning-text">Warning text</h3>
   <p class="text">
     Use bold text with an exclamation icon to warn people about something important, for example if there are legal consequences like a fine or prison sentence.
@@ -231,6 +212,28 @@
       <a href="/typography/example-details-summary/">Take a look at example page</a> which demonstrates conditionally revealing information, using the HTML5 details and summary elements.
     </p>
   </div>
+
+  <h3 class="heading-medium" id="typography-inset-text">Inset text</h3>
+  <p class="text">
+    Use this bordered inset text to show something is related to the element above it and was revealed by it. This is used for revealing content in <a href="#typography-hidden-text">hidden text</a> and <a href="/form-elements/#form-toggle-content">form elements</a>.
+  </p>
+  <p class="text">
+    Don't use it to highlight important content. There should only be one way to draw attention to text on the page with the <a href="#typography-warning-text">warning text</a> and it should be done sparingly.
+  </p>
+
+<div class="example">
+  <div class="text">
+    {% include "snippets/typography_inset_text.html" %}
+  </div>
+</div>
+
+<pre>
+<code class="language-markup">
+  {% filter escape %}
+    {% include "snippets/typography_inset_text.html" %}
+  {% endfilter %}
+</code>
+</pre>
 
 
   <h3 class="heading-medium" id="examples">Examples</h3>


### PR DESCRIPTION
This is about consolidating what is currently called ["legal text"](https://govuk-elements.herokuapp.com/typography/#typography-legal-text) and ["inset text"](https://govuk-elements.herokuapp.com/typography/#typography-inset-text).

This is a follow-up to the discussion on #564 and discussions I had with @timpaul and @stephengill separately.

## What problem does the pull request solve?

Having two very different ways to highlight important text (with "legal text" and "inset text") is confusing. Everything on a page should be important, and when something is especially important, there shouldn't be more than one way to highlight it. There is also evidence that inset text
is perceived as less important (see hmrc/design-patterns#133) and therefore often not read by users.

This still keeps the styling because it is also used for the very different purpose of showing revealed content. It only discourages the use of it.

## Screenshots

### Before

![](https://user-images.githubusercontent.com/108893/33942084-c003d1f8-e00c-11e7-8827-64ac45bef959.png)

### After

![](https://user-images.githubusercontent.com/108893/34778431-387cf7ea-f615-11e7-8638-61c1ea06f283.png)


## Has the documentation been updated?

Yes, this change is mostly about the documentation.