### PR TITLE
Pin Node.js version to 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://govuk-elements.herokuapp.com/",
   "license": "MIT",
   "engines": {
-    "node": ">=8.1.4"
+    "node": "^8.0.0"
   },
   "dependencies": {
     "body-parser": "^1.14.1",


### PR DESCRIPTION
Heroku is currently failing to deploy because it's trying to use Node 12, which [Gulp 3 is not compatible with][1].

We've tried pinning to 10.x, but this causes the tests to fail because [the version of node-sass that we are using does not work with Node 10][2]. (The tests pass currently, because the node version is fixed to node 8 in travis.yml)

As node 8 is still under LTS and Elements is deprecated, we'll pin to 8 for now and revisit if it becomes a problem.

[1]: https://github.com/gulpjs/gulp/issues/2324
[2]: https://github.com/sass/node-sass/issues/1931