### PR TITLE
Enforce HTTPS on Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,6 +4,9 @@
   "scripts": {
   },
   "env": {
+    "IS_HEROKU": {
+      "value": true
+    }
   },
   "formation": {
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2113,6 +2113,11 @@
         "vary": "~1.1.2"
       }
     },
+    "express-sslify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-sslify/-/express-sslify-1.2.0.tgz",
+      "integrity": "sha1-MOhLzu0VV+sYdnK74UMKCioQDZw="
+    },
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "body-parser": "^1.14.1",
     "del": "^3.0.0",
     "express": "^4.15.2",
+    "express-sslify": "^1.2.0",
     "govuk_frontend_toolkit": "^7.1.0",
     "govuk_template_jinja": "0.23.0",
     "gulp": "^3.9.1",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 var path = require('path')
 var express = require('express')
 var nunjucks = require('nunjucks')
+var enforce = require('express-sslify')
 var routes = require('./app/routes.js')
 var app = express()
 var bodyParser = require('body-parser')
@@ -8,6 +9,15 @@ var port = (process.env.PORT || 3000)
 var IS_HEROKU = process.env.hasOwnProperty('IS_HEROKU')
 
 module.exports = app
+
+if (IS_HEROKU) {
+  app.use(enforce.HTTPS({
+    // Heroku uses a reverse proxy for SSL, but then forwards traffic to the
+    // website over http. The X-Forwarded-Proto header provides the original
+    // protocol used, but we have to tell express-sslify to trust it.
+    trustProtoHeader: true
+  }))
+}
 
 // Application settings
 app.set('view engine', 'html')


### PR DESCRIPTION
Redirect requests made over http to https by using [express-sslify](https://www.npmjs.com/package/express-sslify).

Closes alphagov/design-system-team-internal#286

(Also #582 and #439)