### PR TITLE
Bump Travis’ node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
- - "4.4.7"
+ - "8"
 notifications:
   email: false
 before_deploy:


### PR DESCRIPTION
#### What problem does the pull request solve?
A [recent update to Travis’ build environment][1] means that we now end up with Yarn 1.3.2 rather than 0.27.5.

Yarn [introduced a check against package.json’s `engines` definition in 1.0][2] which we are now failing, because we specify an engine of `>=8.1.4` for Heroku but install `4.4.7` on Travis:

```
[1/5] Validating package.json...

error govuk-elements@: The engine "node" is incompatible with this module. Expected version ">=8.1.4".
```

Installing the latest version of Node 8 on Travis should fix this.

[1]: https://docs.travis-ci.com/user/build-environment-updates/2017-12-12/
[2]: https://github.com/yarnpkg/yarn/pull/3675/files

#### How has this been tested?
Mostly guesswork. But look, the tests pass!

#### What type of change is it?
Dependency update.

#### Has the documentation been updated?
<!--- Delete the lines below that don't apply -->
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
