### PR TITLE
Wrap snippets in div.form-group for consistency

### DIFF
--- a/app/views/snippets/form_checkbox.html
+++ b/app/views/snippets/form_checkbox.html
@@ -2,7 +2,10 @@
   <label class="form-label" for="telephone-number">Enter your telephone number</label>
   <input class="form-control" id="telephone-number" name="telephone-number" type="text">
 </div>
-<div class="multiple-choice">
-  <input id="checkbox-telephone-number" name="contact-by-text-phone" type="checkbox" value="true">
-  <label for="checkbox-telephone-number">I need to be contacted using a text phone</label>
+<div class="form-group">
+  <div class="multiple-choice">
+    <input id="checkbox-telephone-number" name="contact-by-text-phone" type="checkbox" value="true">
+    <label for="checkbox-telephone-number">I need to be contacted using a text phone</label>
+  </div>
 </div>
+

--- a/app/views/snippets/form_checkboxes.html
+++ b/app/views/snippets/form_checkboxes.html
@@ -1,21 +1,23 @@
-<fieldset>
+<div class="form-group">
+  <fieldset>
 
-  <legend>
-    <h3 class="heading-medium">Which types of waste do you transport regularly?</h3>
-    <span class="body-text">Select all that apply</span>
-  </legend>
+    <legend>
+      <h3 class="heading-medium">Which types of waste do you transport regularly?</h3>
+      <span class="body-text">Select all that apply</span>
+    </legend>
 
-  <div class="multiple-choice">
-    <input id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal">
-    <label for="waste-type-1">Waste from animal carcasses</label>
-  </div>
-  <div class="multiple-choice">
-    <input id="waste-type-2" name="waste-types" type="checkbox" value="waste-mines">
-    <label for="waste-type-2">Waste from mines or quarries</label>
-  </div>
-  <div class="multiple-choice">
-    <input id="waste-type-3" name="waste-types" type="checkbox" value="waste-farm-agricultural">
-    <label for="waste-type-3">Farm or agricultural waste</label>
-  </div>
+    <div class="multiple-choice">
+      <input id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal">
+      <label for="waste-type-1">Waste from animal carcasses</label>
+    </div>
+    <div class="multiple-choice">
+      <input id="waste-type-2" name="waste-types" type="checkbox" value="waste-mines">
+      <label for="waste-type-2">Waste from mines or quarries</label>
+    </div>
+    <div class="multiple-choice">
+      <input id="waste-type-3" name="waste-types" type="checkbox" value="waste-farm-agricultural">
+      <label for="waste-type-3">Farm or agricultural waste</label>
+    </div>
 
-</fieldset>
+  </fieldset>
+</div>

--- a/app/views/snippets/form_checkboxes_disabled.html
+++ b/app/views/snippets/form_checkboxes_disabled.html
@@ -1,4 +1,7 @@
-<div class="multiple-choice">
-  <input id="checkbox-disabled-example" name="checkbox-disabled-group" type="checkbox" value="waste-farm-agricultural" disabled>
-  <label for="checkbox-disabled-example">Farm or agricultural waste</label>
+<div class="form-group">
+  <div class="multiple-choice">
+    <input id="checkbox-disabled-example" name="checkbox-disabled-group" type="checkbox" value="waste-farm-agricultural" disabled>
+    <label for="checkbox-disabled-example">Farm or agricultural waste</label>
+  </div>
 </div>
+

--- a/app/views/snippets/form_hint_text.html
+++ b/app/views/snippets/form_hint_text.html
@@ -1,9 +1,11 @@
-<label class="form-label" for="ni-number">
-  National Insurance number
-  <span class="form-hint">
-    It's on your National Insurance card, benefit letter, payslip or P60.
-    <br>
-    For example, ‘QQ 12 34 56 C’.
-  </span>
-</label>
-<input class="form-control" id="ni-number" type="text" name="ni-number">
+<div class="form-group">
+  <label class="form-label" for="ni-number">
+    National Insurance number
+    <span class="form-hint">
+      It's on your National Insurance card, benefit letter, payslip or P60.
+      <br>
+      For example, ‘QQ 12 34 56 C’.
+    </span>
+  </label>
+  <input class="form-control" id="ni-number" type="text" name="ni-number">
+</div>

--- a/app/views/snippets/form_labels.html
+++ b/app/views/snippets/form_labels.html
@@ -1,2 +1,5 @@
-<label class="form-label" for="full-name-f1">Full name</label>
-<input class="form-control" id="full-name-f1" type="text" name="full-name-f1">
+<div class="form-group">
+  <label class="form-label" for="full-name-f1">Full name</label>
+  <input class="form-control" id="full-name-f1" type="text" name="full-name-f1">
+</div>
+

--- a/app/views/snippets/form_radio_buttons_disabled.html
+++ b/app/views/snippets/form_radio_buttons_disabled.html
@@ -1,4 +1,6 @@
-<div class="multiple-choice">
-  <input id="radio-disabled-example" type="radio" name="radio-disabled-group" value="Isle of Man or the Channel Islands" disabled>
-  <label for="radio-disabled-example">Isle of Man or the Channel Islands</label>
+<div class="form-group">
+  <div class="multiple-choice">
+    <input id="radio-disabled-example" type="radio" name="radio-disabled-group" value="Isle of Man or the Channel Islands" disabled>
+    <label for="radio-disabled-example">Isle of Man or the Channel Islands</label>
+  </div>
 </div>

--- a/app/views/snippets/form_textarea.html
+++ b/app/views/snippets/form_textarea.html
@@ -1,4 +1,6 @@
-<label class="form-label" for="textarea">
-  Why can't you provide a National Insurance number?
-</label>
-<textarea class="form-control form-control-3-4" name="textarea" id="textarea" rows="5"></textarea>
+<div class="form-group">
+  <label class="form-label" for="textarea">
+    Why can't you provide a National Insurance number?
+  </label>
+  <textarea class="form-control form-control-3-4" name="textarea" id="textarea" rows="5"></textarea>
+</div>


### PR DESCRIPTION
#### What problem does the pull request solve?
Half the snippets on the form examples page include `div.form-group` and half don't. This inconsistency causes us issues when teaching the Prototype kit. In nearly all cases our users will actually want to have the `div.form-group` for correct spacing.

NB - this means some of the visual examples now have extra whitespace at the bottom. We _could_ remove this, but since this shows the effect of the spacing div, I think it's probably better to leave in.

I've not updated any examples outside of the form examples page.

#### How has this been tested?
Have run it locally.

#### Screenshots (if appropriate):
Before:
![screen shot 2018-04-18 at 10 43 47](https://user-images.githubusercontent.com/2204224/38925084-7acc91d6-42f6-11e8-916e-ed1d7e394dd3.png)
After:
![screen shot 2018-04-18 at 10 43 24](https://user-images.githubusercontent.com/2204224/38925094-8448d9a4-42f6-11e8-8374-bc182fae2037.png)

#### What type of change is it?
Only impacts the elements style guide.

#### Has the documentation been updated?
Don't think any documentation is relevant