### PR TITLE
Remove redundant example-forms route

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -98,19 +98,6 @@ module.exports = {
       res.render('guide_form_elements', { 'page_name': pageName })
     })
 
-    // Example page: Basic form
-    app.get('/form-elements/example-forms', function (req, res) {
-      var section = 'form-elements'
-      var sectionName = 'Form elements'
-      var pageName = 'Example: Form'
-      res.render('examples/example_forms', { 'section': section, 'section_name': sectionName, 'page_name': pageName })
-    })
-
-    // Redirect examples from /examples/ to /section/example-name-of-example
-    app.get('/examples/forms', function (req, res) {
-      res.redirect('/form-elements/example-forms')
-    })
-
     // Example page: Date pattern
     app.get('/form-elements/example-date', function (req, res) {
       var section = 'form-elements'


### PR DESCRIPTION
The layout for this route and the link to it from the form elements guide were removed in 2592887e93e1df1cb767e2eaadaf341b7e62fa87 (as part of #109) but the route was left in place.

<!--- Provide a summary of your changes in the Title above -->

#### What problem does the pull request solve?
This fixes a 500 at /form-elements/example-forms, replacing it with a 404.
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply. -->
- Bug fix (non-breaking change which fixes an issue)
