### PR TITLE
Update npm token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
         - provider: npm
           email: govuk-dev@digital.cabinet-office.gov.uk
           api_key:
-            secure: CW79rsUR5MFR+YyIsmwhbrndukNjzoKstp2SKupdEzUYTthnzsDxz2CGgI3SwwIcxPh41onxkDZm5R0ZvxwFQf4R+IJEhM94KqjwLdVE5bkKPD0JNYGbYRTDrTCYb74InvjN6LIhYvQwcKO+ThaiMA1IttEc4vCzKHPKKbPv340=
+            secure: Cn1t69Nw5opWGkYfyYzxlyZy2i8EeXcHVLNr/gvW04Vg4leRQKc/W3PUYNUduWUxPCQa1f3akWW+q3z/tbIknxhVH40IoH2+4TmeaU6uRPdo9scZKYga+cE/1+auNAgSz289mTqxCIHqOZNmYVqcvndjiro/BZmO+WPxeSxTf3U=
 
         # Upload the contents of packages/govuk-elements-sass/ to GitHub releases
         - provider: script


### PR DESCRIPTION
This updates the encrypted npm token which we use to release the govuk-elements-sass package to use a new token with read and publish rights, which belongs to the alphagov user.

#### What problem does the pull request solve?

Due to an incident, npm have invalidated all existing npm tokens published before 2018-07-12 12:30 UTC – https://status.npmjs.org/incidents/dn7c1fgrr7ng

#### How has this been tested?

This has not been tested, as it relies on Travis' infrastructure and can't be tested locally.