### PR TITLE
Don't highlight text within documentation

### DIFF
--- a/app/views/examples/_form_validation_implementation_advice.html
+++ b/app/views/examples/_form_validation_implementation_advice.html
@@ -9,25 +9,16 @@
     show an error summary at the top of the page
   </li>
   <li>
-    move keyboard focus to the start of the summary
-    <span class="panel panel-border-narrow">
-      to move keyboard focus, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
-    </span>
+    to move keyboard focus to the start of the summary, put <code>tabindex="-1"</code> on the containing div and use <code>obj.focus()</code>
   </li>
   <li>
-    ensure that the summary is announced to as many screen readers as possible
-    <span class="panel panel-border-narrow">
-      use <code>role="alert"</code> on the containing <code>div</code>
-    </span>
+    to ensure that the summary is announced to as many screen readers as possible use <code>role="alert"</code> on the containing <code>div</code>
   </li>
   <li>
     use a heading at the top of the summary
   </li>
   <li>
-    associate the heading with the summary box
-    <span class="panel panel-border-narrow">
-      use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
-    </span>
+    to associate the heading with the summary box use the ARIA attribute <code>aria-labelledby</code> on the containing <code>div</code>, so that screen readers will automatically announce the heading as soon as focus is moved to the div
   </li>
   <li>
     link from the error list in the summary to the fields with errors

--- a/app/views/examples/example_date.html
+++ b/app/views/examples/example_date.html
@@ -94,14 +94,10 @@
         </fieldset>
       </div>
 
+      <p class="text">
+        Note: The <code class="code">pattern</code> attribute is not valid HTML for inputs where the <code class="code">type</code> attribute is <code class="code">number</code>. It is added deliberately to <a href="http://bradfrost.com/blog/mobile/better-numerical-inputs-for-mobile-forms">force numeric keypads on iOS devices</a>.
+      </p>
     </div>
-    <div class="column-two-thirds">
-      <div class="panel panel-border-wide text">
-        <p>
-          Note: The <code class="code">pattern</code> attribute is not valid HTML for inputs where the <code class="code">type</code> attribute is <code class="code">number</code>. It is added deliberately to <a href="http://bradfrost.com/blog/mobile/better-numerical-inputs-for-mobile-forms">force numeric keypads on iOS devices</a>.
-        </p>
-      </div>
-    </div>  
   </div>
 
 </main><!-- /#content -->

--- a/app/views/guide_colour.html
+++ b/app/views/guide_colour.html
@@ -353,13 +353,9 @@
   <h3 class="heading-medium" id="examples">Examples</h3>
   <h4 class="heading-small">Confirmation page</h4>
 
-  <div class="text">
-    <div class="panel panel-border-wide">
-      <p>
-        When using the white text on a turquoise background &mdash; ensure the minimum text size is 24px normal weight, or 19px bold. This is to meet colour contrast ratio requirements.
-      </p>
-    </div>
-  </div>
+  <p class="text">
+    When using the white text on a turquoise background &mdash; ensure the minimum text size is 24px normal weight, or 19px bold. This is to meet colour contrast ratio requirements.
+  </p>
 
   <div class="example">
     <div class="grid-row">

--- a/app/views/guide_errors.html
+++ b/app/views/guide_errors.html
@@ -66,11 +66,9 @@
 </code>
 </pre>
 
-  <div class="panel panel-border-narrow">
-    <h3 class="heading-small">
-      The error summary must appear at the top of the page, so it is visible when the page is refreshed and is immediately read out by assistive technology.
-    </h3>
-  </div>
+  <p class="text">
+    The error summary must appear at the top of the page, so it is visible when the page is refreshed and is immediately read out by assistive technology.
+  </p>
 
   <h3 class="heading-medium" id="highlight-errors">Highlight errors in forms</h3>
 

--- a/app/views/guide_typography.html
+++ b/app/views/guide_typography.html
@@ -219,7 +219,7 @@
 </code>
 </pre>
 
-  <div class="panel panel-border-wide text">
+  <div class="text">
     <p>
       If you’re using the HTML5 details and summary elements, you’ll need a polyfill for <a href="http://caniuse.com/#feat=details" rel="external">not-so-modern browsers</a>.
     </p>

--- a/app/views/snippets/form_error_radio_more_text.html
+++ b/app/views/snippets/form_error_radio_more_text.html
@@ -32,11 +32,9 @@
   To save time, look at the photo in your current passport and tell us now if you look very different.
 </p>
 
-<div class="panel panel-border-wide">
-  <p>
-    Don't worry about normal signs of ageing, or your hairstyle or facial hair changing a lot - the examiners are used to that
-  </p>
-</div>
+<p>
+  Don't worry about normal signs of ageing, or your hairstyle or facial hair changing a lot - the examiners are used to that.
+</p>
 
 
 <div class="form-group {% if error %} form-group-error{% endif %}">


### PR DESCRIPTION
There should not be a need to highlight text within the GOV.UK Elements documentation.
This removes all 6 occurrences of inset text used to highlight content within the documentation. Even before deprecating it, I noticed that none of it really makes any sense to highlight.

This change would be necessary if we merged #586 but also makes sense on its own.


## Bottom section of all form error example pages

### [Before](https://govuk-elements.herokuapp.com/errors/example-form-validation-multiple-questions)
<img width="623" alt="" src="https://user-images.githubusercontent.com/108893/34735656-172bdfc8-f568-11e7-9d9b-956f5f3f913d.png">

### [After](https://govuk-elements-review-pr-587.herokuapp.com/errors/example-form-validation-multiple-questions)
<img width="616" alt="" src="https://user-images.githubusercontent.com/108893/34735666-234cbcfa-f568-11e7-8b7e-b49080431c7b.png">


## Bottom note of date example

### [Before](https://govuk-elements.herokuapp.com/form-elements/example-date/)
<img width="575" alt="" src="https://user-images.githubusercontent.com/108893/34735845-c75c9ec8-f568-11e7-803f-4c32c871bf2f.png">

### [After](https://govuk-elements-review-pr-587.herokuapp.com/form-elements/example-date/)
<img width="574" alt="" src="https://user-images.githubusercontent.com/108893/34735854-d502b4f4-f568-11e7-8059-3ade174e71c2.png">


## Note on examples on colour use

### [Before](https://govuk-elements.herokuapp.com/colour/#examples)
<img width="661" alt="" src="https://user-images.githubusercontent.com/108893/34735980-5182a034-f569-11e7-9f06-7ab58ff388fb.png">

### [After](https://govuk-elements-review-pr-587.herokuapp.com/colour/#examples)
<img width="662" alt="" src="https://user-images.githubusercontent.com/108893/34735991-59e43148-f569-11e7-9cfe-9c54057d9f51.png">


## Bottom note on summarising errors

(I have also changed the wrongly used heading to a paragraph.)

### [Before](https://govuk-elements.herokuapp.com/errors/#summarise-errors)
<img width="923" alt="" src="https://user-images.githubusercontent.com/108893/34736104-b80bf4c2-f569-11e7-880c-0adc711c6a24.png">

### [After](https://govuk-elements-review-pr-587.herokuapp.com/errors/#summarise-errors)
<img width="597" alt="" src="https://user-images.githubusercontent.com/108893/34736116-bf28fd0e-f569-11e7-94c9-eb548a24b2a4.png">


## Note below hidden text

### [Before](https://govuk-elements.herokuapp.com/typography/#typography-hidden-text)
<img width="609" alt="" src="https://user-images.githubusercontent.com/108893/34736189-0222eb92-f56a-11e7-8ee0-83d079f8e89a.png">

### [After](https://govuk-elements-review-pr-587.herokuapp.com/typography/#typography-hidden-text)
<img width="598" alt="" src="https://user-images.githubusercontent.com/108893/34736200-0a0631fc-f56a-11e7-8aad-fe5ccee6f78d.png">


## Form error example page with additional guidance

(This is the only case where I think it could make sense to keep it.)

### [Before](https://govuk-elements.herokuapp.com/errors/example-form-validation-single-question-more-text)
<img width="659" alt="" src="https://user-images.githubusercontent.com/108893/34736298-61993bda-f56a-11e7-9fec-8933f7c40b00.png">

### [After](https://govuk-elements-review-pr-587.herokuapp.com/errors/example-form-validation-single-question-more-text)
<img width="661" alt="" src="https://user-images.githubusercontent.com/108893/34736314-69b6e308-f56a-11e7-9069-e5fd709fbac4.png">

  