### PR TITLE
Update to Heroku-18 stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,6 @@
 {
   "name": "govuk_elements",
+  "stack": "heroku-18",
   "scripts": {
   },
   "env": {

--- a/app.json
+++ b/app.json
@@ -4,12 +4,6 @@
   "scripts": {
   },
   "env": {
-    "NODE_ENV": {
-      "required": true
-    },
-    "NPM_CONFIG_PRODUCTION": {
-      "required": true
-    }
   },
   "formation": {
   },


### PR DESCRIPTION
Beginning November 2nd, 2020, the cedar-14 stack will no longer receive security updates and builds will be disabled for apps running on the cedar-14 stack.

Update to the latest Heroku-18 stack [following the Heroku guidance][1]. THe Heroku-18 stack is supported through April 2023.

[1]: https://devcenter.heroku.com/articles/upgrading-to-the-latest-stack#review-apps-recommended

Closes https://github.com/alphagov/design-system-team-internal/issues/283