### PR TITLE
Update GOV.UK Elements deprecation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 The GOV.UK Design System launched on 22 June 2018
 ===============
 
-GOV.UK Elements has now been replaced by the GOV.UK Design System. Elements will remain available in case you are currently using it, but is no longer maintained. The Government Digital Service will only carry out major bug fixes and security patches.
+GOV.UK Elements is:
 
-The GOV.UK Design System will be updated to ensure the things it contains meet level AA of WCAG 2.1, but Elements will not. [Read more about accessibility of the GOV.UK Design System](https://design-system.service.gov.uk/accessibility/).
+- no longer maintained
+- will only be updated for major bug fixes and security patches
+- does not meet the [Web Content Accessibility Guidelines (WCAG 2.1 level AA) accessibility standard](https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps)
 
+This framework will remain available in case you’re currently using it. To help your service meet accessibility requirements, you should use the [GOV.UK Design System](https://design-system.service.gov.uk/). You can [migrate to the Design System from GOV.UK Elements](https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/).
 
 GOV.UK elements ·
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
@@ -71,11 +74,11 @@ GOV.UK elements uses Wraith so that regressions can be easily spotted.
 This needs to be run from the Wraith directory `/tests/wraith` and some dependencies need to be installed on the local machine first.
 
 1. Install Wraith and its dependencies.
-      
+
         gem install wraith
-        
+
         brew install phantomjs
-        
+
         brew install imagemagick
 
 2. Take a baseline of the current version.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ GOV.UK Elements is:
 
 - no longer maintained
 - will only be updated for major bug fixes and security patches
-- does not meet the [Web Content Accessibility Guidelines (WCAG 2.1 level AA) accessibility standard](https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps)
+- does not meet the [Web Content Accessibility Guidelines (WCAG 2.1 level AA) accessibility standard](https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps#meeting-accessibility-requirements)
 
 This framework will remain available in case you’re currently using it. To help your service meet accessibility requirements, you should use the [GOV.UK Design System](https://design-system.service.gov.uk/). You can [migrate to the Design System from GOV.UK Elements](https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/).
 
@@ -74,11 +74,11 @@ GOV.UK elements uses Wraith so that regressions can be easily spotted.
 This needs to be run from the Wraith directory `/tests/wraith` and some dependencies need to be installed on the local machine first.
 
 1. Install Wraith and its dependencies.
-
+      
         gem install wraith
-
+        
         brew install phantomjs
-
+        
         brew install imagemagick
 
 2. Take a baseline of the current version.

--- a/app/views/includes/deprecation_message.html
+++ b/app/views/includes/deprecation_message.html
@@ -2,11 +2,10 @@
 <h2 class="heading-medium no-top-margin">GOV.UK Elements has now been replaced by the GOV.UK Design System</h2>
 
 <p>GOV.UK Elements is:<p>
-
-<ul>
-<li>no longer maintained</li>
-<li>will only be updated for major bug fixes and security patches</li>
-<li>does not meet the <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">Web Content Accessibility Guidelines (WCAG 2.1 level AA) accessibility standard</a></li>
+<ul class="list list-bullet">
+  <li>no longer maintained</li>
+  <li>will only be updated for major bug fixes and security patches</li>
+  <li>does not meet the <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps#meeting-accessibility-requirements">Web Content Accessibility Guidelines (WCAG 2.1 level AA) accessibility standard</a></li>
 </ul>
 
 <p>This framework will remain available in case you’re currently using it. To help your service meet accessibility requirements, you should use the <a href="https://design-system.service.gov.uk/">GOV.UK Design System</a>. You can <a href="https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/"> migrate to the Design System from GOV.UK Elements</a>.</p>

--- a/app/views/includes/deprecation_message.html
+++ b/app/views/includes/deprecation_message.html
@@ -1,5 +1,14 @@
 <div class="notification-summary">
 <h2 class="heading-medium no-top-margin">GOV.UK Elements has now been replaced by the GOV.UK Design System</h2>
-<p>Elements will remain available in case you are currently using it, but is no longer maintained. The Government Digital Service will only carry out major bug fixes and security patches.</p>
-<p>The <a href="https://www.gov.uk/design-system">GOV.UK Design System</a> will be updated to ensure the things it contains meet level AA of WCAG 2.1, but Elements will not. <a href="https://design-system.service.gov.uk/accessibility/">Read more about accessibility of the GOV.UK Design System</a>.</p>
+
+<p>GOV.UK Elements is:<p>
+
+<ul>
+<li>no longer maintained</li>
+<li>will only be updated for major bug fixes and security patches</li>
+<li>does not meet the <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">Web Content Accessibility Guidelines (WCAG 2.1 level AA) accessibility standard</a></li>
+</ul>
+
+<p>This framework will remain available in case you’re currently using it. To help your service meet accessibility requirements, you should use the <a href="https://design-system.service.gov.uk/">GOV.UK Design System</a>. You can <a href="https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/"> migrate to the Design System from GOV.UK Elements</a>.</p>
+
 </div>


### PR DESCRIPTION
We’re updating the deprecation notice in the Elements, Template and Frontend Toolkit repos, to reflect the fact that GOV.UK Design System and Frontend have now been updated to better meet WCAG 2.1.