### PR TITLE
Fix misaligned radio example

### DIFF
--- a/app/views/examples/example_radios_checkboxes.html
+++ b/app/views/examples/example_radios_checkboxes.html
@@ -130,7 +130,7 @@
             <div class="multiple-choice">
               <input id="radio-part-2" type="radio" name="housing-act" value="Part 2">
               <label for="radio-part-2">
-                <span class="heading-small">Part 2 of the Housing Act 2004</span><br>
+                <span class="form-label-bold">Part 2 of the Housing Act 2004</span>
                 For properties that are 3 or more stories high and occupied by 5 or more people
               </label>
             </div>
@@ -138,7 +138,7 @@
             <div class="multiple-choice">
               <input id="radio-part-3" type="radio" name="housing-act" value="Part 3">
               <label for="radio-part-3">
-                <span class="heading-small">Part 3 of the Housing Act 2004</span><br>
+                <span class="form-label-bold">Part 3 of the Housing Act 2004</span>
                 For properties that are within a geographical area defined by a local council
               </label>
             </div>


### PR DESCRIPTION
Since `display: block` was introduced for all heading classes in 8f88ccc46f7e71d2c8f4a56f4bac4beda1126cd5 the [radio example with 'headings' inside labels](https://govuk-elements.herokuapp.com/form-elements/example-radios-checkboxes/) was visually broken.
This fixes #581 by switching the `heading-small` class with the more fitting `form-label-bold` class.

## Screenshots

### Before

![](https://user-images.githubusercontent.com/108893/34779439-1c558cfa-f618-11e7-99d8-13d98dda96ad.png)

### After

![](https://user-images.githubusercontent.com/108893/34779446-21d58ad6-f618-11e7-8fd3-adf282d207ad.png)

## What type of change is it?
- Bug fix (non-breaking change which fixes an issue)
