### PR TITLE
Remove min, max attributes from date inputs

### DIFF
--- a/app/views/examples/example_date.html
+++ b/app/views/examples/example_date.html
@@ -30,15 +30,15 @@
           <div class="form-date">
             <div class="form-group form-group-day">
               <label class="form-label" for="example-dob-day-1">Day</label>
-              <input class="form-control form-control-error" id="example-dob-day-1" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+              <input class="form-control form-control-error" id="example-dob-day-1" name="dob-day" type="number" pattern="[0-9]*">
             </div>
             <div class="form-group form-group-month">
               <label class="form-label" for="example-dob-month-1">Month</label>
-              <input class="form-control" id="example-dob-month-1" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+              <input class="form-control" id="example-dob-month-1" name="dob-month" type="number" pattern="[0-9]*">
             </div>
             <div class="form-group form-group-year">
               <label class="form-label" for="example-dob-year-1">Year</label>
-              <input class="form-control" id="example-dob-year-1" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+              <input class="form-control" id="example-dob-year-1" name="dob-year" type="number" pattern="[0-9]*">
             </div>
           </div>
         </fieldset>
@@ -55,15 +55,15 @@
           <div class="form-date">
             <div class="form-group form-group-day">
               <label class="form-label" for="example-dob-day-2">Day</label>
-              <input class="form-control" id="example-dob-day-2" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+              <input class="form-control" id="example-dob-day-2" name="dob-day" type="number" pattern="[0-9]*">
             </div>
             <div class="form-group form-group-month">
               <label class="form-label" for="example-dob-month-2">Month</label>
-              <input class="form-control form-control-error" id="example-dob-month-2" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+              <input class="form-control form-control-error" id="example-dob-month-2" name="dob-month" type="number" pattern="[0-9]*">
             </div>
             <div class="form-group form-group-year">
               <label class="form-label" for="example-dob-year-2">Year</label>
-              <input class="form-control" id="example-dob-year-2" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+              <input class="form-control" id="example-dob-year-2" name="dob-year" type="number" pattern="[0-9]*">
             </div>
           </div>
         </fieldset>
@@ -80,15 +80,15 @@
           <div class="form-date">
             <div class="form-group form-group-day">
               <label class="form-label" for="example-dob-day-3">Day</label>
-              <input class="form-control" id="example-dob-day-3" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+              <input class="form-control" id="example-dob-day-3" name="dob-day" type="number" pattern="[0-9]*">
             </div>
             <div class="form-group form-group-month">
               <label class="form-label" for="example-dob-month-3">Month</label>
-              <input class="form-control" id="example-dob-month-3" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+              <input class="form-control" id="example-dob-month-3" name="dob-month" type="number" pattern="[0-9]*">
             </div>
             <div class="form-group form-group-year">
               <label class="form-label" for="example-dob-year-3">Year</label>
-              <input class="form-control form-control-error" id="example-dob-year-3" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+              <input class="form-control form-control-error" id="example-dob-year-3" name="dob-year" type="number" pattern="[0-9]*">
             </div>
           </div>
         </fieldset>

--- a/app/views/examples/example_form_elements.html
+++ b/app/views/examples/example_form_elements.html
@@ -103,15 +103,15 @@
               <div class="form-date">
                 <div class="form-group form-group-day">
                   <label class="form-label" for="dob-day">Day</label>
-                  <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+                  <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*">
                 </div>
                 <div class="form-group form-group-month">
                   <label class="form-label" for="dob-month">Month</label>
-                  <input class="form-control" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+                  <input class="form-control" id="dob-month" name="dob-month" type="number" pattern="[0-9]*">
                 </div>
                 <div class="form-group form-group-year">
                   <label class="form-label" for="dob-year">Year</label>
-                  <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+                  <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*">
                 </div>
               </div>
             </fieldset>
@@ -184,15 +184,15 @@
               <div class="form-date">
                 <div class="form-group form-group-day">
                   <label class="form-label" for="example-dob-day-1">Day</label>
-                  <input class="form-control form-control-error" id="example-dob-day-1" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+                  <input class="form-control form-control-error" id="example-dob-day-1" name="dob-day" type="number" pattern="[0-9]*">
                 </div>
                 <div class="form-group form-group-month">
                   <label class="form-label" for="example-dob-month-1">Month</label>
-                  <input class="form-control" id="example-dob-month-1" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+                  <input class="form-control" id="example-dob-month-1" name="dob-month" type="number" pattern="[0-9]*">
                 </div>
                 <div class="form-group form-group-year">
                   <label class="form-label" for="example-dob-year-1">Year</label>
-                  <input class="form-control" id="example-dob-year-1" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+                  <input class="form-control" id="example-dob-year-1" name="dob-year" type="number" pattern="[0-9]*">
                 </div>
               </div>
             </fieldset>
@@ -209,15 +209,15 @@
               <div class="form-date">
                 <div class="form-group form-group-day">
                   <label class="form-label" for="example-dob-day-2">Day</label>
-                  <input class="form-control" id="example-dob-day-2" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+                  <input class="form-control" id="example-dob-day-2" name="dob-day" type="number" pattern="[0-9]*">
                 </div>
                 <div class="form-group form-group-month">
                   <label class="form-label" for="example-dob-month-2">Month</label>
-                  <input class="form-control form-control-error" id="example-dob-month-2" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+                  <input class="form-control form-control-error" id="example-dob-month-2" name="dob-month" type="number" pattern="[0-9]*">
                 </div>
                 <div class="form-group form-group-year">
                   <label class="form-label" for="example-dob-year-2">Year</label>
-                  <input class="form-control" id="example-dob-year-2" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+                  <input class="form-control" id="example-dob-year-2" name="dob-year" type="number" pattern="[0-9]*">
                 </div>
               </div>
             </fieldset>
@@ -234,15 +234,15 @@
               <div class="form-date">
                 <div class="form-group form-group-day">
                   <label class="form-label" for="example-dob-day-3">Day</label>
-                  <input class="form-control" id="example-dob-day-3" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+                  <input class="form-control" id="example-dob-day-3" name="dob-day" type="number" pattern="[0-9]*">
                 </div>
                 <div class="form-group form-group-month">
                   <label class="form-label" for="example-dob-month-3">Month</label>
-                  <input class="form-control" id="example-dob-month-3" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+                  <input class="form-control" id="example-dob-month-3" name="dob-month" type="number" pattern="[0-9]*">
                 </div>
                 <div class="form-group form-group-year">
                   <label class="form-label" for="example-dob-year-3">Year</label>
-                  <input class="form-control form-control-error" id="example-dob-year-3" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+                  <input class="form-control form-control-error" id="example-dob-year-3" name="dob-year" type="number" pattern="[0-9]*">
                 </div>
               </div>
             </fieldset>

--- a/app/views/snippets/form_date.html
+++ b/app/views/snippets/form_date.html
@@ -10,15 +10,15 @@
       <div class="form-date">
         <div class="form-group form-group-day">
           <label class="form-label" for="dob-day">Day</label>
-          <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+          <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*">
         </div>
         <div class="form-group form-group-month">
           <label class="form-label" for="dob-month">Month</label>
-          <input class="form-control" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+          <input class="form-control" id="dob-month" name="dob-month" type="number" pattern="[0-9]*">
         </div>
         <div class="form-group form-group-year">
           <label class="form-label" for="dob-year">Year</label>
-          <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+          <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*">
         </div>
       </div>
     </fieldset>

--- a/app/views/snippets/form_date_show_errors.html
+++ b/app/views/snippets/form_date_show_errors.html
@@ -11,15 +11,15 @@
       <div class="form-date">
         <div class="form-group form-group-day">
           <label class="form-label" for="dob-day-example">Day</label>
-          <input class="form-control form-control-error" id="dob-day-example" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+          <input class="form-control form-control-error" id="dob-day-example" name="dob-day" type="number" pattern="[0-9]*">
         </div>
         <div class="form-group form-group-month">
           <label class="form-label" for="dob-month-example">Month</label>
-          <input class="form-control form-control-error" id="dob-month-example" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+          <input class="form-control form-control-error" id="dob-month-example" name="dob-month" type="number" pattern="[0-9]*">
         </div>
         <div class="form-group form-group-year">
           <label class="form-label" for="dob-year-example">Year</label>
-          <input class="form-control form-control-error" id="dob-year-example" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+          <input class="form-control form-control-error" id="dob-year-example" name="dob-year" type="number" pattern="[0-9]*">
         </div>
       </div>
     </fieldset>


### PR DESCRIPTION
Remove the min and max attributes from all inputs in the various 'date' examples.

#### What problem does the pull request solve?

The current max attribute for the year is 2016, which means the examples are effectively two years ‘out of date’. Whilst services _might_ be expected to populate the max attribute dynamically, we’ve seen in user research that developers often copy and paste code examples blindly, and this is more likely to introduce bugs in the future than it is to help anyone.

The min and max attributes only really ‘apply’ when using the spinner (which we consciously disable using CSS), or when using browser form validation, which we advise against. The current experience in the browser is also odd – It’s possible to enter 2020 in the above example in desktop chrome and safari on MacOS but If you then use keyboard up/down it ‘snaps’ to 2016.

There is more discussion about this issue in #597.

Closes #597.

#### How has this been tested?

This change has not been explicitly tested, because the change in behaviour is well defined.

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?
<!--- Delete the lines below that don't apply -->
- I have updated the documentation accordingly.
