### PR TITLE
Use `<button>` not `<input>`s for form submission

### DIFF
--- a/app/views/snippets/buttons_button.html
+++ b/app/views/snippets/buttons_button.html
@@ -1,1 +1,1 @@
-<input class="button" type="submit" value="Save and continue">
+<button class="button" type="submit">Save and continue</button>

--- a/app/views/snippets/buttons_button_disabled.html
+++ b/app/views/snippets/buttons_button_disabled.html
@@ -1,1 +1,1 @@
-<input class="button" type="submit" value="Save and continue" disabled="disabled" aria-disabled="true">
+<button class="button" type="submit" disabled="disabled" aria-disabled="true">Save and continue</button>


### PR DESCRIPTION
Both `<button type='submit'>Submit<button>` and `<input type='submit' value='Submit'>` can be used to submit a form.

Historically `<input>` has been preferred because it’s better-supported by IE6 in that:
- the `submit` attribute is mandatory on `<button>`, not on `<input>`
- the `innerHTML` of a button will be submitted to the server, not the `value` (as in other browsers)

Reasons to now use `<button>` instead:
- IE6/7 support is no longer a concern (especially with deprecation of TLS 1.0 on the way)
- Because an `<input>` element can’t have children, the pseudo-element hack<sup>1</sup> used to ensure the top edge of the button is clickable doesn’t work.

Fixes #545

1. alphagov/govuk_frontend_toolkit@24e1906#diff-ef0e4eb6f1e90b44b0c3fe39dce274a4R79
