### PR TITLE
Add deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+From the end of June 2018, GDS will stop maintaining the code and guidance in GOV.UK Elements.
+===============
+
+You will be able to get all of the GOV.UK styles, components and patterns in the GOV.UK Design System.
+
+GOV.UK Elements will still be available in case you are already using it, but GDS will only make serious bug fixes and security patches.
+
+
 GOV.UK elements ·
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 [![Greenkeeper badge](https://badges.greenkeeper.io/alphagov/govuk_elements.svg)](https://greenkeeper.io/)

--- a/app/views/includes/deprecation_message.html
+++ b/app/views/includes/deprecation_message.html
@@ -1,0 +1,5 @@
+<div class="notification-summary">
+  <h2 class="heading-medium no-top-margin">From the end of June 2018, GDS will stop maintaining the code and guidance in GOV.UK Elements.</h2>
+  <p>You will be able to get all of the GOV.UK styles, components and patterns in the GOV.UK Design System.</p>
+  <p>GOV.UK Elements will still be available in case you are already using it, but GDS will only make serious bug fixes and security patches.</p>
+</div>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -14,6 +14,7 @@
 {% block content %}
 <div class="site-wrapper">
   {% include "includes/breadcrumb.html" %}
+  {% include "includes/deprecation_message.html" %}
   {% block main_content %}{% endblock %}
 </div>
 {% endblock %}

--- a/assets/sass/elements-documentation.scss
+++ b/assets/sass/elements-documentation.scss
@@ -87,6 +87,25 @@ main > .heading-xlarge {
   margin-top: 0;
 }
 
+// deprecation notice
+.notification-summary {
+  border: 4px solid $govuk-blue;
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  padding: $gutter-half 10px;
+
+  @include media(tablet) {
+    border: 5px solid $govuk-blue;
+
+    margin-top: $gutter;
+    margin-bottom: $gutter;
+
+    padding: $gutter-two-thirds $gutter-half $gutter-half;
+  }
+}
+
 // Example boxes
 // ==========================================================================
 


### PR DESCRIPTION
We're adding messaging to inform users that GOV.UK elements is being superseded by GOV.UK Design System.

#### Screenshots (if appropriate):
<img width="1048" alt="screen shot 2018-06-11 at 14 17 26" src="https://user-images.githubusercontent.com/3758555/41233795-5ae57bb0-6d82-11e8-87ef-4dfdaddd4d01.png">

