### PR TITLE
Use `<input type=“tel”>` for mobile keyboard

### DIFF
--- a/app/views/snippets/form_checkbox.html
+++ b/app/views/snippets/form_checkbox.html
@@ -1,6 +1,6 @@
 <div class="form-group">
   <label class="form-label" for="telephone-number">Enter your telephone number</label>
-  <input class="form-control" id="telephone-number" name="telephone-number" type="text">
+  <input class="form-control" id="telephone-number" name="telephone-number" type="tel">
 </div>
 <div class="form-group">
   <div class="multiple-choice">

--- a/app/views/snippets/form_inset_panel.html
+++ b/app/views/snippets/form_inset_panel.html
@@ -1,6 +1,6 @@
 <div class="form-group">
   <div class="panel panel-border-narrow">
     <label class="form-label" for="example-phone-number">Mobile phone number</label>
-    <input class="form-control" id="example-phone-number" name="example-phone-number" type="text">
+    <input class="form-control" id="example-phone-number" name="example-phone-number" type="tel">
   </div>
 </div>

--- a/app/views/snippets/form_inset_radios.html
+++ b/app/views/snippets/form_inset_radios.html
@@ -22,7 +22,7 @@
     </div>
     <div class="panel panel-border-narrow js-hidden" id="contact-by-phone">
       <label class="form-label" for="contact-phone">Phone number</label>
-      <input class="form-control" name="contact-phone" type="text" id="contact-phone">
+      <input class="form-control" name="contact-phone" type="tel" id="contact-phone">
     </div>
 
     <div class="multiple-choice" data-target="contact-by-text">


### PR DESCRIPTION
#### What problem does the pull request solve?
For phone number the keyboard on mobile is the text one
<img width="273" alt="05_31_18 at 09 50 46am" src="https://user-images.githubusercontent.com/360936/40777866-fec34984-64c6-11e8-8233-6563990e81e8.png">


#### How has this been tested?
with xCode ios simulator

#### Screenshots (if appropriate):
<img width="273" alt="05_31_18 at 10 33 02am" src="https://user-images.githubusercontent.com/360936/40777947-45bc3828-64c7-11e8-873b-5299a0993444.png">


#### What type of change is it?
- New feature (non-breaking change which adds functionality)

#### Has the documentation been updated?
- I have read the **CONTRIBUTING** document.
