### PR TITLE
Remove cookie banner

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -2,9 +2,4 @@
 
 // Note: this config can be overridden using environment variables (eg on heroku)
 
-module.exports = {
-
-  // Cookie warning
-  cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'
-
-}
+module.exports = { }

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -14,10 +14,6 @@
 </div>
 {% endblock %}
 
-{% block cookie_message %}
-  <p>{{cookieText | safe }}</p>
-{% endblock %}
-
 {% block proposition_header %}
   {% include "includes/navigation.html" %}
 {% endblock %}

--- a/app/views/layout_example.html
+++ b/app/views/layout_example.html
@@ -32,10 +32,6 @@
   </style>
 {% endblock %}
 
-{% block cookie_message %}
-  <p>{{cookieText | safe }}</p>
-{% endblock %}
-
 {% block proposition_header %}
   {% include "includes/navigation.html" %}
 {% endblock %}

--- a/server.js
+++ b/server.js
@@ -4,7 +4,6 @@ var nunjucks = require('nunjucks')
 var routes = require('./app/routes.js')
 var app = express()
 var bodyParser = require('body-parser')
-var config = require('./app/config.js')
 var port = (process.env.PORT || 3000)
 var IS_HEROKU = process.env.hasOwnProperty('IS_HEROKU')
 

--- a/tests/wraith/snap.js
+++ b/tests/wraith/snap.js
@@ -27,14 +27,6 @@ page.settings.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleW
 
 //  };
 
-// If you want to set a cookie, just add your details below in the following way.
-
-phantom.addCookie({
-    'name': 'seen_cookie_message',
-    'value': 'yes',
-    'domain': 'localhost'
-});
-
 page.onResourceRequested = function(req) {
   current_requests += 1;
 };


### PR DESCRIPTION
When we merge https://github.com/alphagov/govuk_elements/pull/627 we'll not set any cookies so we can remove the cookie banner.

I've had to do some undesirable hot patching to do this due to the limitations of govuk_template.