### PR TITLE
Delete `/package` before preparing package

### DIFF
--- a/config/paths.json
+++ b/config/paths.json
@@ -4,11 +4,12 @@
   "assetsScss": "assets/sass/",
   "config": "config/",
   "nodeModules": "node_modules/",
-  "package": "packages/govuk-elements-sass/",
   "public": "public/",
   "publicImg": "public/images/",
   "publicCss": "public/stylesheets/",
   "publicJs": "public/javascripts/",
+  "package": "packages/govuk-elements-sass/",
+  "packagePublic": "packages/govuk-elements-sass/public",
   "testSpecs": "test/specs/",
   "views": "views/"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,12 +11,20 @@ const postcss = require('gulp-postcss')
 const rename = require('gulp-rename')
 const sass = require('gulp-sass')
 
-// Clean task ----------------------------
+// Clean tasks ----------------------------
+
 // Deletes the /public directory
 // ---------------------------------------
 
-gulp.task('clean', () => {
+gulp.task('clean:public', () => {
   return del(paths.public)
+})
+
+// Deletes the /public directory in /package
+// ---------------------------------------
+
+gulp.task('clean:package', () => {
+  return del(paths.packagePublic)
 })
 
 // Styles build task ---------------------
@@ -59,7 +67,7 @@ gulp.task('scripts', () => {
 // ---------------------------------------
 
 gulp.task('build', gulp.series(
-  'clean',
+  'clean:public',
   gulp.parallel('styles', 'images', 'scripts')
 ))
 
@@ -119,7 +127,7 @@ gulp.task('develop', gulp.series(
 // Ignores the elements-documentation stylesheets
 // ---------------------------------------
 
-gulp.task('package', () => {
+gulp.task('prepare:package', () => {
   return gulp.src(
     [
       paths.assetsScss + '**/elements/**/*.scss',
@@ -129,6 +137,11 @@ gulp.task('package', () => {
     ])
     .pipe(gulp.dest(paths.package + 'public/sass/'))
 })
+
+gulp.task('package', gulp.series(
+  'clean:package',
+  'prepare:package'
+))
 
 // Default task --------------------------
 // Lists out available tasks.


### PR DESCRIPTION
This PR modifies the gulp tasks to clean `/package/govuk-elements-sass/public/sass` before building it so that any removed/renamed files get correctly modified.

This issue this resolves was highlighted by `_shame.scss` still being in the package folder, despite having been deleted in https://github.com/alphagov/govuk_elements/pull/611.

This problem was identified in https://github.com/alphagov/govuk_elements/pull/635#discussion_r419287965 but was out of scope for that PR so I've split it into this separate one. 

#### How has this been tested?

- `npm test` passes and fails automated tests appropriately
- `gulp package` generates `/package/` with changes for publishing, removing `_shame.scss` as expected

#### What type of change is it?
- Fix build packaging pipeline

#### Has the documentation been updated?
- My change requires no change to the documentation.
- I have read the **CONTRIBUTING** document.
