### PR TITLE
Remove form tag from snippets

### DIFF
--- a/app/views/snippets/form_checkboxes.html
+++ b/app/views/snippets/form_checkboxes.html
@@ -1,23 +1,21 @@
-<form>
-  <fieldset>
+<fieldset>
 
-    <legend>
-      <h3 class="heading-medium">Which types of waste do you transport regularly?</h3>
-      <span class="body-text">Select all that apply</span>
-    </legend>
+  <legend>
+    <h3 class="heading-medium">Which types of waste do you transport regularly?</h3>
+    <span class="body-text">Select all that apply</span>
+  </legend>
 
-    <div class="multiple-choice">
-      <input id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal">
-      <label for="waste-type-1">Waste from animal carcasses</label>
-    </div>
-    <div class="multiple-choice">
-      <input id="waste-type-2" name="waste-types" type="checkbox" value="waste-mines">
-      <label for="waste-type-2">Waste from mines or quarries</label>
-    </div>
-    <div class="multiple-choice">
-      <input id="waste-type-3" name="waste-types" type="checkbox" value="waste-farm-agricultural">
-      <label for="waste-type-3">Farm or agricultural waste</label>
-    </div>
+  <div class="multiple-choice">
+    <input id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal">
+    <label for="waste-type-1">Waste from animal carcasses</label>
+  </div>
+  <div class="multiple-choice">
+    <input id="waste-type-2" name="waste-types" type="checkbox" value="waste-mines">
+    <label for="waste-type-2">Waste from mines or quarries</label>
+  </div>
+  <div class="multiple-choice">
+    <input id="waste-type-3" name="waste-types" type="checkbox" value="waste-farm-agricultural">
+    <label for="waste-type-3">Farm or agricultural waste</label>
+  </div>
 
-  </fieldset>
-</form>
+</fieldset>

--- a/app/views/snippets/form_inset_checkboxes.html
+++ b/app/views/snippets/form_inset_checkboxes.html
@@ -1,31 +1,29 @@
-<form>
-  <div class="form-group">
-    <fieldset>
+<div class="form-group">
+  <fieldset>
 
-      <legend>
-        <h1 class="heading-medium">
-          What is your nationality?
-        </h1>
-        <span class="body-text">Select all options that are relevant to you.</span>
-      </legend>
+    <legend>
+      <h1 class="heading-medium">
+        What is your nationality?
+      </h1>
+      <span class="body-text">Select all options that are relevant to you.</span>
+    </legend>
 
-      <div class="multiple-choice">
-        <input id="nationalities-british" name="nationalities" type="checkbox" value="British">
-        <label for="nationalities-british">British (including English, Scottish, Welsh and Northern Irish)</label>
-      </div>
-      <div class="multiple-choice">
-        <input id="nationalities-irish" name="nationalities" type="checkbox" value="Irish">
-        <label for="nationalities-irish">Irish</label>
-      </div>
-      <div class="multiple-choice" data-target="example-different-country">
-        <input id="nationalities-other" name="nationalities" type="checkbox" value="Citizen of a different country">
-        <label for="nationalities-other">Citizen of a different country</label>
-      </div>
-      <div class="panel panel-border-narrow js-hidden" id="example-different-country">
-        <label class="form-label" for="nationalities-other-country">Country name</label>
-        <input class="form-control" type="text" id="nationalities-other-country" name="nationalities-other-country">
-      </div>
+    <div class="multiple-choice">
+      <input id="nationalities-british" name="nationalities" type="checkbox" value="British">
+      <label for="nationalities-british">British (including English, Scottish, Welsh and Northern Irish)</label>
+    </div>
+    <div class="multiple-choice">
+      <input id="nationalities-irish" name="nationalities" type="checkbox" value="Irish">
+      <label for="nationalities-irish">Irish</label>
+    </div>
+    <div class="multiple-choice" data-target="example-different-country">
+      <input id="nationalities-other" name="nationalities" type="checkbox" value="Citizen of a different country">
+      <label for="nationalities-other">Citizen of a different country</label>
+    </div>
+    <div class="panel panel-border-narrow js-hidden" id="example-different-country">
+      <label class="form-label" for="nationalities-other-country">Country name</label>
+      <input class="form-control" type="text" id="nationalities-other-country" name="nationalities-other-country">
+    </div>
 
-    </fieldset>
-  </div>
-</form>
+  </fieldset>
+</div>

--- a/app/views/snippets/form_inset_radios.html
+++ b/app/views/snippets/form_inset_radios.html
@@ -1,40 +1,38 @@
-<form>
-  <div class="form-group">
-    <fieldset>
+<div class="form-group">
+  <fieldset>
 
-      <legend>
-        <h1 class="heading-medium">
-          How do you want to be contacted?
-        </h1>
-      </legend>
+    <legend>
+      <h1 class="heading-medium">
+        How do you want to be contacted?
+      </h1>
+    </legend>
 
-      <div class="multiple-choice" data-target="contact-by-email">
-        <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Yes">
-        <label for="example-contact-by-email">Email</label>
-      </div>
-      <div class="panel panel-border-narrow js-hidden" id="contact-by-email">
-        <label class="form-label" for="contact-email">Email address</label>
-        <input class="form-control" name="contact-email" type="text" id="contact-email">
-      </div>
+    <div class="multiple-choice" data-target="contact-by-email">
+      <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Yes">
+      <label for="example-contact-by-email">Email</label>
+    </div>
+    <div class="panel panel-border-narrow js-hidden" id="contact-by-email">
+      <label class="form-label" for="contact-email">Email address</label>
+      <input class="form-control" name="contact-email" type="text" id="contact-email">
+    </div>
 
-      <div class="multiple-choice" data-target="contact-by-phone">
-        <input id="example-contact-by-phone" type="radio" name="radio-contact-group" value="No">
-        <label for="example-contact-by-phone">Phone</label>
-      </div>
-      <div class="panel panel-border-narrow js-hidden" id="contact-by-phone">
-        <label class="form-label" for="contact-phone">Phone number</label>
-        <input class="form-control" name="contact-phone" type="text" id="contact-phone">
-      </div>
+    <div class="multiple-choice" data-target="contact-by-phone">
+      <input id="example-contact-by-phone" type="radio" name="radio-contact-group" value="No">
+      <label for="example-contact-by-phone">Phone</label>
+    </div>
+    <div class="panel panel-border-narrow js-hidden" id="contact-by-phone">
+      <label class="form-label" for="contact-phone">Phone number</label>
+      <input class="form-control" name="contact-phone" type="text" id="contact-phone">
+    </div>
 
-      <div class="multiple-choice" data-target="contact-by-text">
-        <input id="example-contact-by-text" type="radio" name="radio-contact-group" value="No">
-        <label for="example-contact-by-text">Text message</label>
-      </div>
-      <div class="panel panel-border-narrow js-hidden" id="contact-by-text">
-        <label class="form-label" for="contact-text-message">Mobile phone number</label>
-        <input class="form-control" name="contact-text-message" type="text" id="contact-text-message">
-      </div>
+    <div class="multiple-choice" data-target="contact-by-text">
+      <input id="example-contact-by-text" type="radio" name="radio-contact-group" value="No">
+      <label for="example-contact-by-text">Text message</label>
+    </div>
+    <div class="panel panel-border-narrow js-hidden" id="contact-by-text">
+      <label class="form-label" for="contact-text-message">Mobile phone number</label>
+      <input class="form-control" name="contact-text-message" type="text" id="contact-text-message">
+    </div>
 
-    </fieldset>
-  </div>
-</form>
+  </fieldset>
+</div>

--- a/app/views/snippets/form_radio_buttons.html
+++ b/app/views/snippets/form_radio_buttons.html
@@ -1,25 +1,23 @@
-<form>
-  <div class="form-group">
-    <fieldset>
+<div class="form-group">
+  <fieldset>
 
-      <legend>
-        <h1 class="heading-medium">Where do you live?</h1>
-      </legend>
+    <legend>
+      <h1 class="heading-medium">Where do you live?</h1>
+    </legend>
 
-      <div class="multiple-choice">
-        <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">
-        <label for="radio-1">Northern Ireland</label>
-      </div>
-      <div class="multiple-choice">
-        <input id="radio-2" type="radio" name="radio-group" value="Isle of Man or the Channel Islands">
-        <label for="radio-2">Isle of Man or the Channel Islands</label>
-      </div>
-      <p class="form-block">or</p>
-      <div class="multiple-choice">
-        <input id="radio-3" type="radio" name="radio-group" value="I am a British citizen living abroad">
-        <label for="radio-3">I am a British citizen living abroad</label>
-      </div>
+    <div class="multiple-choice">
+      <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">
+      <label for="radio-1">Northern Ireland</label>
+    </div>
+    <div class="multiple-choice">
+      <input id="radio-2" type="radio" name="radio-group" value="Isle of Man or the Channel Islands">
+      <label for="radio-2">Isle of Man or the Channel Islands</label>
+    </div>
+    <p class="form-block">or</p>
+    <div class="multiple-choice">
+      <input id="radio-3" type="radio" name="radio-group" value="I am a British citizen living abroad">
+      <label for="radio-3">I am a British citizen living abroad</label>
+    </div>
 
-    </fieldset>
-  </div>
-</form>
+  </fieldset>
+</div>

--- a/app/views/snippets/form_radio_buttons_inline.html
+++ b/app/views/snippets/form_radio_buttons_inline.html
@@ -1,22 +1,20 @@
-<form>
-  <div class="form-group">
-    <fieldset class="inline">
+<div class="form-group">
+  <fieldset class="inline">
 
-      <legend>
-        <h1 class="heading-medium">
-          Do you already have a personal user account?
-        </h1>
-      </legend>
+    <legend>
+      <h1 class="heading-medium">
+        Do you already have a personal user account?
+      </h1>
+    </legend>
 
-      <div class="multiple-choice">
-        <input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes">
-        <label for="radio-inline-1">Yes</label>
-      </div>
-      <div class="multiple-choice">
-        <input id="radio-inline-2" type="radio" name="radio-inline-group" value="No">
-        <label for="radio-inline-2">No</label>
-      </div>
+    <div class="multiple-choice">
+      <input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes">
+      <label for="radio-inline-1">Yes</label>
+    </div>
+    <div class="multiple-choice">
+      <input id="radio-inline-2" type="radio" name="radio-inline-group" value="No">
+      <label for="radio-inline-2">No</label>
+    </div>
 
-    </fieldset>
-  </div>
-</form>
+  </fieldset>
+</div>


### PR DESCRIPTION
Removing for tags from the snippets used on the form elements page.

#### What problem does the pull request solve?
* Having the form tag causes us issues in Prototype Kit training as we have to talk users through removing them.
* The tags aren't needed for the snippets, and aren't valid - they don't seem helpful to include.
* Most examples on the page don't include the form tag - it seems odd that some do and some don't. This pr makes the examples more consistent.

NB - there are other snippets used on other pages which I haven't touched as I wasn't sure what they were used form.

#### Screenshots (if appropriate):
Before:
![screen shot 2018-04-17 at 17 19 08](https://user-images.githubusercontent.com/2204224/38882947-7b800f9c-4263-11e8-92d2-f8c6e9eaaf8d.png)

After:
![screen shot 2018-04-17 at 17 19 36](https://user-images.githubusercontent.com/2204224/38882967-884d375e-4263-11e8-927a-01907e94f4b9.png)

#### What type of change is it?
Hopefully not a breaking change. Since the forms don't have actions, I don't think they can be doing anything right now.

#### Has the documentation been updated?
Don't think this is relevant.
