### PR TITLE
Update to latest version of govuk-lint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'sass', '3.4.15'
-gem 'govuk-lint', '0.7.0'
+gem 'govuk-lint', '3.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,40 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.2.0)
-    astrolabe (1.3.1)
-      parser (~> 2.2)
-    govuk-lint (0.7.0)
-      rubocop (~> 0.35.0)
-      scss_lint (~> 0.44.0)
-    parser (2.3.0.6)
-      ast (~> 2.2)
+    ast (2.3.0)
+    govuk-lint (3.4.0)
+      rubocop (~> 0.51.0)
+      rubocop-rspec (~> 1.19.0)
+      scss_lint
+    parallel (1.12.0)
+    parser (2.4.0.2)
+      ast (~> 2.3)
     powerpack (0.1.1)
-    rainbow (2.1.0)
-    rake (10.5.0)
-    rubocop (0.35.1)
-      astrolabe (~> 1.3)
-      parser (>= 2.2.3.0, < 3.0)
+    rainbow (2.2.2)
+      rake
+    rake (11.3.0)
+    rubocop (0.51.0)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 3.0)
       ruby-progressbar (~> 1.7)
-      tins (<= 1.6.0)
-    ruby-progressbar (1.7.5)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-rspec (1.19.0)
+      rubocop (>= 0.51.0)
+    ruby-progressbar (1.9.0)
     sass (3.4.15)
-    scss_lint (0.44.0)
-      rake (~> 10.0)
+    scss_lint (0.48.0)
+      rake (>= 0.9, < 12)
       sass (~> 3.4.15)
-    tins (1.6.0)
+    unicode-display_width (1.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  govuk-lint (= 0.7.0)
+  govuk-lint (= 3.4.0)
   sass (= 3.4.15)
+
+BUNDLED WITH
+   1.13.6


### PR DESCRIPTION
Update Gemfile to use the latest version of govuk-lint.

#### What problem does the pull request solve?

The version of govuk-lint we're currently using is out of date.

#### How has this been tested?

1. Ran the linter manually using `npm run-script lint` and verified that the code still passed according to the linter. 
2. Made a manual change to the elements CSS to introduce a violation, and ran the command again, verifying that the violation was identified.

#### What type of change is it?
Dependency update

#### Has the documentation been updated?

N/A