### PR TITLE
Typo in button intro text (comma splice)

### DIFF
--- a/app/views/guide_buttons.html
+++ b/app/views/guide_buttons.html
@@ -12,7 +12,7 @@
   </h1>
 
   <p class="lede text">
-    Use buttons to move though a transaction, aim to use only one button per page.
+    Use buttons to move though a transaction. Aim to use only one button per page.
   </p>
 
   <h2 class="heading-small heading-contents">Contents:</h2>


### PR DESCRIPTION
2 complete sentences joined with a comma in the lede par for 'Buttons'.
Fixing with a full stop and cap.
	modified:   app/views/guide_buttons.html

#### What problem does the pull request solve?

None. It's just a small grammar thing. 

#### How has this been tested?

No testing. 

#### Screenshots (if appropriate):
n/a

#### What type of change is it?

- Bug fix (non-breaking change which fixes an issue)

#### Has the documentation been updated?

- I have read the **CONTRIBUTING** document.
